### PR TITLE
feat(rgbpp-sdk/btc): add mempool.space api to provide default fee rate

### DIFF
--- a/.changeset/lovely-rings-do.md
+++ b/.changeset/lovely-rings-do.md
@@ -1,0 +1,5 @@
+---
+"@rgbpp-sdk/btc": patch
+---
+
+Add and wrap mempool.space APIs, provides DataSource.getRecommendedFeeRates() and DataSource.getAverageFeeRate() APIs for fee rate recommendations. By default, the TxBuilder uses the "halfHourFee" rate from the mempool.space as the default fee rate.

--- a/packages/btc/README.md
+++ b/packages/btc/README.md
@@ -399,6 +399,19 @@ interface DataSource {
     satoshi: number;
     exceedSatoshi: number;
   }>;
+  getRecommendedFeeRates(): Promise<FeesRecommended>;
+  getAverageFeeRate(): Promise<number>;
+}
+```
+
+#### FeesRecommended
+
+```typescript
+interface FeesRecommended {
+  fastestFee: number;
+  halfHourFee: number;
+  hourFee: number;
+  minimumFee: number;
 }
 ```
 

--- a/packages/btc/package.json
+++ b/packages/btc/package.json
@@ -18,6 +18,7 @@
   "dependencies": {
     "@bitcoinerlab/secp256k1": "^1.1.1",
     "@ckb-lumos/lumos": "0.22.0-next.5",
+    "@mempool/mempool.js": "^2.3.0",
     "@nervosnetwork/ckb-types": "^0.109.1",
     "@rgbpp-sdk/ckb": "workspace:^",
     "bip32": "^4.0.0",

--- a/packages/btc/src/error.ts
+++ b/packages/btc/src/error.ts
@@ -8,6 +8,7 @@ export enum ErrorCodes {
   UNSUPPORTED_OUTPUT,
   UNSUPPORTED_ADDRESS_TYPE,
   UNSUPPORTED_OP_RETURN_SCRIPT,
+  INVALID_FEE_RATE,
 
   ASSETS_API_RESPONSE_ERROR,
   ASSETS_API_UNAUTHORIZED,
@@ -20,6 +21,8 @@ export enum ErrorCodes {
   CKB_INVALID_OUTPUTS,
   CKB_UNMATCHED_COMMITMENT,
   CKB_RGBPP_LOCK_UNPACK_ERROR,
+
+  MEMPOOL_API_RESPONSE_ERROR,
 }
 
 export const ErrorMessages = {
@@ -32,6 +35,7 @@ export const ErrorMessages = {
   [ErrorCodes.UNSUPPORTED_OUTPUT]: 'Unsupported output format',
   [ErrorCodes.UNSUPPORTED_ADDRESS_TYPE]: 'Unsupported address type',
   [ErrorCodes.UNSUPPORTED_OP_RETURN_SCRIPT]: 'Unsupported OP_RETURN script format',
+  [ErrorCodes.INVALID_FEE_RATE]: 'Invalid fee rate provided or recommended',
 
   [ErrorCodes.ASSETS_API_UNAUTHORIZED]: 'BtcAssetsAPI unauthorized, please check your token/origin',
   [ErrorCodes.ASSETS_API_INVALID_PARAM]: 'Invalid param(s) was provided to the BtcAssetsAPI',
@@ -44,6 +48,8 @@ export const ErrorMessages = {
   [ErrorCodes.CKB_INVALID_OUTPUTS]: 'Invalid output(s) found in the CKB VirtualTx',
   [ErrorCodes.CKB_UNMATCHED_COMMITMENT]: 'Invalid commitment found in the CKB VirtualTx',
   [ErrorCodes.CKB_RGBPP_LOCK_UNPACK_ERROR]: 'Failed to unpack RgbppLockArgs from the CKB cell lock',
+
+  [ErrorCodes.MEMPOOL_API_RESPONSE_ERROR]: 'Mempool.space API returned an error',
 };
 
 export class TxBuildError extends Error {

--- a/packages/btc/src/query/mempool.ts
+++ b/packages/btc/src/query/mempool.ts
@@ -1,0 +1,41 @@
+import Mempool from '@mempool/mempool.js';
+import { NetworkType } from '../network';
+
+export type MempoolInstance = ReturnType<typeof Mempool>;
+
+export interface MempoolConfig {
+  hostname: string;
+  network: string;
+}
+
+export const mempoolConfigs: Record<'mainnet' | 'testnet', MempoolConfig> = {
+  testnet: {
+    hostname: 'mempool.space',
+    network: 'testnet',
+  },
+  mainnet: {
+    hostname: 'mempool.space',
+    network: 'mainnet',
+  },
+};
+
+/**
+ * Get predefined mempool config by network type.
+ * If the network is regtest, it will use the testnet config.
+ */
+export function getMempoolConfig(network: NetworkType) {
+  if (network === NetworkType.MAINNET) {
+    return mempoolConfigs.mainnet;
+  }
+
+  // Using the testnet config for both testnet/regtest
+  return mempoolConfigs.testnet;
+}
+
+/**
+ * Create a mempool instance by network type.
+ */
+export function createMempool(network: NetworkType) {
+  const config = getMempoolConfig(network);
+  return Mempool(config);
+}

--- a/packages/btc/tests/DataSource.test.ts
+++ b/packages/btc/tests/DataSource.test.ts
@@ -20,6 +20,6 @@ describe('DataSource', () => {
 
     expect(averageFeeRate).toBeTypeOf('number');
     expect(feeRates.halfHourFee).toBeTypeOf('number');
-    expect(averageFeeRate).toEqual(feeRates.minimumFee);
+    expect(averageFeeRate).toEqual(feeRates.halfHourFee);
   });
 });

--- a/packages/btc/tests/DataSource.test.ts
+++ b/packages/btc/tests/DataSource.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+import { source } from './shared/env';
+
+describe('DataSource', () => {
+  it('Get recommended fee rates', async () => {
+    const fees = await source.getRecommendedFeeRates();
+
+    expect(fees).toBeDefined();
+    expect(fees.fastestFee).toBeTypeOf('number');
+    expect(fees.halfHourFee).toBeTypeOf('number');
+    expect(fees.hourFee).toBeTypeOf('number');
+    expect(fees.minimumFee).toBeTypeOf('number');
+
+    expect(fees.fastestFee).toBeGreaterThanOrEqual(fees.halfHourFee);
+    expect(fees.halfHourFee).toBeGreaterThanOrEqual(fees.hourFee);
+    expect(fees.hourFee).toBeGreaterThanOrEqual(fees.minimumFee);
+  });
+  it('Get average fee rate', async () => {
+    const [feeRates, averageFeeRate] = await Promise.all([source.getRecommendedFeeRates(), source.getAverageFeeRate()]);
+
+    expect(averageFeeRate).toBeTypeOf('number');
+    expect(feeRates.halfHourFee).toBeTypeOf('number');
+    expect(averageFeeRate).toEqual(feeRates.minimumFee);
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -146,6 +146,9 @@ importers:
       '@ckb-lumos/lumos':
         specifier: 0.22.0-next.5
         version: 0.22.0-next.5
+      '@mempool/mempool.js':
+        specifier: ^2.3.0
+        version: 2.3.0
       '@nervosnetwork/ckb-types':
         specifier: ^0.109.1
         version: 0.109.1
@@ -1213,6 +1216,17 @@ packages:
       read-yaml-file: 1.1.0
     dev: true
 
+  /@mempool/mempool.js@2.3.0:
+    resolution: {integrity: sha512-FrN9WjZCEyyLodrTPQxmlWDh8B/UGK0jlKfVNzJxqzQ1IMPo/Hpdws8xwYEcsks5JqsaxbjLwaC3GAtJ6Brd0A==}
+    dependencies:
+      axios: 0.24.0
+      ws: 8.3.0
+    transitivePeerDependencies:
+      - bufferutil
+      - debug
+      - utf-8-validate
+    dev: false
+
   /@nervosnetwork/ckb-sdk-core@0.109.1:
     resolution: {integrity: sha512-YU3yJZvz69WU6Bw//vRxzxLGcIj74CwGffdp6GYZbQpZwFaACT6FCojvOMjHIyJ8Rw32r114LhMKHvyBwagWjw==}
     dependencies:
@@ -2044,6 +2058,14 @@ packages:
     dependencies:
       possible-typed-array-names: 1.0.0
     dev: true
+
+  /axios@0.24.0:
+    resolution: {integrity: sha512-Q6cWsys88HoPgAaFAVUb0WpPk0O8iTeisR9IMqy9G8AbO4NlpVknrnQS03zzF9PGAWgO3cgletO3VjV/P7VztA==}
+    dependencies:
+      follow-redirects: 1.15.6
+    transitivePeerDependencies:
+      - debug
+    dev: false
 
   /axios@1.6.7:
     resolution: {integrity: sha512-/hDJGff6/c7u0hDkvkGxR/oy6CbCs8ziCsC7SqmhjfozqiJGc8Z11wrv9z9lYfY4K8l+H9TpjcMDX0xOZmx+RA==}
@@ -6120,6 +6142,19 @@ packages:
   /wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
     dev: true
+
+  /ws@8.3.0:
+    resolution: {integrity: sha512-Gs5EZtpqZzLvmIM59w4igITU57lrtYVFneaa434VROv4thzJyV6UjIL3D42lslWlI+D4KzLYnxSwtfuiO79sNw==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: ^5.0.2
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+    dev: false
 
   /ws@8.5.0:
     resolution: {integrity: sha512-BWX0SWVgLPzYwF8lTzEy1egjhS4S4OEAHfsO8o65WOVsrnSRGaSiUaa9e0ggGlkMTtBlmOpEXiie9RUcBO86qg==}


### PR DESCRIPTION
## Changes
- Add `DataSource.getRecommendedFeeRates` and `DataSource.getAverageFeeRate` APIs
- When the `feeRate` prop in TxBuilder is undefined, get a fee rate from `DataSource.getAverageFeeRate`

## Details

The `getRecommendedFeeRates` API returns a `FeesRecommended` object, which offers several levels of fee rates for users to choose from. The overall ranking on satoshi costing from high to low, or confirm time spent from fastest to slowest, is as follows:

```
fastestFee > halfHourFee > economyFee > hourFee > minimumFee > minimumFee
```

On the other hand, the `getAverageFeeRate` API returns the `halfHourFee`. This means that if the user leaves the `feeRate` empty while initializing a `TxBuilder`, it uses the `halfHourFee` as the default fee rate.

## Types

`getRecommendedFeeRates` and `getAverageFeeRate`:

```ts
interface DataSource {
  // ... other apis
  getRecommendedFeeRates(): Promise<FeesRecommended>;
  getAverageFeeRate(): Promise<number>;
}
```

FeesRecommended:

```ts
interface FeesRecommended {
  fastestFee: number;
  halfHourFee: number;
  hourFee: number;
  minimumFee: number;
}
```