### PR TITLE
feat(rgbpp-sdk/ckb): Add examples with queue service

### DIFF
--- a/examples/rgbpp/README.md
+++ b/examples/rgbpp/README.md
@@ -53,6 +53,8 @@ npx ts-node examples/rgbpp/queue/3-btc-transfer.ts
 npx ts-node examples/rgbpp/queue/4-btc-jump-ckb.ts 
 ```
 
+### Unlock BTC time cells on CKB
+A cron job in RGB++ queue service will construct a transaction unlocking the mature btc_time_lock cells to the their `target_ckb_address`.
 ## Local Examples
 
 ### Mint XUDT

--- a/examples/rgbpp/README.md
+++ b/examples/rgbpp/README.md
@@ -53,14 +53,6 @@ npx ts-node examples/rgbpp/queue/3-btc-transfer.ts
 npx ts-node examples/rgbpp/queue/4-btc-jump-ckb.ts 
 ```
 
-### Unlock BTC time cells on CKB
-
-**Warning: Wait at least 6 BTC confirmation blocks to unlock the BTC time cells after 4-btc-jump-ckb.ts**
-
-```shell
-npx ts-node examples/rgbpp/queue/5-spend-btc-time-cell.ts 
-```
-
 ## Local Examples
 
 ### Mint XUDT

--- a/examples/rgbpp/README.md
+++ b/examples/rgbpp/README.md
@@ -1,8 +1,8 @@
-## RGB++ Examples
+# RGB++ Examples
 
 **All examples are just to demonstrate the use of RGB++ SDK. SPV proof is not ready yet, so these examples do not involve the verification of SPV proof.**
 
-### What you must know about BTC transaction id
+## What you must know about BTC transaction id
 
 **The btc tx transaction id(hash) displayed on BTC explorer is different from the btc transaction id(hash) in RGB++ lock args. They are in reverse byte order.**
 
@@ -24,6 +24,44 @@ But when you're searching for this transaction in [Bitcoin Core](https://bitcoin
 ```
 018025fb6989eed484774170eefa2bef1074b0c24537f992a64dbc138277bc4a
 ```
+
+## Examples with Queue service(Recommended)
+
+### Mint XUDT
+As a simple example, Omiga protocol is reused for a quick demonstration of XUDT asset insurance.
+Developers have the option to utilize an existing XUDT (User-Defined Token) on CKB.
+
+```shell
+npx ts-node examples/rgbpp/queue/1-mint-xudt.ts 
+```
+
+### Jump XUDT from CKB to BTC
+
+```shell
+npx ts-node examples/rgbpp/queue/2-ckb-jump-btc.ts 
+```
+
+### Transfer RGB++ asset on BTC
+
+```shell
+npx ts-node examples/rgbpp/queue/3-btc-transfer.ts 
+```
+
+### Jump RGB++ asset from BTC to CKB
+
+```shell
+npx ts-node examples/rgbpp/queue/4-btc-jump-ckb.ts 
+```
+
+### Unlock BTC time cells on CKB
+
+**Warning: Wait at least 6 BTC confirmation blocks to unlock the BTC time cells after 4-btc-jump-ckb.ts**
+
+```shell
+npx ts-node examples/rgbpp/queue/5-spend-btc-time-cell.ts 
+```
+
+## Local Examples
 
 ### Mint XUDT
 As a simple example, Omiga protocol is reused for a quick demonstration of XUDT asset insurance.

--- a/examples/rgbpp/README.md
+++ b/examples/rgbpp/README.md
@@ -4,7 +4,7 @@
 
 ## What you must know about BTC transaction id
 
-**The btc tx transaction id(hash) displayed on BTC explorer is different from the btc transaction id(hash) in RGB++ lock args. They are in reverse byte order.**
+**The BTC transaction id(hash) displayed on BTC explorer is different from the BTC transaction id(hash) in RGB++ lock args. They are in reverse byte order.**
 
 We follow the following two rules： 
 

