### PR TITLE
feat(rgbpp-sdk/ckb): Check btc time cells status

### DIFF
--- a/packages/ckb/src/types/rgbpp.ts
+++ b/packages/ckb/src/types/rgbpp.ts
@@ -139,3 +139,12 @@ export interface UpdateCkbTxWithRealBtcTxIdParams {
   btcTxId: Hex;
   isMainnet: boolean;
 }
+
+export interface BtcTimeCellStatusParams {
+  // The collector that collects CKB live cells and transactions
+  collector: Collector;
+  // The ckb address who is the receiver of the btc time lock args
+  ckbAddress: Address;
+  // The BTC transaction id
+  btcTxId: Hex;
+}


### PR DESCRIPTION
## Backgroud

The JoyID  needs to know the current status of the BTC time cells to display the expected status on the UI for its users

## Main Changes

- Add `isBtcTimeCellsSpent` function to tell the JoyID whether the BTC time cells have been spent