### PR TITLE
fix(rgbpp-sdk/btc): fee estimation/collection issues

### DIFF
--- a/packages/btc/src/transaction/build.ts
+++ b/packages/btc/src/transaction/build.ts
@@ -150,7 +150,7 @@ export class TxBuilder {
           fromPublicKey: publicKey,
         });
       } else {
-        const protectionAmount = !safeToProcess ? 1 : 0;
+        const protectionAmount = safeToProcess ? 0 : 1;
         const targetAmount = needCollect - needReturn + previousFee + protectionAmount;
         await this.injectSatoshi({
           address,
@@ -383,16 +383,19 @@ export class TxBuilder {
   }
 
   summary() {
-    const sumOfInputs = this.inputs.reduce((acc, input) => acc + input.utxo.value, 0);
-    const sumOfOutputs = this.outputs.reduce((acc, output) => acc + output.value, 0);
+    const inputsTotal = this.inputs.reduce((acc, input) => acc + input.utxo.value, 0);
+    const outputsTotal = this.outputs.reduce((acc, output) => acc + output.value, 0);
+
+    const inputsRemaining = inputsTotal - outputsTotal;
+    const outputsRemaining = outputsTotal - inputsTotal;
 
     return {
-      inputsTotal: sumOfInputs,
-      outputsTotal: sumOfOutputs,
-      inputsRemaining: sumOfInputs - sumOfOutputs,
-      outputsRemaining: sumOfOutputs - sumOfInputs,
-      needReturn: sumOfInputs > sumOfOutputs ? sumOfInputs - sumOfOutputs : 0,
-      needCollect: sumOfOutputs > sumOfInputs ? sumOfOutputs - sumOfInputs : 0,
+      inputsTotal,
+      outputsTotal,
+      inputsRemaining,
+      outputsRemaining,
+      needReturn: inputsRemaining > 0 ? inputsRemaining : 0,
+      needCollect: outputsRemaining > 0 ? outputsRemaining : 0,
     };
   }
 

--- a/packages/btc/src/transaction/build.ts
+++ b/packages/btc/src/transaction/build.ts
@@ -1,11 +1,11 @@
 import clone from 'lodash/cloneDeep';
 import { bitcoin } from '../bitcoin';
 import { DataSource } from '../query/source';
-import { addressToScriptPublicKeyHex, AddressType, getAddressType, isSupportedFromAddress } from '../address';
+import { ErrorCodes, TxBuildError } from '../error';
 import { NetworkType, RgbppBtcConfig } from '../preset/types';
-import { ErrorCodes, ErrorMessages, TxBuildError } from '../error';
-import { networkTypeToConfig } from '../preset/config';
+import { AddressType, addressToScriptPublicKeyHex, getAddressType, isSupportedFromAddress } from '../address';
 import { dataToOpReturnScriptPubkey, isOpReturnScriptPubkey } from './embed';
+import { networkTypeToConfig } from '../preset/config';
 import { Utxo, utxoToInput } from './utxo';
 import { FeeEstimator } from './fee';
 
@@ -137,18 +137,19 @@ export class TxBuilder {
     let currentFee: number = 0;
     let previousFee: number = 0;
     while (true) {
-      const { inputsNeeding, outputsNeeding } = this.summary();
-      if (outputsNeeding > 0) {
-        // If sum(inputs) > sum(outputs), return change while deducting fee
+      const { needCollect, needReturn } = this.summary();
+      const returnAmount = needReturn - previousFee;
+      if (returnAmount > 0) {
+        // If sum(inputs) - sum(outputs) > fee, return change while deducting fee
         // Note, should not deduct fee from outputs while also returning change at the same time
-        const returnAmount = outputsNeeding - previousFee;
         await this.injectChange({
           address: changeAddress ?? address,
           amount: returnAmount,
-          publicKey,
+          fromAddress: address,
+          fromPublicKey: publicKey,
         });
       } else {
-        const targetAmount = inputsNeeding + previousFee;
+        const targetAmount = needCollect + previousFee - needReturn;
         await this.injectSatoshi({
           address,
           publicKey,
@@ -291,9 +292,12 @@ export class TxBuilder {
     let changeIndex: number = -1;
     if (changeAmount > 0) {
       changeIndex = this.outputs.length;
-      this.addOutput({
-        address: props.changeAddress ?? props.address,
-        value: changeAmount,
+      const changeAddress = props.changeAddress ?? props.address;
+      await this.injectChange({
+        amount: changeAmount,
+        address: changeAddress,
+        fromAddress: props.address,
+        fromPublicKey: props.publicKey,
       });
     }
 
@@ -304,8 +308,8 @@ export class TxBuilder {
     };
   }
 
-  async injectChange(props: { amount: number; address: string; publicKey?: string }) {
-    const { address, publicKey, amount } = props;
+  async injectChange(props: { amount: number; address: string; fromAddress: string; fromPublicKey?: string }) {
+    const { address, fromAddress, fromPublicKey, amount } = props;
 
     for (let i = 0; i < this.outputs.length; i++) {
       const output = this.outputs[i];
@@ -322,9 +326,10 @@ export class TxBuilder {
 
     if (amount < this.minUtxoSatoshi) {
       const { collected } = await this.injectSatoshi({
-        address,
-        publicKey,
+        address: fromAddress,
+        publicKey: fromPublicKey,
         targetAmount: amount,
+        changeAddress: address,
         injectCollected: true,
         deductFromOutputs: false,
       });
@@ -381,11 +386,11 @@ export class TxBuilder {
 
     return {
       inputsTotal: sumOfInputs,
-      inputsRemaining: sumOfInputs - sumOfOutputs,
-      inputsNeeding: sumOfOutputs > sumOfInputs ? sumOfOutputs - sumOfInputs : 0,
       outputsTotal: sumOfOutputs,
+      inputsRemaining: sumOfInputs - sumOfOutputs,
       outputsRemaining: sumOfOutputs - sumOfInputs,
-      outputsNeeding: sumOfInputs > sumOfOutputs ? sumOfInputs - sumOfOutputs : 0,
+      needReturn: sumOfInputs > sumOfOutputs ? sumOfInputs - sumOfOutputs : 0,
+      needCollect: sumOfOutputs > sumOfInputs ? sumOfOutputs - sumOfInputs : 0,
     };
   }
 

--- a/packages/btc/tests/Transaction.test.ts
+++ b/packages/btc/tests/Transaction.test.ts
@@ -296,7 +296,7 @@ describe('Transaction', () => {
       // const res = await service.sendBtcTransaction(tx.toHex());
       // console.log(`explorer: https://mempool.space/testnet/tx/${res.txid}`);
     });
-    it('Transfer fixed UTXO, sum(ins) > sum(outs), change > fee, change > fee + minUtxoSatoshi', async () => {
+    it('Transfer fixed UTXO, sum(ins) > sum(outs), change > fee + minUtxoSatoshi', async () => {
       const psbt = await sendUtxos({
         from: accounts.charlie.p2wpkh.address,
         inputs: [
@@ -334,7 +334,7 @@ describe('Transaction', () => {
       // const res = await service.sendBtcTransaction(tx.toHex());
       // console.log(`explorer: https://mempool.space/testnet/tx/${res.txid}`);
     });
-    it('Transfer fixed UTXO, sum(ins) > sum(outs), change > fee, change = fee + minUtxoSatoshi', async () => {
+    it('Transfer fixed UTXO, sum(ins) > sum(outs), change = fee + minUtxoSatoshi', async () => {
       const psbt = await sendUtxos({
         from: accounts.charlie.p2wpkh.address,
         inputs: [

--- a/packages/btc/tests/Transaction.test.ts
+++ b/packages/btc/tests/Transaction.test.ts
@@ -228,7 +228,7 @@ describe('Transaction', () => {
       // const res = await service.sendBtcTransaction(tx.toHex());
       // console.log(`explorer: https://mempool.space/testnet/tx/${res.txid}`);
     });
-    it('Transfer fixed UTXO, sum(ins) > sum(outs), need collection', async () => {
+    it('Transfer fixed UTXO, sum(ins) > sum(outs), change > fee, change < fee + minUtxoSatoshi', async () => {
       const psbt = await sendUtxos({
         from: accounts.charlie.p2wpkh.address,
         inputs: [
@@ -266,7 +266,7 @@ describe('Transaction', () => {
       // const res = await service.sendBtcTransaction(tx.toHex());
       // console.log(`explorer: https://mempool.space/testnet/tx/${res.txid}`);
     });
-    it('Transfer fixed UTXO, sum(ins) > sum(outs), but no collection', async () => {
+    it('Transfer fixed UTXO, sum(ins) > sum(outs), change > fee, change > fee + minUtxoSatoshi', async () => {
       const psbt = await sendUtxos({
         from: accounts.charlie.p2wpkh.address,
         inputs: [
@@ -304,7 +304,86 @@ describe('Transaction', () => {
       // const res = await service.sendBtcTransaction(tx.toHex());
       // console.log(`explorer: https://mempool.space/testnet/tx/${res.txid}`);
     });
-    it('Transfer fixed UTXO, sum(ins) > sum(outs), the fee is prepaid', async () => {
+    it('Transfer fixed UTXO, sum(ins) > sum(outs), change > fee, change = fee + minUtxoSatoshi', async () => {
+      const psbt = await sendUtxos({
+        from: accounts.charlie.p2wpkh.address,
+        inputs: [
+          {
+            txid: '4e1e9f8ff4bf245793c05bf2da58bff812c332a296d93c6935fbc980d906e567',
+            vout: 1,
+            value: 3000,
+            addressType: AddressType.P2WPKH,
+            address: accounts.charlie.p2wpkh.address,
+            scriptPk: accounts.charlie.p2wpkh.scriptPubkey.toString('hex'),
+          },
+        ],
+        outputs: [
+          {
+            address: accounts.charlie.p2wpkh.address,
+            value: 1856,
+            fixed: true,
+          },
+        ],
+        source,
+      });
+
+      // Sign & finalize inputs
+      psbt.signAllInputs(accounts.charlie.keyPair);
+      psbt.finalizeAllInputs();
+
+      expect(psbt.txInputs).toHaveLength(1);
+      expect(psbt.txOutputs).toHaveLength(2);
+
+      console.log('tx paid fee:', psbt.getFee());
+      expectPsbtFeeInRange(psbt);
+
+      // Broadcast transaction
+      // const tx = psbt.extractTransaction();
+      // const res = await service.sendBtcTransaction(tx.toHex());
+      // console.log(`explorer: https://mempool.space/testnet/tx/${res.txid}`);
+    });
+    it('Transfer fixed UTXO, sum(ins) > sum(outs), change < fee', async () => {
+      const { builder, feeRate } = await createSendUtxosBuilder({
+        from: accounts.charlie.p2wpkh.address,
+        inputs: [
+          {
+            txid: '4e1e9f8ff4bf245793c05bf2da58bff812c332a296d93c6935fbc980d906e567',
+            vout: 1,
+            value: 2000,
+            addressType: AddressType.P2WPKH,
+            address: accounts.charlie.p2wpkh.address,
+            scriptPk: accounts.charlie.p2wpkh.scriptPubkey.toString('hex'),
+          },
+        ],
+        outputs: [
+          {
+            address: accounts.charlie.p2wpkh.address,
+            value: 1000,
+            fixed: true,
+          },
+        ],
+        feeRate: 10,
+        source,
+      });
+
+      // Sign & finalize inputs
+      const psbt = builder.toPsbt();
+      psbt.signAllInputs(accounts.charlie.keyPair);
+      psbt.finalizeAllInputs();
+
+      expect(psbt.txInputs.length).toBeGreaterThanOrEqual(2);
+      expect(psbt.txOutputs).toHaveLength(2);
+
+      console.log('tx fee:', psbt.getFee());
+      console.log('tx fee rate:', psbt.getFeeRate());
+      expectPsbtFeeInRange(psbt, feeRate);
+
+      // Broadcast transaction
+      // const tx = psbt.extractTransaction();
+      // const res = await service.sendBtcTransaction(tx.toHex());
+      // console.log(`explorer: https://mempool.space/testnet/tx/${res.txid}`);
+    });
+    it('Transfer fixed UTXO, sum(ins) > sum(outs), change = fee', async () => {
       const psbt = await sendUtxos({
         from: accounts.charlie.p2wpkh.address,
         inputs: [
@@ -423,7 +502,7 @@ describe('Transaction', () => {
       psbt.finalizeAllInputs();
 
       expect(psbt.txInputs.length).toBeGreaterThanOrEqual(2);
-      expect(psbt.txOutputs).toHaveLength(2);
+      expect(psbt.txOutputs).toHaveLength(1);
 
       console.log('tx paid fee:', psbt.getFee());
       expectPsbtFeeInRange(psbt);
@@ -433,7 +512,7 @@ describe('Transaction', () => {
       // const res = await service.sendBtcTransaction(tx.toHex());
       // console.log(`explorer: https://mempool.space/testnet/tx/${res.txid}`);
     });
-    it('Transfer protected UTXO, sum(ins) > sum(outs), change to outs[0]', async () => {
+    it('Transfer protected UTXO, sum(ins) > sum(outs), change > fee', async () => {
       const psbt = await sendUtxos({
         from: accounts.charlie.p2wpkh.address,
         inputs: [
@@ -465,6 +544,47 @@ describe('Transaction', () => {
 
       console.log('tx paid fee:', psbt.getFee());
       expectPsbtFeeInRange(psbt);
+
+      // Broadcast transaction
+      // const tx = psbt.extractTransaction();
+      // const res = await service.sendBtcTransaction(tx.toHex());
+      // console.log(`explorer: https://mempool.space/testnet/tx/${res.txid}`);
+    });
+    it('Transfer protected UTXO, sum(ins) > sum(outs), change < fee', async () => {
+      const { builder, feeRate } = await createSendUtxosBuilder({
+        from: accounts.charlie.p2wpkh.address,
+        inputs: [
+          {
+            txid: '4e1e9f8ff4bf245793c05bf2da58bff812c332a296d93c6935fbc980d906e567',
+            vout: 1,
+            value: 2000,
+            addressType: AddressType.P2WPKH,
+            address: accounts.charlie.p2wpkh.address,
+            scriptPk: accounts.charlie.p2wpkh.scriptPubkey.toString('hex'),
+          },
+        ],
+        outputs: [
+          {
+            address: accounts.charlie.p2wpkh.address,
+            value: 1000,
+            protected: true,
+          },
+        ],
+        feeRate: 10,
+        source,
+      });
+
+      // Sign & finalize inputs
+      const psbt = builder.toPsbt();
+      psbt.signAllInputs(accounts.charlie.keyPair);
+      psbt.finalizeAllInputs();
+
+      expect(psbt.txInputs.length).toBeGreaterThanOrEqual(2);
+      expect(psbt.txOutputs).toHaveLength(1);
+
+      console.log('tx paid fee:', psbt.getFee());
+      console.log('tx paid fee rate:', psbt.getFeeRate());
+      expectPsbtFeeInRange(psbt, feeRate);
 
       // Broadcast transaction
       // const tx = psbt.extractTransaction();
@@ -515,7 +635,9 @@ describe('Transaction', () => {
       psbt.finalizeAllInputs();
 
       expect(psbt.txInputs.length).toBeGreaterThanOrEqual(3);
-      expect(psbt.txOutputs).toHaveLength(3);
+      expect(psbt.txOutputs).toHaveLength(2);
+      expect(psbt.txOutputs[0].value).toBeGreaterThan(RGBPP_UTXO_DUST_LIMIT);
+      expect(psbt.txOutputs[1].value).toBe(RGBPP_UTXO_DUST_LIMIT);
 
       console.log('tx paid fee:', psbt.getFee());
       expectPsbtFeeInRange(psbt);
@@ -615,8 +737,8 @@ describe('Transaction', () => {
 
       console.log(psbt.txOutputs);
       expect(psbt.txInputs.length).toBeGreaterThanOrEqual(2);
-      expect(psbt.txOutputs).toHaveLength(3);
-      expect(psbt.txOutputs[0].value).toBe(RGBPP_UTXO_DUST_LIMIT);
+      expect(psbt.txOutputs).toHaveLength(2);
+      expect(psbt.txOutputs[0].value).toBeGreaterThan(RGBPP_UTXO_DUST_LIMIT);
       expect(psbt.txOutputs[1].value).toBe(RGBPP_UTXO_DUST_LIMIT);
 
       console.log('tx paid fee:', psbt.getFee());

--- a/packages/btc/tests/Transaction.test.ts
+++ b/packages/btc/tests/Transaction.test.ts
@@ -190,6 +190,36 @@ describe('Transaction', () => {
       // const res = await service.sendBtcTransaction(tx.toHex());
       // console.log(`explorer: https://mempool.space/testnet/tx/${res.txid}`);
     });
+    it('Transfer fixed UTXO, sum(ins) = sum(outs) = 0', async () => {
+      const { builder, feeRate } = await createSendUtxosBuilder({
+        from: accounts.charlie.p2wpkh.address,
+        inputs: [],
+        outputs: [
+          {
+            data: Buffer.from('00'.repeat(32), 'hex'),
+            fixed: true,
+            value: 0,
+          },
+        ],
+        source,
+      });
+
+      // Sign & finalize inputs
+      const psbt = builder.toPsbt();
+      psbt.signAllInputs(accounts.charlie.keyPair);
+      psbt.finalizeAllInputs();
+
+      expect(psbt.txInputs.length).toBeGreaterThanOrEqual(1);
+      expect(psbt.txOutputs).toHaveLength(2);
+
+      console.log('tx paid fee:', psbt.getFee());
+      expectPsbtFeeInRange(psbt, feeRate);
+
+      // Broadcast transaction
+      // const tx = psbt.extractTransaction();
+      // const res = await service.sendBtcTransaction(tx.toHex());
+      // console.log(`explorer: https://mempool.space/testnet/tx/${res.txid}`);
+    });
     it('Transfer fixed UTXO, sum(ins) < sum(outs)', async () => {
       const psbt = await sendUtxos({
         from: accounts.charlie.p2wpkh.address,


### PR DESCRIPTION
## Changes
1. Fix when `sum(ins) > sum(outs) && change < fee`, the returned change is incorrect (found by @duanyytop)
2. Fix when `outs` has only an `OP_RETURN` output, and `ins` has no UTXOs specified, the collection is skipped

## Details

### When `sum(ins) > sum(outs) && change < fee`

Previously when the sum of ins is greater than the sum of outs, the process goes in the returning phase. But when calculating the return amount with `extraSatoshiInInputs - fee`, the `fee` can actually be greater then the `extraSatoshiInInputs`, in that case, the returning amount is a negative number.

To address the issue, I changed the check statement:
- from: `if (sum(ins) - sum(outs) > 0) { return change } else { colelct satoshi }`
- to: `if (sum(ins) - sum(outs) - fee > 0) { return change } else { colelct satoshi }`

The logic change should prevent errors when there is change to be returned, but the change is less than the fee. In this situation, it should always collect for more instead of returning a negative value.

### When `sum(ins) == sum(outs) == 0`

When the BTC TX initialized as the following, the `sum(ins)` and `sum(outs)` are both zero:
```yaml
ins(0):

outs(1):
- OP_RETURN output, value=0
```

When the inputs list has no length, the PSBT cannot be signed or finalized, and the fee estimation cannot be processed if the PSBT isn't finalized. The process will throw an error in that case, even though this is a possible situation for an initial transaction.

To resolve this issue, I added a protection check:
```ts
const safeToProcess = inputsTotal > 0 || previousFee > 0;
if (safeToProcess && canReturnChange) { 
  // ... return change
} else {
  const protectionAmount = !safeToProcess ? 1 : 0;
  await collectSatoshi({ amount: targetAmount + protectionAmount, ... })
}
``` 

The protection ensures that if the fee is 0 (not calculated yet) and the inputs list is empty, the collection must be processed once with the targeet of at least 1 satoshi, in order for the fee estimation to be calculated later on.