--- a/examples/rgbpp/local/3-btc-transfer.ts
+++ b/examples/rgbpp/local/3-btc-transfer.ts
@@ -13,7 +13,7 @@ import { BtcAssetsApi } from '@rgbpp-sdk/service';
 // CKB SECP256K1 private key
 const CKB_TEST_PRIVATE_KEY = '0x0000000000000000000000000000000000000000000000000000000000000001';
 // BTC SECP256K1 private key
-const BTC_TEST_PRIVATE_KEY = '0x0000000000000000000000000000000000000000000000000000000000000001';
+const BTC_TEST_PRIVATE_KEY = '0000000000000000000000000000000000000000000000000000000000000001';
 // API docs: https://btc-assets-api.testnet.mibao.pro/docs
 const BTC_ASSETS_API_URL = 'https://btc-assets-api.testnet.mibao.pro/';
 // https://btc-assets-api.testnet.mibao.pro/docs/static/index.html#/Token/post_token_generate

--- a/examples/rgbpp/local/4-btc-jump-ckb.ts
+++ b/examples/rgbpp/local/4-btc-jump-ckb.ts
@@ -20,7 +20,7 @@ import { BtcAssetsApi } from '@rgbpp-sdk/service'
 // CKB SECP256K1 private key
 const CKB_TEST_PRIVATE_KEY = '0x0000000000000000000000000000000000000000000000000000000000000001';
 // BTC SECP256K1 private key
-const BTC_TEST_PRIVATE_KEY = '0x0000000000000000000000000000000000000000000000000000000000000001';
+const BTC_TEST_PRIVATE_KEY = '0000000000000000000000000000000000000000000000000000000000000001';
 // API docs: https://btc-assets-api.testnet.mibao.pro/docs
 const BTC_ASSETS_API_URL = 'https://btc-assets-api.testnet.mibao.pro/';
 // https://btc-assets-api.testnet.mibao.pro/docs/static/index.html#/Token/post_token_generate
