### PR TITLE
feat(rgbpp-sdk/btc): btc builder apis

### DIFF
--- a/.changeset/dirty-walls-beg.md
+++ b/.changeset/dirty-walls-beg.md
@@ -1,0 +1,5 @@
+---
+"@rgbpp-sdk/btc": patch
+---
+
+Add BTC Builder APIs to provide more transaction construction info, like "fee" and "feeRate"

--- a/packages/btc/README.md
+++ b/packages/btc/README.md
@@ -224,61 +224,91 @@ const psbt = await sendRgbppUtxos({
 
 ### Transaction
 
-#### sendBtc
+#### sendBtc / createSendBtcBuilder / SendBtcProps
 
 ```typescript
-interface sendBtc {
-  (props: {
-    from: string;
-    tos: InitOutput[];
-    source: DataSource;
-    fromPubkey?: string;
-    changeAddress?: string;
-    minUtxoSatoshi?: number;
-    feeRate?: number;
-  }): Promise<bitcoin.Psbt>;
+declare function sendBtc(props: SendBtcProps): Promise<bitcoin.Psbt>;
+```
+
+```typescript
+declare function createSendBtcBuilder(props: SendBtcProps): Promise<{
+  builder: TxBuilder;
+  feeRate: number;
+  fee: number;
+}>;
+```
+
+```typescript
+interface SendBtcProps {
+  from: string;
+  tos: InitOutput[];
+  source: DataSource;
+  fromPubkey?: string;
+  changeAddress?: string;
+  minUtxoSatoshi?: number;
+  feeRate?: number;
 }
 ```
 
-#### sendUtxos
+#### sendUtxos / createSendUtxosBuilder / SendUtxosProps
 
 ```typescript
-interface sendUtxos {
-  (props: {
-    inputs: Utxo[];
-    outputs: InitOutput[];
-    source: DataSource;
-    from: string;
-    fromPubkey?: string;
-    changeAddress?: string;
-    minUtxoSatoshi?: number;
-    feeRate?: number;
-  }): Promise<bitcoin.Psbt>;
+declare function sendUtxos(props: SendUtxosProps): Promise<bitcoin.Psbt>;
+```
+
+```typescript
+declare function createSendUtxosBuilder(props: SendUtxosProps): Promise<{
+  builder: TxBuilder;
+  feeRate: number;
+  fee: number;
+}>;
+```
+
+```typescript
+interface SendUtxosProps {
+  inputs: Utxo[];
+  outputs: InitOutput[];
+  source: DataSource;
+  from: string;
+  fromPubkey?: string;
+  changeAddress?: string;
+  minUtxoSatoshi?: number;
+  feeRate?: number;
 }
 ```
 
-#### sendRgbppUtxos
+#### sendRgbppUtxos / createSendRgbppUtxosBuilder / SendRgbppUtxosProps
 
 ```typescript
-interface sendRgbppUtxos {
-  (props: {
-    ckbVirtualTx: RawTransaction;
-    commitment: Hash;
-    tos?: string[];
-    paymaster?: TxAddressOutput;
+declare function sendRgbppUtxos(props: SendRgbppUtxosProps): Promise<bitcoin.Psbt>;
+```
 
-    ckbNodeUrl: string;
-    rgbppLockCodeHash: Hash;
-    rgbppTimeLockCodeHash: Hash;
-    rgbppMinUtxoSatoshi?: number;
+```typescript
+declare function createSendRgbppUtxosBuilder(props: SendRgbppUtxosProps): Promise<{
+  builder: TxBuilder;
+  feeRate: number;
+  fee: number;
+}>;
+```
 
-    from: string;
-    source: DataSource;
-    fromPubkey?: string;
-    changeAddress?: string;
-    minUtxoSatoshi?: number;
-    feeRate?: number;
-  }): Promise<bitcoin.Psbt>;
+```typescript
+interface SendRgbppUtxosProps {
+  ckbVirtualTx: RawTransaction;
+  commitment: Hash;
+  tos?: string[];
+  paymaster?: TxAddressOutput;
+
+  ckbNodeUrl: string;
+  rgbppLockCodeHash: Hash;
+  rgbppTimeLockCodeHash: Hash;
+  rgbppMinUtxoSatoshi?: number;
+
+  from: string;
+  source: DataSource;
+  fromPubkey?: string;
+  changeAddress?: string;
+  minUtxoSatoshi?: number;
+  feeRate?: number;
 }
 ```
 

