### PR TITLE
feat(rgbpp-sdk/ckb): Realize batch jump of assets from CKB to BTC

### DIFF
--- a/examples/rgbpp/local/batch/2-ckb-jump-btc.ts
+++ b/examples/rgbpp/local/batch/2-ckb-jump-btc.ts
@@ -1,0 +1,58 @@
+import { AddressPrefix, privateKeyToAddress, serializeScript } from '@nervosnetwork/ckb-sdk-utils';
+import { genCkbJumpBtcVirtualTx, Collector, getSecp256k1CellDep, buildRgbppLockArgs, genCkbBatchJumpBtcVirtualTx, RgbppCkbJumpReceiver } from '@rgbpp-sdk/ckb';
+
+// CKB SECP256K1 private key
+const CKB_TEST_PRIVATE_KEY = '0x0000000000000000000000000000000000000000000000000000000000000001';
+
+const batchJumpFromCkbToBtc = async (rgbppReceivers: RgbppCkbJumpReceiver[]) => {
+  const collector = new Collector({
+    ckbNodeUrl: 'https://testnet.ckb.dev/rpc',
+    ckbIndexerUrl: 'https://testnet.ckb.dev/indexer',
+  });
+  const isMainnet = false;
+  const address = privateKeyToAddress(CKB_TEST_PRIVATE_KEY, {
+      prefix: isMainnet ? AddressPrefix.Mainnet : AddressPrefix.Testnet,
+    });
+  console.log('ckb address: ', address);
+
+  const xudtType: CKBComponents.Script = {
+    codeHash: '0x25c29dc317811a6f6f3985a7a9ebc4838bd388d19d0feeecf0bcd60f6c0975bb',
+    hashType: 'type',
+    args: '0x1ba116c119d1cfd98a53e9d1a615cf2af2bb87d95515c9d217d367054cfc696b',
+  };
+
+  const ckbRawTx = await genCkbBatchJumpBtcVirtualTx({
+    collector,
+    fromCkbAddress: address,
+    xudtTypeBytes: serializeScript(xudtType),
+    rgbppReceivers,
+  });
+
+  const emptyWitness = { lock: '', inputType: '', outputType: '' };
+  let unsignedTx: CKBComponents.RawTransactionToSign = {
+    ...ckbRawTx,
+    cellDeps: [...ckbRawTx.cellDeps, getSecp256k1CellDep(false)],
+    witnesses: [emptyWitness, ...ckbRawTx.witnesses.slice(1)],
+  };
+
+  const signedTx = collector.getCkb().signTransaction(CKB_TEST_PRIVATE_KEY)(unsignedTx);
+
+  let txHash = await collector.getCkb().rpc.sendTransaction(signedTx, 'passthrough');
+  console.info(`Rgbpp asset has been jumped from CKB to BTC and tx hash is ${txHash}`);
+};
+
+// Use your real BTC UTXO information on the BTC Testnet
+const rgbppReceivers: RgbppCkbJumpReceiver[] = [
+  {
+    // outIndex and btcTxId
+    toRgbppLockArgs: buildRgbppLockArgs(1, 'bf991a2d6d08efffa089076d59b02bc78479b73c6300e640c148ec660bba0305'),
+    transferAmount: BigInt(800_0000_0000),
+  },
+  {
+    // outIndex and btcTxId
+    toRgbppLockArgs: buildRgbppLockArgs(1, 'bf991a2d6d08efffa089076d59b02bc78479b73c6300e640c148ec660bba0305'),
+    transferAmount: BigInt(800_0000_0000),
+  },
+];
+batchJumpFromCkbToBtc(rgbppReceivers);
+

