### PR TITLE
fix(rgbpp-sdk/service): fix error handling and type issues

### DIFF
--- a/packages/service/README.md
+++ b/packages/service/README.md
@@ -244,22 +244,16 @@ interface BtcApiTransaction {
 
 ```typescript
 interface RgbppApis {
-  getRgbppTransactionHash(btcTxId: string): Promise<RgbppApiCkbTransactionHash>;
-  getRgbppTransactionState(btcTxId: string): Promise<RgbppApiTransactionState>;
+  getRgbppTransactionHash(btcTxId: string): Promise<RgbppApiCkbTransactionHash | undefined>;
+  getRgbppTransactionState(btcTxId: string): Promise<RgbppApiTransactionState | undefined>;
   getRgbppAssetsByBtcTxId(btcTxId: string): Promise<Cell[]>;
   getRgbppAssetsByBtcUtxo(btcTxId: string, vout: number): Promise<Cell[]>;
   getRgbppAssetsByBtcAddress(btcAddress: string, params?: RgbppApiAssetsByAddressParams): Promise<Cell[]>;
-  getRgbppSpvProof(btcTxId: string, confirmations: number): Promise<RgbppApiSpvProof>;
+  getRgbppSpvProof(btcTxId: string, confirmations: number): Promise<RgbppApiSpvProof | undefined>;
   sendRgbppCkbTransaction(payload: RgbppApiSendCkbTransactionPayload): Promise<RgbppApiTransactionState>;
 }
 
-enum RgbppTransactionState {
-  Completed = 'completed',
-  Failed = 'failed',
-  Delayed = 'delayed',
-  Active = 'active',
-  Waiting = 'waiting',
-}
+type RgbppTransactionState = 'completed' | 'failed' | 'delayed' | 'active' | 'waiting';
 
 interface RgbppApiCkbTransactionHash {
   txhash: string;
@@ -277,7 +271,7 @@ interface RgbppApiSpvProof {
   proof: string;
   spv_client: {
     tx_hash: string;
-    index: number;
+    index: string;
   };
 }
 

--- a/packages/service/README.md
+++ b/packages/service/README.md
@@ -282,9 +282,12 @@ interface RgbppApiSpvProof {
 }
 
 interface RgbppApiSendCkbTransactionPayload {
-  ckbRawTx: CKBComponents.RawTransaction;
-  needPaymasterCell: boolean;
-  sumInputsCapacity: string;
-  commitment: string;
+  btc_txid: string;
+  ckb_virtual_result: {
+    ckbRawTx: CKBComponents.RawTransaction;
+    needPaymasterCell: boolean;
+    sumInputsCapacity: string;
+    commitment: string;
+  };
 }
 ```

--- a/packages/service/src/error.ts
+++ b/packages/service/src/error.ts
@@ -26,8 +26,8 @@ export class BtcAssetsApiError extends Error {
     Object.setPrototypeOf(this, BtcAssetsApiError.prototype);
   }
 
-  static withComment(code: ErrorCodes, comment: string): BtcAssetsApiError {
+  static withComment(code: ErrorCodes, comment?: string): BtcAssetsApiError {
     const message = ErrorMessages[code] || 'Unknown error';
-    return new BtcAssetsApiError(code, `${message}: ${comment}`);
+    return new BtcAssetsApiError(code, comment ? `${message}: ${comment}` : message);
   }
 }

--- a/packages/service/src/service/service.ts
+++ b/packages/service/src/service/service.ts
@@ -89,11 +89,15 @@ export class BtcAssetsApi extends BtcAssetsApiBase implements BtcApis, RgbppApis
    */
 
   getRgbppTransactionHash(btcTxId: string) {
-    return this.request<RgbppApiCkbTransactionHash>(`/rgbpp/v1/transaction/${btcTxId}`);
+    return this.request<RgbppApiCkbTransactionHash | undefined>(`/rgbpp/v1/transaction/${btcTxId}`, {
+      allow404: true,
+    });
   }
 
   getRgbppTransactionState(btcTxId: string) {
-    return this.request<RgbppApiTransactionState>(`/rgbpp/v1/transaction/${btcTxId}/job`);
+    return this.request<RgbppApiTransactionState | undefined>(`/rgbpp/v1/transaction/${btcTxId}/job`, {
+      allow404: true,
+    });
   }
 
   getRgbppAssetsByBtcTxId(btcTxId: string) {
@@ -111,7 +115,8 @@ export class BtcAssetsApi extends BtcAssetsApiBase implements BtcApis, RgbppApis
   }
 
   getRgbppSpvProof(btcTxId: string, confirmations: number) {
-    return this.request<RgbppApiSpvProof>('/rgbpp/v1/btc-spv/proof', {
+    return this.request<RgbppApiSpvProof | undefined>('/rgbpp/v1/btc-spv/proof', {
+      allow404: true,
       params: {
         txid: btcTxId,
         confirmations,

--- a/packages/service/src/types/base.ts
+++ b/packages/service/src/types/base.ts
@@ -9,6 +9,7 @@ export interface BaseApiRequestOptions extends RequestInit {
   params?: Record<string, any>;
   method?: 'GET' | 'POST';
   requireToken?: boolean;
+  allow404?: boolean;
 }
 
 export interface BtcAssetsApiToken {

--- a/packages/service/src/types/rgbpp.ts
+++ b/packages/service/src/types/rgbpp.ts
@@ -1,22 +1,16 @@
 import { Cell } from '@ckb-lumos/lumos';
 
 export interface RgbppApis {
-  getRgbppTransactionHash(btcTxId: string): Promise<RgbppApiCkbTransactionHash>;
-  getRgbppTransactionState(btcTxId: string): Promise<RgbppApiTransactionState>;
+  getRgbppTransactionHash(btcTxId: string): Promise<RgbppApiCkbTransactionHash | undefined>;
+  getRgbppTransactionState(btcTxId: string): Promise<RgbppApiTransactionState | undefined>;
   getRgbppAssetsByBtcTxId(btcTxId: string): Promise<Cell[]>;
   getRgbppAssetsByBtcUtxo(btcTxId: string, vout: number): Promise<Cell[]>;
   getRgbppAssetsByBtcAddress(btcAddress: string, params?: RgbppApiAssetsByAddressParams): Promise<Cell[]>;
-  getRgbppSpvProof(btcTxId: string, confirmations: number): Promise<RgbppApiSpvProof>;
+  getRgbppSpvProof(btcTxId: string, confirmations: number): Promise<RgbppApiSpvProof | undefined>;
   sendRgbppCkbTransaction(payload: RgbppApiSendCkbTransactionPayload): Promise<RgbppApiTransactionState>;
 }
 
-export enum RgbppTransactionState {
-  Completed = 'completed',
-  Failed = 'failed',
-  Delayed = 'delayed',
-  Active = 'active',
-  Waiting = 'waiting',
-}
+export type RgbppTransactionState = 'completed' | 'failed' | 'delayed' | 'active' | 'waiting';
 
 export interface RgbppApiCkbTransactionHash {
   txhash: string;
@@ -34,7 +28,7 @@ export interface RgbppApiSpvProof {
   proof: string;
   spv_client: {
     tx_hash: string;
-    index: number;
+    index: string;
   };
 }
 

--- a/packages/service/src/types/rgbpp.ts
+++ b/packages/service/src/types/rgbpp.ts
@@ -39,8 +39,11 @@ export interface RgbppApiSpvProof {
 }
 
 export interface RgbppApiSendCkbTransactionPayload {
-  ckbRawTx: CKBComponents.RawTransaction;
-  needPaymasterCell: boolean;
-  sumInputsCapacity: string;
-  commitment: string;
+  btc_txid: string;
+  ckb_virtual_result: {
+    ckbRawTx: CKBComponents.RawTransaction;
+    needPaymasterCell: boolean;
+    sumInputsCapacity: string;
+    commitment: string;
+  };
 }

--- a/packages/service/tests/Service.test.ts
+++ b/packages/service/tests/Service.test.ts
@@ -142,11 +142,17 @@ describe(
         }),
       );
 
+      const emptyBtcTxId = '0000000000000000000000000000000000000000000000000000000000000001';
+
       it('Get the hash of RGBPP CKB_TX', async () => {
         const res = await service.getRgbppTransactionHash(rgbppBtcTxId);
         expect(res).toBeDefined();
         expect(res.txhash).toBeTypeOf('string');
         expect(res.txhash).toHaveLength(66);
+      });
+      it('Try to get the hash of RGBPP CKB_TX and returned undefined', async () => {
+        const res = await service.getRgbppTransactionHash(emptyBtcTxId);
+        expect(res).toBeUndefined();
       });
       // TODO: make a record and remove the "skip" marker
       it.skip('Get the state of RGBPP CKB_TX', async () => {
@@ -192,6 +198,10 @@ describe(
         expect(res.spv_client).toBeDefined();
         expect(res.spv_client.index).toBeTypeOf('string');
         expect(res.spv_client.tx_hash).toBeTypeOf('string');
+      });
+      it('Try to get RGBPP SPV proof and returned undefined', async () => {
+        const res = await service.getRgbppSpvProof(emptyBtcTxId, 6);
+        expect(res).toBeUndefined();
       });
     });
   },


### PR DESCRIPTION
## Changes
- Allow some RGBPP APIs to return `undefined` instead of throwing 404
- Catch code/message from the response when status !== 200 (suggested by @ahonn)
- Redefine `RgbppTransactionState` from an enum to a simple type (suggested by @duanyytop)
- Fix type RgbppApiCkbTransactionHash.spv_client.index from `number` to `srting` (suggested by @duanyytop)
- Fix type RgbppApiSendCkbTransactionPayload to add an extra layer