### PR TITLE
fix(rgbpp-sdk/ckb): Update change capacity for multiply inputs

### DIFF
--- a/packages/ckb/src/rgbpp/btc-jump-ckb.ts
+++ b/packages/ckb/src/rgbpp/btc-jump-ckb.ts
@@ -65,6 +65,8 @@ export const genBtcJumpCkbVirtualTx = async ({
   if (isLockArgsSizeExceeded(toLock.args)) {
     throw new Error('The lock script size of the to ckb address is too large');
   }
+
+  let changeCapacity = sumInputsCapacity;
   const outputs: CKBComponents.CellOutput[] = [
     {
       lock: genBtcTimeLockScript(toLock, isMainnet),
@@ -80,6 +82,7 @@ export const genBtcJumpCkbVirtualTx = async ({
       capacity: append0x(rpbppCellCapacity.toString(16)),
     });
     outputsData.push(append0x(u128ToLe(sumAmount - transferAmount)));
+    changeCapacity -= rpbppCellCapacity;
   }
 
   const cellDeps = [getRgbppLockDep(isMainnet), getXudtDep(isMainnet), getRgbppLockConfigDep(isMainnet)];
@@ -113,7 +116,7 @@ export const genBtcJumpCkbVirtualTx = async ({
     const txSize = getTransactionSize(ckbRawTx) + RGBPP_TX_WITNESS_MAX_SIZE;
     const estimatedTxFee = calculateTransactionFee(txSize);
 
-    const changeCapacity = sumInputsCapacity - estimatedTxFee;
+    changeCapacity -= estimatedTxFee;
     ckbRawTx.outputs[ckbRawTx.outputs.length - 1].capacity = append0x(changeCapacity.toString(16));
   }
 

--- a/packages/ckb/src/rgbpp/btc-transfer.ts
+++ b/packages/ckb/src/rgbpp/btc-transfer.ts
@@ -48,6 +48,8 @@ export const genBtcTransferCkbVirtualTx = async ({
   const rpbppCellCapacity = calculateRgbppCellCapacity(xudtType);
   const outputsData = [append0x(u128ToLe(transferAmount))];
 
+  let changeCapacity = sumInputsCapacity;
+
   // The Vouts[0] for OP_RETURN and Vouts[1], Vouts[2] for RGBPP assets
   const outputs: CKBComponents.CellOutput[] = [
     {
@@ -64,6 +66,7 @@ export const genBtcTransferCkbVirtualTx = async ({
       capacity: append0x(rpbppCellCapacity.toString(16)),
     });
     outputsData.push(append0x(u128ToLe(sumAmount - transferAmount)));
+    changeCapacity -= rpbppCellCapacity;
   }
 
   const cellDeps = [getRgbppLockDep(isMainnet), getXudtDep(isMainnet), getRgbppLockConfigDep(isMainnet)];
@@ -96,7 +99,7 @@ export const genBtcTransferCkbVirtualTx = async ({
     const txSize = getTransactionSize(ckbRawTx) + RGBPP_TX_WITNESS_MAX_SIZE;
     const estimatedTxFee = calculateTransactionFee(txSize);
 
-    const changeCapacity = sumInputsCapacity - estimatedTxFee;
+    changeCapacity -= estimatedTxFee;
     ckbRawTx.outputs[ckbRawTx.outputs.length - 1].capacity = append0x(changeCapacity.toString(16));
   }
 


### PR DESCRIPTION
## Main Changes

- Update change capacity calculation for CKB transactions whose output length exceeds one.