--- a/packages/ckb/src/rgbpp/ckb-jump-btc.ts
+++ b/packages/ckb/src/rgbpp/ckb-jump-btc.ts
@@ -1,4 +1,4 @@
-import { CkbJumpBtcVirtualTxParams } from '../types/rgbpp';
+import { CkbBatchJumpBtcVirtualTxParams, CkbJumpBtcVirtualTxParams } from '../types/rgbpp';
 import { blockchain } from '@ckb-lumos/base';
 import { NoLiveCellError, NoXudtLiveCellError, TypeAssetNotSupportedError } from '../error';
 import {
@@ -84,6 +84,108 @@ export const genCkbJumpBtcVirtualTx = async ({
       capacity: append0x(xudtCellCapacity.toString(16)),
     });
     outputsData.push(append0x(u128ToLe(sumAmount - transferAmount)));
+    changeCapacity -= xudtCellCapacity;
+  }
+  outputs.push({
+    lock: fromLock,
+    capacity: append0x(changeCapacity.toString(16)),
+  });
+  outputsData.push('0x');
+
+  const cellDeps = [getXudtDep(isMainnet)];
+  const witnesses = inputs.map((_) => '0x');
+
+  const ckbRawTx: CKBComponents.RawTransaction = {
+    version: '0x0',
+    cellDeps,
+    headerDeps: [],
+    inputs,
+    outputs,
+    outputsData,
+    witnesses,
+  };
+
+  if (txFee === MAX_FEE) {
+    const txSize = getTransactionSize(ckbRawTx) + (witnessLockPlaceholderSize ?? RGBPP_TX_WITNESS_MAX_SIZE);
+    const estimatedTxFee = calculateTransactionFee(txSize);
+    const estimatedChangeCapacity = changeCapacity + (MAX_FEE - estimatedTxFee);
+    ckbRawTx.outputs[ckbRawTx.outputs.length - 1].capacity = append0x(estimatedChangeCapacity.toString(16));
+  }
+
+  return ckbRawTx;
+};
+
+/**
+ * Generate a virtual ckb transaction to realize a batch jump of assets from CKB to BTC
+ * @param collector The collector that collects CKB live cells and transactions
+ * @param xudtTypeBytes The serialized hex string of the XUDT type script
+ * @param fromCkbAddress The from ckb address who will use his private key to sign the ckb tx
+ * @param rgbppReceivers The rgbpp receiver list which include toRgbppLockArgs and transferAmount
+ * @param witnessLockPlaceholderSize The WitnessArgs.lock placeholder bytes array size and the default value is 3000(It can make most scenarios work properly)
+ * @param isMainnet
+ */
+export const genCkbBatchJumpBtcVirtualTx = async ({
+  collector,
+  xudtTypeBytes,
+  fromCkbAddress,
+  rgbppReceivers,
+  witnessLockPlaceholderSize,
+}: CkbBatchJumpBtcVirtualTxParams): Promise<CKBComponents.RawTransaction> => {
+  const isMainnet = fromCkbAddress.startsWith('ckb');
+  const xudtType = blockchain.Script.unpack(xudtTypeBytes) as CKBComponents.Script;
+  if (!isTypeAssetSupported(xudtType, isMainnet)) {
+    throw new TypeAssetNotSupportedError('The type script asset is not supported now');
+  }
+
+  const fromLock = addressToScript(fromCkbAddress);
+
+  const xudtCells = await collector.getCells({ lock: fromLock, type: xudtType });
+  if (!xudtCells || xudtCells.length === 0) {
+    throw new NoXudtLiveCellError('No rgbpp cells found with the xudt type script and the rgbpp lock args');
+  }
+
+  const sumTransferAmount = rgbppReceivers
+    .map((receiver) => receiver.transferAmount)
+    .reduce((prev, current) => prev + current, BigInt(0));
+
+  let { inputs, sumInputsCapacity, sumAmount } = collector.collectUdtInputs({
+    liveCells: xudtCells,
+    needAmount: sumTransferAmount,
+  });
+
+  const rpbppCellCapacity = calculateRgbppCellCapacity(xudtType);
+  const sumRgbppCellCapacity = rpbppCellCapacity * BigInt(rgbppReceivers.length);
+  const outputs: CKBComponents.CellOutput[] = rgbppReceivers.map((receiver) => ({
+    lock: genRgbppLockScript(receiver.toRgbppLockArgs, isMainnet),
+    type: xudtType,
+    capacity: append0x(rpbppCellCapacity.toString(16)),
+  }));
+  const outputsData = rgbppReceivers.map((receiver) => append0x(u128ToLe(receiver.transferAmount)));
+
+  let txFee = MAX_FEE;
+  const xudtCellCapacity = calculateUdtCellCapacity(fromLock, xudtType);
+  if (sumInputsCapacity < xudtCellCapacity + sumRgbppCellCapacity + MIN_CAPACITY + txFee) {
+    const emptyCells = await collector.getCells({ lock: fromLock });
+    if (!emptyCells || emptyCells.length === 0) {
+      throw new NoLiveCellError('The address has no empty cells');
+    }
+    const { inputs: emptyInputs, sumInputsCapacity: sumEmptyCapacity } = collector.collectInputs(
+      emptyCells,
+      rpbppCellCapacity,
+      txFee,
+    );
+    inputs = [...emptyInputs, ...inputs];
+    sumInputsCapacity += sumEmptyCapacity;
+  }
+
+  let changeCapacity = sumInputsCapacity - sumRgbppCellCapacity - txFee;
+  if (sumAmount > sumTransferAmount) {
+    outputs.push({
+      lock: fromLock,
+      type: xudtType,
+      capacity: append0x(xudtCellCapacity.toString(16)),
+    });
+    outputsData.push(append0x(u128ToLe(sumAmount - sumTransferAmount)));
     changeCapacity -= xudtCellCapacity;
   }
   outputs.push({

--- a/packages/ckb/src/types/rgbpp.ts
+++ b/packages/ckb/src/types/rgbpp.ts
@@ -138,3 +138,23 @@ export interface BtcTimeCellStatusParams {
   // The BTC transaction id
   btcTxId: Hex;
 }
+
+export interface RgbppCkbJumpReceiver {
+  // The receiver rgbpp lock script args whose data structure is: out_index | bitcoin_tx_id
+  toRgbppLockArgs: Hex;
+  // The XUDT amount to be transferred
+  transferAmount: bigint;
+}
+
+export interface CkbBatchJumpBtcVirtualTxParams {
+  // The collector that collects CKB live cells and transactions
+  collector: Collector;
+  // The serialized hex string of the XUDT type script
+  xudtTypeBytes: Hex;
+  // The from ckb address who will use his private key to sign the ckb tx
+  fromCkbAddress: Address;
+  // The rgbpp receiver list which include toRgbppLockArgs and transferAmount
+  rgbppReceivers: RgbppCkbJumpReceiver[];
+  // The WitnessArgs.lock placeholder bytes array size and the default value is 3000(It can make most scenarios work properly)
+  witnessLockPlaceholderSize?: number;
+}


### PR DESCRIPTION
## Main Changes

- Add `genCkbBatchJumpBtcVirtualTx` to realize a batch jump
- Add batch example for RGB++ assets jumping from CKB to BTC

## CKB Testnet transaction

https://pudge.explorer.nervos.org/transaction/0xfd5a4d897ed231f5d3afd155e95e9f90c2e99c1e71fc55f16ecd66b99411315f