### PR TITLE
feat(rgbpp-sdk/ckb): Add BTC transfer example without CKB tx outputs merged

### DIFF
--- a/examples/rgbpp/README.md
+++ b/examples/rgbpp/README.md
@@ -54,7 +54,9 @@ npx ts-node examples/rgbpp/queue/4-btc-jump-ckb.ts
 ```
 
 ### Unlock BTC time cells on CKB
-A cron job in RGB++ queue service will construct a transaction unlocking the mature btc_time_lock cells to the their `target_ckb_address`.
+
+A cron job in RGB++ Queue service will construct a transaction unlocking the mature BTC time cells to the their `target_ckb_address`.
+
 ## Local Examples
 
 ### Mint XUDT

--- a/examples/rgbpp/local/2-ckb-jump-btc.ts
+++ b/examples/rgbpp/local/2-ckb-jump-btc.ts
@@ -45,6 +45,6 @@ const jumpFromCkbToBtc = async ({ outIndex, btcTxId }: { outIndex: number; btcTx
 // Use your real BTC UTXO information on the BTC Testnet
 jumpFromCkbToBtc({
   outIndex: 1,
-  btcTxId: '70b250e2a3cc7a33b47f7a4e94e41e1ee2501ce73b393d824db1dd4c872c5348',
+  btcTxId: '4ff1855b64b309afa19a8b9be3d4da99dcb18b083b65d2d851662995c7d99e7a',
 });
 

--- a/examples/rgbpp/local/3-btc-transfer.ts
+++ b/examples/rgbpp/local/3-btc-transfer.ts
@@ -15,7 +15,7 @@ const CKB_TEST_PRIVATE_KEY = '0x000000000000000000000000000000000000000000000000
 // BTC SECP256K1 private key
 const BTC_TEST_PRIVATE_KEY = '0000000000000000000000000000000000000000000000000000000000000001';
 // API docs: https://btc-assets-api.testnet.mibao.pro/docs
-const BTC_ASSETS_API_URL = 'https://btc-assets-api.testnet.mibao.pro/';
+const BTC_ASSETS_API_URL = 'https://btc-assets-api.testnet.mibao.pro';
 // https://btc-assets-api.testnet.mibao.pro/docs/static/index.html#/Token/post_token_generate
 const BTC_ASSETS_TOKEN = '';
 

--- a/examples/rgbpp/local/4-btc-jump-ckb.ts
+++ b/examples/rgbpp/local/4-btc-jump-ckb.ts
@@ -22,7 +22,7 @@ const CKB_TEST_PRIVATE_KEY = '0x000000000000000000000000000000000000000000000000
 // BTC SECP256K1 private key
 const BTC_TEST_PRIVATE_KEY = '0000000000000000000000000000000000000000000000000000000000000001';
 // API docs: https://btc-assets-api.testnet.mibao.pro/docs
-const BTC_ASSETS_API_URL = 'https://btc-assets-api.testnet.mibao.pro/';
+const BTC_ASSETS_API_URL = 'https://btc-assets-api.testnet.mibao.pro';
 // https://btc-assets-api.testnet.mibao.pro/docs/static/index.html#/Token/post_token_generate
 const BTC_ASSETS_TOKEN = '';
 

--- a/examples/rgbpp/local/5-spend-btc-time-cell.ts
+++ b/examples/rgbpp/local/5-spend-btc-time-cell.ts
@@ -11,9 +11,9 @@ import {
 import { BtcAssetsApi } from '@rgbpp-sdk/service';
 
 // CKB SECP256K1 private key
-const CKB_TEST_PRIVATE_KEY = '';
+const CKB_TEST_PRIVATE_KEY = '0x0000000000000000000000000000000000000000000000000000000000000001';
 // API docs: https://btc-assets-api.testnet.mibao.pro/docs
-const BTC_ASSETS_API_URL = 'https://btc-assets-api.testnet.mibao.pro/';
+const BTC_ASSETS_API_URL = 'https://btc-assets-api.testnet.mibao.pro';
 // https://btc-assets-api.testnet.mibao.pro/docs/static/index.html#/Token/post_token_generate
 const BTC_ASSETS_TOKEN = '';
 

--- a/examples/rgbpp/local/transfer-btc.ts
+++ b/examples/rgbpp/local/transfer-btc.ts
@@ -1,0 +1,50 @@
+
+import { sendBtc, DataSource, NetworkType, bitcoin, ECPair } from '@rgbpp-sdk/btc';
+import { BtcAssetsApi } from '@rgbpp-sdk/service';
+
+// BTC SECP256K1 private key
+const BTC_TEST_PRIVATE_KEY = '0000000000000000000000000000000000000000000000000000000000000001';
+
+// https://btc-assets-api-develop.vercel.app/docs/static/index.html
+const BTC_ASSETS_API_URL = 'https://btc-assets-api.testnet.mibao.pro';
+
+// https://btc-assets-api.testnet.mibao.pro/docs/static/index.html#/Token/post_token_generate
+const BTC_ASSETS_TOKEN = '';
+
+
+const transfer = async () => {
+  const network = bitcoin.networks.testnet;
+  const keyPair = ECPair.fromPrivateKey(Buffer.from(BTC_TEST_PRIVATE_KEY, 'hex'), { network });
+  const { address: btcAddress } = bitcoin.payments.p2wpkh({
+    pubkey: keyPair.publicKey,
+    network,
+  });
+  console.log('btc address: ', btcAddress);
+
+  const networkType = NetworkType.TESTNET;
+  const service = BtcAssetsApi.fromToken(BTC_ASSETS_API_URL, BTC_ASSETS_TOKEN, 'https://btc-test.app');
+  const source = new DataSource(service, networkType);
+
+  const psbt = await sendBtc({
+    from: btcAddress!, // your P2WPKH address
+    tos: [
+      {
+        address: btcAddress!, // destination btc address
+        value: 100000, // transfer satoshi amount
+      },
+    ],
+    feeRate: 1, // optional, default to 1 sat/vbyte
+    source,
+  });
+
+  // Sign & finalize inputs
+  psbt.signAllInputs(keyPair);
+  psbt.finalizeAllInputs();
+
+  // Broadcast transaction
+  const tx = psbt.extractTransaction();
+  const res = await service.sendBtcTransaction(tx.toHex());
+  console.log('txid:', res.txid);
+}
+
+transfer()

--- a/examples/rgbpp/local/transfer-btc.ts
+++ b/examples/rgbpp/local/transfer-btc.ts
@@ -4,15 +4,13 @@ import { BtcAssetsApi } from '@rgbpp-sdk/service';
 
 // BTC SECP256K1 private key
 const BTC_TEST_PRIVATE_KEY = '0000000000000000000000000000000000000000000000000000000000000001';
-
 // https://btc-assets-api-develop.vercel.app/docs/static/index.html
 const BTC_ASSETS_API_URL = 'https://btc-assets-api.testnet.mibao.pro';
-
 // https://btc-assets-api.testnet.mibao.pro/docs/static/index.html#/Token/post_token_generate
 const BTC_ASSETS_TOKEN = '';
 
-
-const transfer = async () => {
+// This example shows how to transfer BTC on testnet
+const transferBtc = async () => {
   const network = bitcoin.networks.testnet;
   const keyPair = ECPair.fromPrivateKey(Buffer.from(BTC_TEST_PRIVATE_KEY, 'hex'), { network });
   const { address: btcAddress } = bitcoin.payments.p2wpkh({
@@ -43,8 +41,8 @@ const transfer = async () => {
 
   // Broadcast transaction
   const tx = psbt.extractTransaction();
-  const res = await service.sendBtcTransaction(tx.toHex());
-  console.log('txid:', res.txid);
+  const { txid: txId} = await service.sendBtcTransaction(tx.toHex());
+  console.log('txId:', txId);
 }
 
-transfer()
+transferBtc();

--- a/examples/rgbpp/queue/2-ckb-jump-btc.ts
+++ b/examples/rgbpp/queue/2-ckb-jump-btc.ts
@@ -44,7 +44,7 @@ const jumpFromCkbToBtc = async ({ outIndex, btcTxId }: { outIndex: number; btcTx
 
 // Use your real BTC UTXO information on the BTC Testnet
 jumpFromCkbToBtc({
-  outIndex: 1,
-  btcTxId: '64252b582aea1249ed969a20385fae48bba35bf1ab9b3df3b0fcddc754ccf592',
+  outIndex: 0,
+  btcTxId: '4ff1855b64b309afa19a8b9be3d4da99dcb18b083b65d2d851662995c7d99e7a',
 });
 

--- a/examples/rgbpp/queue/4-btc-jump-ckb.ts
+++ b/examples/rgbpp/queue/4-btc-jump-ckb.ts
@@ -18,7 +18,7 @@ const CKB_TEST_PRIVATE_KEY = '0x000000000000000000000000000000000000000000000000
 // BTC SECP256K1 private key
 const BTC_TEST_PRIVATE_KEY = '0000000000000000000000000000000000000000000000000000000000000001';
 // API docs: https://btc-assets-api.testnet.mibao.pro/docs
-const BTC_ASSETS_API_URL = 'https://btc-assets-api.testnet.mibao.pro/';
+const BTC_ASSETS_API_URL = 'https://btc-assets-api.testnet.mibao.pro';
 // https://btc-assets-api.testnet.mibao.pro/docs/static/index.html#/Token/post_token_generate
 const BTC_ASSETS_TOKEN = '';
 

--- a/examples/rgbpp/queue/no-merge-outputs/3-btc-transfer.ts
+++ b/examples/rgbpp/queue/no-merge-outputs/3-btc-transfer.ts
@@ -1,9 +1,5 @@
 import { AddressPrefix, privateKeyToAddress, serializeScript } from '@nervosnetwork/ckb-sdk-utils';
-import {
-  Collector,
-  buildRgbppLockArgs,
-  genBtcTransferCkbVirtualTx,
-} from '@rgbpp-sdk/ckb';
+import { Collector, buildRgbppLockArgs, genBtcTransferCkbVirtualTx } from '@rgbpp-sdk/ckb';
 import { sendRgbppUtxos, DataSource, ECPair, bitcoin, NetworkType } from '@rgbpp-sdk/btc';
 import { BtcAssetsApi } from '@rgbpp-sdk/service';
 
@@ -55,6 +51,7 @@ const transferRgbppOnBtc = async ({ rgbppLockArgsList, toBtcAddress, transferAmo
     xudtTypeBytes: serializeScript(xudtType),
     transferAmount,
     isMainnet: false,
+    noMergeOutputCells: true
   });
 
   const { commitment, ckbRawTx } = ckbVirtualTxResult;
@@ -82,7 +79,7 @@ const transferRgbppOnBtc = async ({ rgbppLockArgsList, toBtcAddress, transferAmo
       const { state, failedReason } = await service.getRgbppTransactionState(btcTxId);
       console.log('state', state);
       if (state === 'completed' || state === 'failed') {
-        clearInterval(interval)
+        clearInterval(interval);
         if (state === 'completed') {
           const { txhash: txHash } = await service.getRgbppTransactionHash(btcTxId);
           console.info(`Rgbpp asset has been transferred on BTC and the related CKB tx hash is ${txHash}`);
@@ -90,19 +87,20 @@ const transferRgbppOnBtc = async ({ rgbppLockArgsList, toBtcAddress, transferAmo
           console.warn(`Rgbpp CKB transaction failed and the reason is ${failedReason} `);
         }
       }
-    }, 30 * 1000)
+    }, 30 * 1000);
   } catch (error) {
-    console.error(error)
+    console.error(error);
   }
 };
-
 
 // Use your real BTC UTXO information on the BTC Testnet
 // rgbppLockArgs: outIndexU32 + btcTxId
 transferRgbppOnBtc({
-  rgbppLockArgsList: [buildRgbppLockArgs(1, '64252b582aea1249ed969a20385fae48bba35bf1ab9b3df3b0fcddc754ccf592')],
+  rgbppLockArgsList: [
+    buildRgbppLockArgs(0, '4ff1855b64b309afa19a8b9be3d4da99dcb18b083b65d2d851662995c7d99e7a'),
+    buildRgbppLockArgs(1, '4ff1855b64b309afa19a8b9be3d4da99dcb18b083b65d2d851662995c7d99e7a'),
+  ],
   toBtcAddress: 'tb1qvt7p9g6mw70sealdewtfp0sekquxuru6j3gwmt',
-  // To simplify, keep the transferAmount the same as 2-ckb-jump-btc
-  transferAmount: BigInt(800_0000_0000),
+  // the transferAmount will be ignored
+  transferAmount: BigInt(0),
 });
-

--- a/examples/rgbpp/tsconfig.json
+++ b/examples/rgbpp/tsconfig.json
@@ -27,6 +27,6 @@
     "skipLibCheck": true,
     "strict": true,
   },
-  "include": ["local/**.ts", "queue/**.ts", "queue/**/*.ts"],
+  "include": ["local/**.ts", "queue/**/*.ts"],
   "exclude": ["node_modules"]
 }

--- a/examples/rgbpp/tsconfig.json
+++ b/examples/rgbpp/tsconfig.json
@@ -27,6 +27,6 @@
     "skipLibCheck": true,
     "strict": true,
   },
-  "include": ["local/**.ts", "queue/**.ts"],
+  "include": ["local/**.ts", "queue/**.ts", "queue/**/*.ts"],
   "exclude": ["node_modules"]
 }

--- a/packages/ckb/README.md
+++ b/packages/ckb/README.md
@@ -24,12 +24,12 @@ The `example/paymaster.ts` demonstrates how to use `@rgbpp-sdk/ckb` SDK to split
 cd packages/ckb && pnpm splitCells
 ```
 
