### PR TITLE
refactor(rgbpp-sdk/ckb): Check lock size and remove the same client cell

### DIFF
--- a/packages/ckb/src/rgbpp/btc-jump-ckb.ts
+++ b/packages/ckb/src/rgbpp/btc-jump-ckb.ts
@@ -1,7 +1,14 @@
 import { RgbppCkbVirtualTx, BtcJumpCkbVirtualTxParams, BtcJumpCkbVirtualTxResult } from '../types/rgbpp';
 import { blockchain } from '@ckb-lumos/base';
 import { NoRgbppLiveCellError } from '../error';
-import { append0x, calculateRgbppCellCapacity, calculateTransactionFee, u128ToLe } from '../utils';
+import {
+  append0x,
+  calculateRgbppCellCapacity,
+  calculateTransactionFee,
+  isLockArgsSizeExceeded,
+  remove0x,
+  u128ToLe,
+} from '../utils';
 import {
   buildPreLockArgs,
   calculateCommitment,
@@ -55,6 +62,9 @@ export const genBtcJumpCkbVirtualTx = async ({
   const outputsData = [append0x(u128ToLe(transferAmount))];
 
   const toLock = addressToScript(toCkbAddress);
+  if (isLockArgsSizeExceeded(toLock.args)) {
+    throw new Error('The lock script size of the to ckb address is too large');
+  }
   const outputs: CKBComponents.CellOutput[] = [
     {
       lock: genBtcTimeLockScript(toLock, isMainnet),

--- a/packages/ckb/src/utils/ckb-tx.spec.ts
+++ b/packages/ckb/src/utils/ckb-tx.spec.ts
@@ -1,10 +1,18 @@
 import { describe, it, expect } from 'vitest';
-import { calculateRgbppCellCapacity, calculateTransactionFee } from './ckb-tx';
+import { calculateRgbppCellCapacity, calculateTransactionFee, isLockArgsSizeExceeded } from './ckb-tx';
 
 describe('ckb tx utils', () => {
   it('calculateTransactionFee', () => {
     const fee = calculateTransactionFee(1245);
     expect(BigInt(1370)).toBe(fee);
+  });
+
+  it('calculateTransactionFee', () => {
+    const longLockArgs = '0x06ec22c2def100bba3e295a1ff279c490d227151bf3166a4f3f008906c849399';
+    expect(true).toBe(isLockArgsSizeExceeded(longLockArgs));
+
+    const shortLockArgs = '0x06ec22c2def100bba3e295a1ff279c490d227151bf3166a4f3';
+    expect(false).toBe(isLockArgsSizeExceeded(shortLockArgs));
   });
 
   it('calculateRgbppCellCapacity', () => {

--- a/packages/ckb/src/utils/ckb-tx.ts
+++ b/packages/ckb/src/utils/ckb-tx.ts
@@ -1,6 +1,7 @@
 import BigNumber from 'bignumber.js';
 import { remove0x } from './hex';
 import { CKB_UNIT } from '../constants';
+import { Hex } from '../types';
 
 export const calculateTransactionFee = (txSize: number): bigint => {
   const ratio = BigNumber(1000);
@@ -10,7 +11,10 @@ export const calculateTransactionFee = (txSize: number): bigint => {
 };
 
 // The BTC_TIME_CELL_INCREASED_SIZE is related to the specific lock script.
-// We have left some redundancy based on the commonly used lock scripts.
+// We assume that the maximum length of lock script args is 26 bytes. If it exceeds, an error will be thrown.
+const LOCK_ARGS_HEX_MAX_SIZE = 26 * 2;
+export const isLockArgsSizeExceeded = (args: Hex) => remove0x(args).length > LOCK_ARGS_HEX_MAX_SIZE;
+
 const BTC_TIME_CELL_INCREASED_SIZE = 95;
 
 // For simplicity, we keep the capacity of the RGBPP cell the same as the BTC time cell


### PR DESCRIPTION
## Main Changes

- Add `isLockArgsSizeExceeded` function to check the lock script size
- When the size of `toLock` is too large,  an error will be thrown
- Delete the same SPV client cell
