### PR TITLE
chore: add snapshot release workflow

### DIFF
--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -1,0 +1,72 @@
+# Release snapshot packages to NPM.
+
+name: Release Snapshots
+
+on:
+  push:
+    branches:
+      - main
+      - develop
+
+concurrency: ${{ github.workflow }}-${{ github.ref }}
+
+jobs:
+  release-snapshots:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: 20
+
+      - uses: pnpm/action-setup@v2
+        name: Install pnpm
+        with:
+          version: 8
+          run_install: false
+
+      - name: Get pnpm store directory
+        shell: bash
+        run: |
+          echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
+
+      - uses: actions/cache@v3
+        name: Setup pnpm cache
+        with:
+          path: ${{ env.STORE_PATH }}
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-store-
+
+      - name: Install dependencies
+        run: pnpm i
+
+      - name: Clear cache
+        run: pnpm run clean:packages
+
+      - name: Build packages
+        run: pnpm run build:packages
+
+      - name: Publish to npm (ignore GitHub)
+        id: changesets
+        uses: changesets/action@v1
+        with:
+          version: changeset version --snapshot snap
+          publish: changeset publish --snapshot --tag snap
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Create commit comment
+        uses: peter-evans/commit-comment@v3
+        if: ${{ steps.changesets.outputs.published == 'true' }}
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          body: |
+            ```json
+            ${{ steps.changesets.outputs.publishedPackages }}
+            ```


### PR DESCRIPTION
## Changes
- Add a GitHub workflow to release packages' snapshot, which performs the following tasks:
    1. Releases snapshots for every commit to the `main` or `develop` branch
    2. Creates a comment on the commit if snapshots was released

## Request review
@Flouse @Dawn-githup Can you help review the process of the workflow?