--- a/packages/btc/src/transaction/build.ts
+++ b/packages/btc/src/transaction/build.ts
@@ -129,14 +129,14 @@ export class TxBuilder {
     const originalInputs = clone(this.inputs);
     const originalOutputs = clone(this.outputs);
 
-    // Use the average fee rate if feeRate is not provided
+    // Fetch the latest average fee rate if feeRate param is not provided
     // The transaction is expected be confirmed within half an hour with the fee rate
     let averageFeeRate: number | undefined;
     if (!feeRate && !this.feeRate) {
       averageFeeRate = await this.source.getAverageFeeRate();
     }
 
-    // Use the feeRate it is specified,
+    // Use the feeRate param if it is specified,
     // otherwise use the average fee rate from the DataSource
     const currentFeeRate = feeRate ?? this.feeRate ?? averageFeeRate!;
 

--- a/packages/btc/src/transaction/build.ts
+++ b/packages/btc/src/transaction/build.ts
@@ -1,7 +1,7 @@
 import clone from 'lodash/cloneDeep';
 import { bitcoin } from '../bitcoin';
-import { addressToScriptPublicKeyHex, AddressType, getAddressType, isSupportedFromAddress } from '../address';
 import { DataSource } from '../query/source';
+import { addressToScriptPublicKeyHex, AddressType, getAddressType, isSupportedFromAddress } from '../address';
 import { NetworkType, RgbppBtcConfig } from '../preset/types';
 import { ErrorCodes, ErrorMessages, TxBuildError } from '../error';
 import { networkTypeToConfig } from '../preset/config';
@@ -121,7 +121,10 @@ export class TxBuilder {
     changeAddress?: string;
     deductFromOutputs?: boolean;
     feeRate?: number;
-  }) {
+  }): Promise<{
+    fee: number;
+    feeRate: number;
+  }> {
     const { address, publicKey, feeRate, changeAddress, deductFromOutputs } = props;
     const originalInputs = clone(this.inputs);
     const originalOutputs = clone(this.outputs);
@@ -133,6 +136,11 @@ export class TxBuilder {
       averageFeeRate = await this.source.getAverageFeeRate();
     }
 
+    // Use the feeRate it is specified,
+    // otherwise use the average fee rate from the DataSource
+    const currentFeeRate = feeRate ?? this.feeRate ?? averageFeeRate!;
+
+    let currentFee: number = 0;
     let previousFee: number = 0;
     while (true) {
       const { inputsNeeding, outputsNeeding } = this.summary();
@@ -157,16 +165,20 @@ export class TxBuilder {
       }
 
       const addressType = getAddressType(address);
-      const currentFeeRate = feeRate ?? averageFeeRate;
-      const fee = await this.calculateFee(addressType, currentFeeRate);
-      if ([-1, 0, 1].includes(fee - previousFee)) {
+      currentFee = await this.calculateFee(addressType, currentFeeRate);
+      if ([-1, 0, 1].includes(currentFee - previousFee)) {
         break;
       }
 
-      previousFee = fee;
+      previousFee = currentFee;
       this.inputs = clone(originalInputs);
       this.outputs = clone(originalOutputs);
     }
+
+    return {
+      fee: currentFee,
+      feeRate: currentFeeRate,
+    };
   }
 
   async injectSatoshi(props: {


### PR DESCRIPTION
## Changes
1. Add BTC Builder APIs to provide more transaction construction info, e.g. `feeRate` and `fee`
    - Added: `createSendBtcBuilder`, `createSendUtxosBuilder`, `createSendRgbppUtxosBuilder`
    - Refactored with the Builder APIs: `sendBtc`, `sendUtxos`, `sendRgbppUtxos`
2. Update readme and add BTC Builder APIs types

## Todos
- [x] Merge #70 
- [x] Change base branch from `feat/config-by-network` to `main`