### PR TITLE
fix: fill GITHUB_TOKEN to the snapshot workflow

### DIFF
--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -58,8 +58,10 @@ jobs:
         with:
           version: changeset version --snapshot snap
           publish: changeset publish --snapshot --tag snap
+          createGithubReleases: false
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Create commit comment
         uses: peter-evans/commit-comment@v3


### PR DESCRIPTION
## Changes
- Fill `GITHUB_TOKEN` to the snapshot workflow
- Disable GitHub releases in the snapshot workflow

## Reviewers
@Flouse @Dawn-githup @duanyytop 