@@ -113,7 +113,7 @@ const jumpFromBtcToCkb = async ({ rgbppLockArgsList, toCkbAddress, transferAmoun
   // console.log('BTC time lock args: ', newCkbRawTx.outputs[0].lock.args);
 
   // const txHash = await sendCkbTx({ collector, signedTx: ckbTx });
-  // console.info(`gbpp asset has been jumped from BTC to CKB and tx hash is ${txHash}`);
+  // console.info(`Rgbpp asset has been jumped from BTC to CKB and tx hash is ${txHash}`);
 };
 
 // rgbppLockArgs: outIndexU32 + btcTxId

--- a/examples/rgbpp/queue/1-mint-xudt.ts
+++ b/examples/rgbpp/queue/1-mint-xudt.ts
@@ -1,0 +1,44 @@
+import { AddressPrefix } from '@nervosnetwork/ckb-sdk-utils';
+import { blockchain } from '@ckb-lumos/base';
+import { buildMintTx, Collector } from 'ckb-omiga';
+
+// CKB SECP256K1 private key
+const CKB_TEST_PRIVATE_KEY = '0x0000000000000000000000000000000000000000000000000000000000000001';
+
+// To simplify, we reuse the Omiga protocol to quickly issue XUDT assets on Testnet CKB
+const mintXudt = async () => {
+  const collector = new Collector({
+    ckbNodeUrl: 'https://testnet.ckb.dev/rpc',
+    ckbIndexerUrl: 'https://testnet.ckb.dev/indexer',
+  });
+
+  const address = collector.getCkb().utils.privateKeyToAddress(CKB_TEST_PRIVATE_KEY, { prefix: AddressPrefix.Testnet });
+  // ckt1qzda0cr08m85hc8jlnfp3zer7xulejywt49kt2rr0vthywaa50xwsq0e4xk4rmg5jdkn8aams492a7jlg73ue0gc0ddfj
+  console.log('ckb address: ', address);
+
+  const mintLimit = BigInt(1000) * BigInt(10 ** 8);
+  const inscriptionId = '0xd378891e711cf5c612321b7f51529215187403c61cbb27bc4413fded871b73d5';
+
+  const rawTx = await buildMintTx({ collector, address, inscriptionId, mintLimit });
+
+  const secp256k1Dep: CKBComponents.CellDep = {
+    outPoint: {
+      txHash: '0xf8de3bb47d055cdf460d93a2a6e1b05f7432f9777c8c474abf4eec1d4aee5d37',
+      index: '0x0',
+    },
+    depType: 'depGroup',
+  };
+  const witnessArgs = blockchain.WitnessArgs.unpack(rawTx.witnesses[0]) as CKBComponents.WitnessArgs;
+  let unsignedTx: CKBComponents.RawTransactionToSign = {
+    ...rawTx,
+    cellDeps: [...rawTx.cellDeps, secp256k1Dep],
+    witnesses: [witnessArgs, ...rawTx.witnesses.slice(1)],
+  };
+  const signedTx = collector.getCkb().signTransaction(CKB_TEST_PRIVATE_KEY)(unsignedTx);
+
+  let txHash = await collector.getCkb().rpc.sendTransaction(signedTx, 'passthrough');
+  console.info(`Xudt has been minted with tx hash ${txHash}`);
+};
+
+mintXudt();
+

--- a/examples/rgbpp/queue/2-ckb-jump-btc.ts
+++ b/examples/rgbpp/queue/2-ckb-jump-btc.ts
@@ -1,0 +1,50 @@
+import { AddressPrefix, privateKeyToAddress, serializeScript } from '@nervosnetwork/ckb-sdk-utils';
+import { genCkbJumpBtcVirtualTx, Collector, getSecp256k1CellDep, buildRgbppLockArgs } from '@rgbpp-sdk/ckb';
+
+// CKB SECP256K1 private key
+const CKB_TEST_PRIVATE_KEY = '0x0000000000000000000000000000000000000000000000000000000000000001';
+
+const jumpFromCkbToBtc = async ({ outIndex, btcTxId }: { outIndex: number; btcTxId: string }) => {
+  const collector = new Collector({
+    ckbNodeUrl: 'https://testnet.ckb.dev/rpc',
+    ckbIndexerUrl: 'https://testnet.ckb.dev/indexer',
+  });
+  const address = privateKeyToAddress(CKB_TEST_PRIVATE_KEY, { prefix: AddressPrefix.Testnet });
+  console.log('ckb address: ', address);
+
+  const toRgbppLockArgs = buildRgbppLockArgs(outIndex, btcTxId);
+
+  const xudtType: CKBComponents.Script = {
+    codeHash: '0x25c29dc317811a6f6f3985a7a9ebc4838bd388d19d0feeecf0bcd60f6c0975bb',
+    hashType: 'type',
+    args: '0x1ba116c119d1cfd98a53e9d1a615cf2af2bb87d95515c9d217d367054cfc696b',
+  };
+
+  const ckbRawTx = await genCkbJumpBtcVirtualTx({
+    collector,
+    fromCkbAddress: address,
+    toRgbppLockArgs,
+    xudtTypeBytes: serializeScript(xudtType),
+    transferAmount: BigInt(800_0000_0000),
+    witnessLockPlaceholderSize: 1000
+  });
+
+  const emptyWitness = { lock: '', inputType: '', outputType: '' };
+  let unsignedTx: CKBComponents.RawTransactionToSign = {
+    ...ckbRawTx,
+    cellDeps: [...ckbRawTx.cellDeps, getSecp256k1CellDep(false)],
+    witnesses: [emptyWitness, ...ckbRawTx.witnesses.slice(1)],
+  };
+
+  const signedTx = collector.getCkb().signTransaction(CKB_TEST_PRIVATE_KEY)(unsignedTx);
+
+  let txHash = await collector.getCkb().rpc.sendTransaction(signedTx, 'passthrough');
+  console.info(`Rgbpp asset has been jumped from CKB to BTC and tx hash is ${txHash}`);
+};
+
+// Use your real BTC UTXO information on the BTC Testnet
+jumpFromCkbToBtc({
+  outIndex: 1,
+  btcTxId: '64252b582aea1249ed969a20385fae48bba35bf1ab9b3df3b0fcddc754ccf592',
+});
+

--- a/examples/rgbpp/queue/3-btc-transfer.ts
+++ b/examples/rgbpp/queue/3-btc-transfer.ts
@@ -1,0 +1,108 @@
+import { AddressPrefix, privateKeyToAddress, serializeScript } from '@nervosnetwork/ckb-sdk-utils';
+import {
+  Collector,
+  buildRgbppLockArgs,
+  genBtcTransferCkbVirtualTx,
+} from '@rgbpp-sdk/ckb';
+import { sendRgbppUtxos, DataSource, ECPair, bitcoin, NetworkType } from '@rgbpp-sdk/btc';
+import { BtcAssetsApi } from '@rgbpp-sdk/service';
+
+// CKB SECP256K1 private key
+const CKB_TEST_PRIVATE_KEY = '0x0000000000000000000000000000000000000000000000000000000000000001';
+// BTC SECP256K1 private key
+const BTC_TEST_PRIVATE_KEY = '0000000000000000000000000000000000000000000000000000000000000001';
+// API docs: https://btc-assets-api.testnet.mibao.pro/docs
+const BTC_ASSETS_API_URL = 'https://btc-assets-api.testnet.mibao.pro/';
+// https://btc-assets-api.testnet.mibao.pro/docs/static/index.html#/Token/post_token_generate
+const BTC_ASSETS_TOKEN = '';
+
+interface Params {
+  rgbppLockArgsList: string[];
+  toBtcAddress: string;
+  transferAmount: bigint;
+}
+const transferRgbppOnBtc = async ({ rgbppLockArgsList, toBtcAddress, transferAmount }: Params) => {
+  const collector = new Collector({
+    ckbNodeUrl: 'https://testnet.ckb.dev/rpc',
+    ckbIndexerUrl: 'https://testnet.ckb.dev/indexer',
+  });
+  const ckbAddress = privateKeyToAddress(CKB_TEST_PRIVATE_KEY, { prefix: AddressPrefix.Testnet });
+  console.log('ckb address: ', ckbAddress);
+  // const fromLock = addressToScript(ckbAddress);
+
+  const network = bitcoin.networks.testnet;
+  const keyPair = ECPair.fromPrivateKey(Buffer.from(BTC_TEST_PRIVATE_KEY, 'hex'), { network });
+  const { address: btcAddress } = bitcoin.payments.p2wpkh({
+    pubkey: keyPair.publicKey,
+    network,
+  });
+
+  console.log('btc address: ', btcAddress);
+
+  const networkType = NetworkType.TESTNET;
+  const service = BtcAssetsApi.fromToken(BTC_ASSETS_API_URL, BTC_ASSETS_TOKEN, 'https://btc-test.app');
+  const source = new DataSource(service, networkType);
+
+  const xudtType: CKBComponents.Script = {
+    codeHash: '0x25c29dc317811a6f6f3985a7a9ebc4838bd388d19d0feeecf0bcd60f6c0975bb',
+    hashType: 'type',
+    args: '0x1ba116c119d1cfd98a53e9d1a615cf2af2bb87d95515c9d217d367054cfc696b',
+  };
+
+  const ckbVirtualTxResult = await genBtcTransferCkbVirtualTx({
+    collector,
+    rgbppLockArgsList,
+    xudtTypeBytes: serializeScript(xudtType),
+    transferAmount,
+    isMainnet: false,
+  });
+
+  const { commitment, ckbRawTx } = ckbVirtualTxResult;
+
+  // Send BTC tx
+  const psbt = await sendRgbppUtxos({
+    ckbVirtualTx: ckbRawTx,
+    commitment,
+    tos: [toBtcAddress],
+    ckbCollector: collector,
+    from: btcAddress!,
+    source,
+  });
+  psbt.signAllInputs(keyPair);
+  psbt.finalizeAllInputs();
+
+  const btcTx = psbt.extractTransaction();
+  const { txid: btcTxId } = await service.sendBtcTransaction(btcTx.toHex());
+
+  console.log('BTC TxId: ', btcTxId);
+
+  try {
+    await service.sendRgbppCkbTransaction({ btc_txid: btcTxId, ckb_virtual_result: ckbVirtualTxResult });
+    const interval = setInterval(async () => {
+      const { state, failedReason } = await service.getRgbppTransactionState(btcTxId);
+      console.log('state', state);
+      if (state === 'completed' || state === 'failed') {
+        clearInterval(interval)
+        if (state === 'completed') {
+          const { txhash: txHash } = await service.getRgbppTransactionHash(btcTxId);
+          console.info(`Rgbpp asset has been transferred on BTC and tx hash and tx hash is ${txHash}`);
+        } else {
+          console.warn(`Rgbpp CKB transaction failed and the reason is ${failedReason} `);
+        }
+      }
+    }, 30 * 1000)
+  } catch (error) {
+    console.error(error)
+  }
+};
+
+
+// Use your real BTC UTXO information on the BTC Testnet
+// rgbppLockArgs: outIndexU32 + btcTxId
+transferRgbppOnBtc({
+  rgbppLockArgsList: [buildRgbppLockArgs(1, '64252b582aea1249ed969a20385fae48bba35bf1ab9b3df3b0fcddc754ccf592')],
+  toBtcAddress: 'tb1qvt7p9g6mw70sealdewtfp0sekquxuru6j3gwmt',
+  // To simplify, keep the transferAmount the same as 2-ckb-jump-btc
+  transferAmount: BigInt(800_0000_0000),
+});
+

--- a/examples/rgbpp/queue/3-btc-transfer.ts
+++ b/examples/rgbpp/queue/3-btc-transfer.ts
@@ -85,7 +85,7 @@ const transferRgbppOnBtc = async ({ rgbppLockArgsList, toBtcAddress, transferAmo
         clearInterval(interval)
         if (state === 'completed') {
           const { txhash: txHash } = await service.getRgbppTransactionHash(btcTxId);
-          console.info(`Rgbpp asset has been transferred on BTC and tx hash and tx hash is ${txHash}`);
+          console.info(`Rgbpp asset has been transferred on BTC and the related CKB tx hash is ${txHash}`);
         } else {
           console.warn(`Rgbpp CKB transaction failed and the reason is ${failedReason} `);
         }

--- a/examples/rgbpp/queue/4-btc-jump-ckb.ts
+++ b/examples/rgbpp/queue/4-btc-jump-ckb.ts
@@ -1,0 +1,113 @@
+import { AddressPrefix, privateKeyToAddress, serializeScript } from '@nervosnetwork/ckb-sdk-utils';
+import {
+  Collector,
+  genBtcJumpCkbVirtualTx,
+  buildRgbppLockArgs,
+} from '@rgbpp-sdk/ckb';
+import {
+  sendRgbppUtxos,
+  DataSource,
+  NetworkType,
+  bitcoin,
+  ECPair,
+} from '@rgbpp-sdk/btc';
+import { BtcAssetsApi } from '@rgbpp-sdk/service'
+
+// CKB SECP256K1 private key
+const CKB_TEST_PRIVATE_KEY = '0x0000000000000000000000000000000000000000000000000000000000000001';
+// BTC SECP256K1 private key
+const BTC_TEST_PRIVATE_KEY = '0000000000000000000000000000000000000000000000000000000000000001';
+// API docs: https://btc-assets-api.testnet.mibao.pro/docs
+const BTC_ASSETS_API_URL = 'https://btc-assets-api.testnet.mibao.pro/';
+// https://btc-assets-api.testnet.mibao.pro/docs/static/index.html#/Token/post_token_generate
+const BTC_ASSETS_TOKEN = '';
+
+interface Params {
+  rgbppLockArgsList: string[];
+  toCkbAddress: string;
+  transferAmount: bigint;
+}
+const jumpFromBtcToCkb = async ({ rgbppLockArgsList, toCkbAddress, transferAmount }: Params) => {
+  const collector = new Collector({
+    ckbNodeUrl: 'https://testnet.ckb.dev/rpc',
+    ckbIndexerUrl: 'https://testnet.ckb.dev/indexer',
+  });
+  const address = privateKeyToAddress(CKB_TEST_PRIVATE_KEY, { prefix: AddressPrefix.Testnet });
+  console.log('ckb address: ', address);
+
+  const network = bitcoin.networks.testnet;
+  const keyPair = ECPair.fromPrivateKey(Buffer.from(BTC_TEST_PRIVATE_KEY, 'hex'), { network });
+  const { address: btcAddress } = bitcoin.payments.p2wpkh({
+    pubkey: keyPair.publicKey,
+    network,
+  });
+  console.log('btc address: ', btcAddress);
+
+  const networkType = NetworkType.TESTNET;
+  const service = BtcAssetsApi.fromToken(BTC_ASSETS_API_URL, BTC_ASSETS_TOKEN, 'https://btc-test.app');
+  const source = new DataSource(service, networkType);
+
+  const xudtType: CKBComponents.Script = {
+    codeHash: '0x25c29dc317811a6f6f3985a7a9ebc4838bd388d19d0feeecf0bcd60f6c0975bb',
+    hashType: 'type',
+    args: '0x1ba116c119d1cfd98a53e9d1a615cf2af2bb87d95515c9d217d367054cfc696b',
+  };
+
+  const ckbVirtualTxResult = await genBtcJumpCkbVirtualTx({
+    collector,
+    rgbppLockArgsList,
+    xudtTypeBytes: serializeScript(xudtType),
+    transferAmount,
+    toCkbAddress,
+    isMainnet: false,
+  });
+
+  const { commitment, ckbRawTx } = ckbVirtualTxResult;
+
+  // Send BTC tx
+  const psbt = await sendRgbppUtxos({
+    ckbVirtualTx: ckbRawTx,
+    commitment,
+    tos: [btcAddress!], 
+    ckbCollector: collector,
+    from: btcAddress!,
+    source,
+  });
+  psbt.signAllInputs(keyPair);
+  psbt.finalizeAllInputs();
+
+  const btcTx = psbt.extractTransaction();
+  const { txid: btcTxId } = await service.sendBtcTransaction(btcTx.toHex());
+
+  console.log('BTC TxId: ', btcTxId);
+
+  try {
+    await service.sendRgbppCkbTransaction({ btc_txid: btcTxId, ckb_virtual_result: ckbVirtualTxResult });
+    const interval = setInterval(async () => {
+      const { state, failedReason } = await service.getRgbppTransactionState(btcTxId);
+      console.log('state', state);
+      if (state === 'completed' || state === 'failed') {
+        clearInterval(interval);
+        if (state === 'completed') {
+          const { txhash: txHash } = await service.getRgbppTransactionHash(btcTxId);
+          console.info(`Rgbpp asset has been jumped from BTC to CKB and tx hash is ${txHash}`);
+        } else {
+          console.warn(`Rgbpp CKB transaction failed and the reason is ${failedReason} `);
+        }
+      }
+    }, 30 * 1000);
+  } catch (error) {
+    console.error(error);
+  }
+};
+
+// rgbppLockArgs: outIndexU32 + btcTxId
+jumpFromBtcToCkb({
+  // If the `3-btc-transfer.ts` has been executed, the BTC txId should be the new generated BTC txId by the `3-btc-transfer.ts`
+  // Otherwise the BTC txId should be same as the the BTC txId of the `2-ckb-jump-btc.ts`
+  rgbppLockArgsList: [buildRgbppLockArgs(1, '6edd4b9327506fab09fb9a0f5e5f35136a6a94bd4c9dd79af04921618fa6c800')],
+  toCkbAddress: 'ckt1qrfrwcdnvssswdwpn3s9v8fp87emat306ctjwsm3nmlkjg8qyza2cqgqq9kxr7vy7yknezj0vj0xptx6thk6pwyr0sxamv6q',
+  // To simplify, keep the transferAmount the same as 2-ckb-jump-btc
+  transferAmount: BigInt(800_0000_0000),
+});
+

--- a/examples/rgbpp/queue/4-btc-jump-ckb.ts
+++ b/examples/rgbpp/queue/4-btc-jump-ckb.ts
@@ -90,7 +90,7 @@ const jumpFromBtcToCkb = async ({ rgbppLockArgsList, toCkbAddress, transferAmoun
         clearInterval(interval);
         if (state === 'completed') {
           const { txhash: txHash } = await service.getRgbppTransactionHash(btcTxId);
-          console.info(`Rgbpp asset has been jumped from BTC to CKB and tx hash is ${txHash}`);
+          console.info(`Rgbpp asset has been jumped from BTC to CKB and the related CKB tx hash is ${txHash}`);
         } else {
           console.warn(`Rgbpp CKB transaction failed and the reason is ${failedReason} `);
         }

--- a/examples/rgbpp/tsconfig.json
+++ b/examples/rgbpp/tsconfig.json
@@ -27,6 +27,6 @@
     "skipLibCheck": true,
     "strict": true,
   },
-  "include": ["local/**.ts"],
+  "include": ["local/**.ts", "queue/**.ts"],
   "exclude": ["node_modules"]
 }

--- a/packages/ckb/src/rgbpp/ckb-jump-btc.ts
+++ b/packages/ckb/src/rgbpp/ckb-jump-btc.ts
@@ -9,7 +9,7 @@ import {
   u128ToLe,
 } from '../utils';
 import { genRgbppLockScript } from '../utils/rgbpp';
-import { MAX_FEE, SECP256K1_WITNESS_LOCK_SIZE, getXudtDep } from '../constants';
+import { MAX_FEE, RGBPP_TX_WITNESS_MAX_SIZE, getXudtDep } from '../constants';
 import { addressToScript, getTransactionSize } from '@nervosnetwork/ckb-sdk-utils';
 
 /**
@@ -98,7 +98,7 @@ export const genCkbJumpBtcVirtualTx = async ({
   };
 
   if (txFee === MAX_FEE) {
-    const txSize = getTransactionSize(ckbRawTx) + (witnessLockPlaceholderSize ?? SECP256K1_WITNESS_LOCK_SIZE);
+    const txSize = getTransactionSize(ckbRawTx) + (witnessLockPlaceholderSize ?? RGBPP_TX_WITNESS_MAX_SIZE);
     const estimatedTxFee = calculateTransactionFee(txSize);
     const estimatedChangeCapacity = changeCapacity + (MAX_FEE - estimatedTxFee);
     ckbRawTx.outputs[ckbRawTx.outputs.length - 1].capacity = append0x(estimatedChangeCapacity.toString(16));

--- a/packages/service/src/types/rgbpp.ts
+++ b/packages/service/src/types/rgbpp.ts
@@ -18,6 +18,7 @@ export interface RgbppApiCkbTransactionHash {
 
 export interface RgbppApiTransactionState {
   state: RgbppTransactionState;
+  failedReason: string;
 }
 
 export interface RgbppApiAssetsByAddressParams {


### PR DESCRIPTION
## Main Changes

- Add examples with queue service 
- Update the CKB Tx fee of the jumping transaction from CKB to BTC
- Add failedReason to the RGBPP state response
- Update examples readme