-## BTC rgbpp asset transfer
+## RGB++ assetS transfer on BTC
 
 The method `genBtcTransferCkbVirtualTx` can generate a CKB virtual transaction which contains the necessary `inputCells/outputCells` for rgbpp asset transfer and the commitment to be inserted to the BTC tx OP_RETURN.
 
 ```TypeScript
-interface BtcTransferVirtualTxResult {
+export interface BtcTransferVirtualTxResult {
   // CKB raw transaction
   ckbRawTx: CKBComponents.RawTransaction;
   // The rgbpp commitment to be inserted into BTC op_return
@@ -37,7 +37,7 @@ interface BtcTransferVirtualTxResult {
   // The needPaymasterCell indicates whether a paymaster cell is required
   needPaymasterCell: boolean;
   // The sum capacity of the ckb inputs
-  sumInputsCapacity: bigint;
+  sumInputsCapacity: Hex;
 }
 
 /**
@@ -45,19 +45,21 @@ interface BtcTransferVirtualTxResult {
  * @param collector The collector that collects CKB live cells and transactions
  * @param xudtTypeBytes The serialized hex string of the XUDT type script
  * @param rgbppLockArgsList The rgbpp assets cell lock script args array whose data structure is: out_index | bitcoin_tx_id
- * @param transferAmount The XUDT amount to be transferred
+ * @param transferAmount The XUDT amount to be transferred, if the noMergeOutputCells is true, the transferAmount will be ignored
  * @param isMainnet
+ * @param noMergeOutputCells The noMergeOutputCells indicates whether the CKB outputs need to be merged. By default, the outputs will be merged.
  */
-const genBtcTransferCkbVirtualTx = async ({
+export const genBtcTransferCkbVirtualTx = async ({
   collector,
   xudtTypeBytes,
   rgbppLockArgsList,
   transferAmount,
   isMainnet,
+  noMergeOutputCells,
 }: BtcTransferVirtualTxParams): Promise<BtcTransferVirtualTxResult>
 ```
 
