### PR TITLE
refactor(rgbpp-sdk/ckb): Add feeRate to calculateTransactionFee

### DIFF
--- a/packages/ckb/package.json
+++ b/packages/ckb/package.json
@@ -24,7 +24,6 @@
     "@nervosnetwork/ckb-sdk-utils": "^0.109.1",
     "@nervosnetwork/ckb-types": "^0.109.1",
     "axios": "^1.6.8",
-    "bignumber.js": "^9.1.1",
     "camelcase-keys": "^7.0.2",
     "js-sha256": "^0.11.0"
   },

--- a/packages/ckb/src/utils/ckb-tx.spec.ts
+++ b/packages/ckb/src/utils/ckb-tx.spec.ts
@@ -3,8 +3,11 @@ import { calculateRgbppCellCapacity, calculateTransactionFee, isLockArgsSizeExce
 
 describe('ckb tx utils', () => {
   it('calculateTransactionFee', () => {
-    const fee = calculateTransactionFee(1245);
-    expect(BigInt(1370)).toBe(fee);
+    const fee1 = calculateTransactionFee(1245);
+    expect(BigInt(1245)).toBe(fee1);
+
+    const fee2 = calculateTransactionFee(1245, BigInt(1100));
+    expect(BigInt(1370)).toBe(fee2);
   });
 
   it('calculateTransactionFee', () => {

--- a/packages/ckb/src/utils/ckb-tx.ts
+++ b/packages/ckb/src/utils/ckb-tx.ts
@@ -1,13 +1,12 @@
-import BigNumber from 'bignumber.js';
+import { calculateTransactionFee as calculateTxFee } from '@nervosnetwork/ckb-sdk-utils/lib/calculateTransactionFee';
 import { remove0x } from './hex';
 import { CKB_UNIT } from '../constants';
 import { Hex } from '../types';
 
-export const calculateTransactionFee = (txSize: number): bigint => {
-  const ratio = BigNumber(1000);
-  const defaultFeeRate = BigNumber(1100);
-  const fee = BigNumber(txSize).multipliedBy(defaultFeeRate).div(ratio);
-  return BigInt(fee.toFixed(0, BigNumber.ROUND_CEIL).toString());
+export const calculateTransactionFee = (txSize: number, feeRate?: bigint): bigint => {
+  const rate = feeRate ?? BigInt(1000);
+  const fee = calculateTxFee(BigInt(txSize), rate);
+  return BigInt(fee);
 };
 
 // The BTC_TIME_CELL_INCREASED_SIZE is related to the specific lock script.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -192,9 +192,6 @@ importers:
       axios:
         specifier: ^1.6.8
         version: 1.6.8
-      bignumber.js:
-        specifier: ^9.1.1
-        version: 9.1.1
       camelcase-keys:
         specifier: ^7.0.2
         version: 7.0.2
@@ -2099,10 +2096,6 @@ packages:
 
   /bignumber.js@4.0.4:
     resolution: {integrity: sha512-LDXpJKVzEx2/OqNbG9mXBNvHuiRL4PzHCGfnANHMJ+fv68Ads3exDVJeGDJws+AoNEuca93bU3q+S0woeUaCdg==}
-    dev: false
-
-  /bignumber.js@9.1.1:
-    resolution: {integrity: sha512-pHm4LsMJ6lzgNGVfZHjMoO8sdoRhOzOH4MLmY65Jg70bpxCKu5iOHNJyfF6OyvYw7t8Fpf35RuzUyqnQsj8Vig==}
     dev: false
 
   /bip174@2.1.1:


### PR DESCRIPTION
## Main Changes

- Add `feeRate` to the `calculateTransactionFee` function
- Update the default `feeRate` from 1100 to 1000
- Update the `calculateTransactionFee`  tests

## Reference

https://github.com/ckb-cell/rgbpp-sdk/issues/44