-## BTC rgbpp asset jump to CKB
+## RGB++ assets jump from BTC to CKB
 
 The method `genBtcJumpCkbVirtualTx` can generate a CKB virtual transaction which contains the necessary `inputCells/outputCells` for rgbpp asset jumping from BTC to CKB and the commitment to be inserted to the BTC tx OP_RETURN.
 
@@ -70,9 +72,8 @@ interface BtcJumpCkbVirtualTxResult {
   // The needPaymasterCell indicates whether a paymaster cell is required
   needPaymasterCell: boolean;
   // The sum capacity of the ckb inputs
-  sumInputsCapacity: bigint;
+  sumInputsCapacity: Hex;
 }
-
 /**
  * Generate the virtual ckb transaction for the jumping tx from BTC to CKB
  * @param collector The collector that collects CKB live cells and transactions
@@ -90,7 +91,7 @@ export const genBtcJumpCkbVirtualTx = async ({
 }: BtcJumpCkbVirtualTxParams): Promise<BtcJumpCkbVirtualTxResult>
 ```
 
-## CKB rgbpp asset jump to BTC
+## RGB++ assets jump from CKB to BTC
 
 The method `genCkbJumpBtcVirtualTx` can generate a CKB transaction for rgbpp assets jumping from CKB to BTC
 
@@ -102,7 +103,7 @@ The method `genCkbJumpBtcVirtualTx` can generate a CKB transaction for rgbpp ass
  * @param fromCkbAddress The from ckb address who will use his private key to sign the ckb tx
  * @param toRgbppLockArgs The receiver rgbpp lock script args whose data structure is: out_index | bitcoin_tx_id
  * @param transferAmount The XUDT amount to be transferred
- * @param witnessLockPlaceholderSize The WitnessArgs.lock placeholder bytes array size and the default value is 65(official secp256k1/blake160 lock)
+ * @param witnessLockPlaceholderSize The WitnessArgs.lock placeholder bytes array size and the default value is 3000(It can make most scenarios work properly)
  * @param isMainnet
  */
 export const genCkbJumpBtcVirtualTx = async ({

--- a/packages/ckb/README.md
+++ b/packages/ckb/README.md
@@ -17,7 +17,7 @@ $ pnpm add @rgbpp-sdk/ckb
 The `example/paymaster.ts` demonstrates how to use `@rgbpp-sdk/ckb` SDK to split multiple cells and you can set the parameters as blow:
 
 - `receiverAddress`: The receiver ckb address
-- `capacityWithCKB`: The capacity(unit is CKB) of each cell, for example: 220CKB
+- `capacityWithCKB`: The capacity(unit is CKB) of each cell, for example: 316CKB
 - `cellAmount`: The amount of cells to be split
 
 ```bash

--- a/packages/ckb/README.md
+++ b/packages/ckb/README.md
@@ -24,7 +24,7 @@ The `example/paymaster.ts` demonstrates how to use `@rgbpp-sdk/ckb` SDK to split
 cd packages/ckb && pnpm splitCells
 ```
 
-## RGB++ assetS transfer on BTC
+## RGB++ assets transfer on BTC
 
 The method `genBtcTransferCkbVirtualTx` can generate a CKB virtual transaction which contains the necessary `inputCells/outputCells` for rgbpp asset transfer and the commitment to be inserted to the BTC tx OP_RETURN.
 

--- a/packages/ckb/example/paymaster.ts
+++ b/packages/ckb/example/paymaster.ts
@@ -15,13 +15,13 @@ const splitPaymasterCells = async () => {
   const address = privateKeyToAddress(MASTER_SECP256K1_PRIVATE_KEY, { prefix: AddressPrefix.Testnet });
   console.log('master address: ', address);
 
-  // Split 200 cells whose capacity are 220CKB for the receiver address
+  // Split 200 cells whose capacity are 316CKB for the receiver address
   await splitMultiCellsWithSecp256k1({
     masterPrivateKey: MASTER_SECP256K1_PRIVATE_KEY,
     collector,
     receiverAddress: RECEIVER_ADDRESS,
-    capacityWithCKB: 220,
-    cellAmount: 2,
+    capacityWithCKB: 316,
+    cellAmount: 200,
   });
 };
 

--- a/packages/ckb/src/rgbpp/ckb-jump-btc.ts
+++ b/packages/ckb/src/rgbpp/ckb-jump-btc.ts
@@ -19,7 +19,7 @@ import { addressToScript, getTransactionSize } from '@nervosnetwork/ckb-sdk-util
  * @param fromCkbAddress The from ckb address who will use his private key to sign the ckb tx
  * @param toRgbppLockArgs The receiver rgbpp lock script args whose data structure is: out_index | bitcoin_tx_id
  * @param transferAmount The XUDT amount to be transferred
- * @param witnessLockPlaceholderSize The WitnessArgs.lock placeholder bytes array size and the default value is 65(official secp256k1/blake160 lock)
+ * @param witnessLockPlaceholderSize The WitnessArgs.lock placeholder bytes array size and the default value is 3000(It can make most scenarios work properly)
  * @param isMainnet
  */
 export const genCkbJumpBtcVirtualTx = async ({

--- a/packages/ckb/src/types/rgbpp.ts
+++ b/packages/ckb/src/types/rgbpp.ts
@@ -118,7 +118,7 @@ export interface CkbJumpBtcVirtualTxParams {
   toRgbppLockArgs: Hex;
   // The XUDT amount to be transferred
   transferAmount: bigint;
-  // The WitnessArgs.lock placeholder bytes array size and the default value is 65(official secp256k1/blake160 lock)
+  // The WitnessArgs.lock placeholder bytes array size and the default value is 3000(It can make most scenarios work properly)
   witnessLockPlaceholderSize?: number;
 }
 

--- a/packages/ckb/src/types/rgbpp.ts
+++ b/packages/ckb/src/types/rgbpp.ts
@@ -23,9 +23,11 @@ export interface BtcTransferVirtualTxParams {
   xudtTypeBytes: Hex;
   // The rgbpp assets cell lock script args array whose data structure is: out_index | bitcoin_tx_id
   rgbppLockArgsList: Hex[];
-  // The XUDT amount to be transferred
+  // The XUDT amount to be transferred, if the noMergeOutputCells is true, the transferAmount will be ignored
   transferAmount: bigint;
   isMainnet: boolean;
+  // The noMergeOutputCells indicates whether the CKB outputs need to be merged. By default, the outputs will be merged.
+  noMergeOutputCells?: boolean;
 }
 
 export interface RgbppCkbVirtualTx {


### PR DESCRIPTION
## Main Changes

- Add BTC transfer example without CKB tx outputs merged
- Update examples BTC_ASSETS_API_URL default value
- Add `noMergeOutputCells` to `genBtcTransferCkbVirtualTx` function to support CKB tx without outputs merged

## Related test BTC and CKB transactions

- BTC TX: https://mempool.space/testnet/tx/c51644a8dd77677da2ee0c925ff8fb7f6a60fd7e46e4bec9e6bedb57c42f2761

- CKB TX: https://pudge.explorer.nervos.org/transaction/0x7c4ab94fd4714c8436ff62673a331f048394657908dde2da3944e1ff9816cdaa