### PR TITLE
feat(btc|service): add option to filter confirmed utxos and validate inputs

### DIFF
--- a/packages/btc/README.md
+++ b/packages/btc/README.md
@@ -36,6 +36,7 @@ const psbt = await sendBtc({
       value: 1000, // transfer satoshi amount
     },
   ],
+  onlyConfirmedUtxos: false, // optional, default to false, only confirmed utxos are allowed in the transaction
   feeRate: 1, // optional, default to 1 on the testnet, and it is a floating number on the mainnet
   source,
 });
@@ -68,6 +69,7 @@ const psbt = await sendBtc({
       value: 1000, // transfer satoshi amount
     },
   ],
+  onlyConfirmedUtxos: false, // optional, default to false, only confirmed utxos are allowed in the transaction
   feeRate: 1, // optional, default to 1 on the testnet, and it is a floating number on the mainnet
   source,
 });
@@ -106,6 +108,7 @@ const psbt = await sendBtc({
     },
   ],
   changeAddress: account.address, // optional, where to return the change
+  onlyConfirmedUtxos: false, // optional, default to false, only confirmed utxos are allowed in the transaction
   feeRate: 1, // optional, default to 1 on the testnet, and it is a floating number on the mainnet
   source,
 });
@@ -156,6 +159,7 @@ const psbt = await sendUtxos({
   from: account.address, // provide fee to the transaction
   fromPubkey: account.publicKey, // optional, required if "from" is a P2TR address
   changeAddress: account.address, // optional, an address to return change, default to "from"
+  onlyConfirmedUtxos: false, // optional, default to false, only confirmed utxos are allowed in the transaction
   feeRate: 1, // optional, default to 1 on the testnet, and it is a floating number on the mainnet
   source,
 });
@@ -216,6 +220,7 @@ const psbt = await sendRgbppUtxos({
   changeAddress: 'address_to_return_change', // optional, where should the change satoshi be returned to
   minUtxoSatoshi: config.btcUtxoDustLimit, // optional, default to 1000 on the testnet, 1,0000 on the mainnet
   rgbppMinUtxoSatoshi: config.rgbppUtxoDustLimit, // optional, default to 546 on both testnet/mainnet
+  onlyConfirmedUtxos: false, // optional, default to false, only confirmed utxos are allowed in the transaction
   feeRate: 1, // optional, default to 1 on the testnet, and it is a floating number on the mainnet
 });
 ```
@@ -243,10 +248,11 @@ interface SendBtcProps {
   from: string;
   tos: InitOutput[];
   source: DataSource;
+  feeRate?: number;
   fromPubkey?: string;
   changeAddress?: string;
   minUtxoSatoshi?: number;
-  feeRate?: number;
+  onlyConfirmedUtxos?: boolean;
 }
 ```
 
@@ -270,10 +276,11 @@ interface SendUtxosProps {
   outputs: InitOutput[];
   source: DataSource;
   from: string;
+  feeRate?: number;
   fromPubkey?: string;
   changeAddress?: string;
   minUtxoSatoshi?: number;
-  feeRate?: number;
+  onlyConfirmedUtxos?: boolean;
 }
 ```
 
@@ -303,12 +310,13 @@ interface SendRgbppUtxosProps {
   rgbppTimeLockCodeHash: Hash;
   rgbppMinUtxoSatoshi?: number;
 
-  from: string;
   source: DataSource;
+  from: string;
+  feeRate?: number;
   fromPubkey?: string;
   changeAddress?: string;
   minUtxoSatoshi?: number;
-  feeRate?: number;
+  onlyConfirmedUtxos?: boolean;
 }
 ```
 
@@ -354,13 +362,14 @@ interface BaseOutput {
 ```typescript
 interface DataSource {
   constructor(service: BtcAssetsApi, networkType: NetworkType): void;
-  getUtxo(hex: string, number: number): Promise<Utxo | undefined>;
-  getOutput(hex: string, number: number): Promise<Output | Utxo | undefined>;
+  getUtxo(hex: string, number: number, requireConfirmed?: boolean): Promise<Utxo | undefined>;
+  getOutput(hex: string, number: number, requireConfirmed?: boolean): Promise<Output | Utxo | undefined>;
   getUtxos(address: string, params?: BtcAssetsApiUtxoParams): Promise<Utxo[]>;
   collectSatoshi(props: {
     address: string;
     targetAmount: number;
     minUtxoSatoshi?: number;
+    onlyConfirmedUtxos?: boolean;
     excludeUtxos?: {
       txid: string;
       vout: number;

--- a/packages/btc/src/api/sendBtc.ts
+++ b/packages/btc/src/api/sendBtc.ts
@@ -6,10 +6,11 @@ export interface SendBtcProps {
   from: string;
   tos: InitOutput[];
   source: DataSource;
-  minUtxoSatoshi?: number;
-  changeAddress?: string;
-  fromPubkey?: string;
   feeRate?: number;
+  fromPubkey?: string;
+  changeAddress?: string;
+  minUtxoSatoshi?: number;
+  onlyConfirmedUtxos?: boolean;
 }
 
 export async function createSendBtcBuilder(props: SendBtcProps): Promise<{
@@ -19,8 +20,9 @@ export async function createSendBtcBuilder(props: SendBtcProps): Promise<{
 }> {
   const tx = new TxBuilder({
     source: props.source,
-    minUtxoSatoshi: props.minUtxoSatoshi,
     feeRate: props.feeRate,
+    minUtxoSatoshi: props.minUtxoSatoshi,
+    onlyConfirmedUtxos: props.onlyConfirmedUtxos,
   });
 
   props.tos.forEach((to) => {

--- a/packages/btc/src/api/sendRgbppUtxos.ts
+++ b/packages/btc/src/api/sendRgbppUtxos.ts
@@ -18,12 +18,13 @@ export interface SendRgbppUtxosProps {
   ckbCollector: Collector;
   rgbppMinUtxoSatoshi?: number;
 
-  from: string;
   source: DataSource;
+  from: string;
+  feeRate?: number;
   fromPubkey?: string;
   changeAddress?: string;
   minUtxoSatoshi?: number;
-  feeRate?: number;
+  onlyConfirmedUtxos?: boolean;
 }
 
 export async function sendRgbppUtxosBuilder(props: SendRgbppUtxosProps): Promise<{
@@ -64,7 +65,7 @@ export async function sendRgbppUtxosBuilder(props: SendRgbppUtxosProps): Promise
     // 4. utxo is not duplicated in the inputs
     if (isRgbppLock) {
       const args = unpackRgbppLockArgs(ckbLiveCell.output.lock.args);
-      const utxo = await props.source.getUtxo(args.btcTxid, args.outIndex);
+      const utxo = await props.source.getUtxo(args.btcTxid, args.outIndex, props.onlyConfirmedUtxos);
       if (!utxo) {
         throw TxBuildError.withComment(ErrorCodes.CANNOT_FIND_UTXO, `hash: ${args.btcTxid}, index: ${args.outIndex}`);
       }
@@ -166,10 +167,11 @@ export async function sendRgbppUtxosBuilder(props: SendRgbppUtxosProps): Promise
     outputs: mergedBtcOutputs,
     from: props.from,
     source: props.source,
+    feeRate: props.feeRate,
     fromPubkey: props.fromPubkey,
     changeAddress: props.changeAddress,
     minUtxoSatoshi: props.minUtxoSatoshi,
-    feeRate: props.feeRate,
+    onlyConfirmedUtxos: props.onlyConfirmedUtxos,
   });
 }
 

--- a/packages/btc/src/api/sendUtxos.ts
+++ b/packages/btc/src/api/sendUtxos.ts
@@ -8,10 +8,11 @@ export interface SendUtxosProps {
   outputs: InitOutput[];
   source: DataSource;
   from: string;
+  feeRate?: number;
   fromPubkey?: string;
   changeAddress?: string;
   minUtxoSatoshi?: number;
-  feeRate?: number;
+  onlyConfirmedUtxos?: boolean;
 }
 
 export async function createSendUtxosBuilder(props: SendUtxosProps): Promise<{
@@ -23,6 +24,7 @@ export async function createSendUtxosBuilder(props: SendUtxosProps): Promise<{
     source: props.source,
     feeRate: props.feeRate,
     minUtxoSatoshi: props.minUtxoSatoshi,
+    onlyConfirmedUtxos: props.onlyConfirmedUtxos,
   });
 
   tx.addInputs(props.inputs);

--- a/packages/btc/src/api/sendUtxos.ts
+++ b/packages/btc/src/api/sendUtxos.ts
@@ -30,6 +30,10 @@ export async function createSendUtxosBuilder(props: SendUtxosProps): Promise<{
   tx.addInputs(props.inputs);
   tx.addOutputs(props.outputs);
 
+  if (props.onlyConfirmedUtxos) {
+    await tx.validateInputs();
+  }
+
   const paid = await tx.payFee({
     address: props.from,
     publicKey: props.fromPubkey,

--- a/packages/btc/src/error.ts
+++ b/packages/btc/src/error.ts
@@ -3,6 +3,7 @@ export enum ErrorCodes {
 
   MISSING_PUBKEY = 20,
   CANNOT_FIND_UTXO,
+  UNCONFIRMED_UTXO,
   INSUFFICIENT_UTXO,
   REFERENCED_UNPROVABLE_UTXO,
   UNSPENDABLE_OUTPUT,
@@ -29,6 +30,7 @@ export const ErrorMessages = {
 
   [ErrorCodes.MISSING_PUBKEY]: 'Missing a pubkey that pairs with the address',
   [ErrorCodes.CANNOT_FIND_UTXO]: 'Cannot find the UTXO, it may not exist or is not live',
+  [ErrorCodes.UNCONFIRMED_UTXO]: 'Unconfirmed UTXO',
   [ErrorCodes.INSUFFICIENT_UTXO]: 'Insufficient UTXO to construct the transaction',
   [ErrorCodes.REFERENCED_UNPROVABLE_UTXO]: 'Cannot reference a UTXO that does not belongs to "from"',
   [ErrorCodes.DUPLICATED_UTXO]: 'Cannot reference the same UTXO twice',

--- a/packages/btc/src/query/source.ts
+++ b/packages/btc/src/query/source.ts
@@ -20,9 +20,10 @@ export class DataSource {
   }
 
   // Query a UTXO from the service.
-  // Will throw error if the target output is unspendable
-  async getUtxo(hash: string, index: number): Promise<Utxo | undefined> {
-    const output = await this.getOutput(hash, index);
+  // Will throw error if the target output is unspendable.
+  // When set "confirmed = true", will throw error if the output is unconfirmed.
+  async getUtxo(hash: string, index: number, requireConfirmed?: boolean): Promise<Utxo | undefined> {
+    const output = await this.getOutput(hash, index, requireConfirmed);
     if (output && !('address' in output)) {
       throw TxBuildError.withComment(ErrorCodes.UNSPENDABLE_OUTPUT, `hash: ${hash}, index: ${index}`);
     }
@@ -32,11 +33,15 @@ export class DataSource {
 
   // Query an output from the service.
   // Both unspent or unspendable output can be queried from the API.
-  async getOutput(hash: string, index: number): Promise<Output | Utxo | undefined> {
+  // When set "confirmed = true", will throw error if the output is unconfirmed.
+  async getOutput(hash: string, index: number, requireConfirmed?: boolean): Promise<Output | Utxo | undefined> {
     const txId = remove0x(hash);
     const tx = await this.service.getBtcTransaction(txId);
     if (!tx) {
       return void 0;
+    }
+    if (requireConfirmed && !tx.status.confirmed) {
+      throw TxBuildError.withComment(ErrorCodes.UNCONFIRMED_UTXO, `hash: ${hash}, index: ${index}`);
     }
     const vout = tx.vout[index];
     if (!vout) {
@@ -61,6 +66,11 @@ export class DataSource {
       address: vout.scriptpubkey_address,
       addressType: getAddressType(vout.scriptpubkey_address),
     } as Utxo;
+  }
+
+  async isTransactionConfirmed(hash: string): Promise<boolean> {
+    const tx = await this.service.getBtcTransaction(remove0x(hash));
+    return tx.status.confirmed;
   }
 
   async getUtxos(address: string, params?: BtcApiUtxoParams): Promise<Utxo[]> {

--- a/packages/btc/src/query/source.ts
+++ b/packages/btc/src/query/source.ts
@@ -92,6 +92,7 @@ export class DataSource {
     address: string;
     targetAmount: number;
     minUtxoSatoshi?: number;
+    onlyConfirmedUtxos?: boolean;
     excludeUtxos?: {
       txid: string;
       vout: number;
@@ -101,8 +102,9 @@ export class DataSource {
     satoshi: number;
     exceedSatoshi: number;
   }> {
-    const { address, targetAmount, minUtxoSatoshi, excludeUtxos = [] } = props;
+    const { address, targetAmount, minUtxoSatoshi, onlyConfirmedUtxos, excludeUtxos = [] } = props;
     const utxos = await this.getUtxos(address, {
+      only_confirmed: onlyConfirmedUtxos,
       min_satoshi: minUtxoSatoshi,
     });
 
@@ -111,9 +113,6 @@ export class DataSource {
     for (const utxo of utxos) {
       if (collectedAmount >= targetAmount) {
         break;
-      }
-      if (minUtxoSatoshi !== void 0 && utxo.value < minUtxoSatoshi) {
-        continue;
       }
       if (excludeUtxos.length > 0) {
         const excluded = excludeUtxos.find((exclude) => {

--- a/packages/btc/src/transaction/build.ts
+++ b/packages/btc/src/transaction/build.ts
@@ -45,13 +45,15 @@ export class TxBuilder {
   source: DataSource;
   config: RgbppBtcConfig;
   networkType: NetworkType;
+  onlyConfirmedUtxos: boolean;
   minUtxoSatoshi: number;
   feeRate?: number;
 
-  constructor(props: { source: DataSource; minUtxoSatoshi?: number; feeRate?: number }) {
+  constructor(props: { source: DataSource; onlyConfirmedUtxos?: boolean; minUtxoSatoshi?: number; feeRate?: number }) {
     this.source = props.source;
     this.networkType = this.source.networkType;
     this.config = networkTypeToConfig(this.networkType);
+    this.onlyConfirmedUtxos = props.onlyConfirmedUtxos ?? false;
     this.minUtxoSatoshi = props.minUtxoSatoshi ?? this.config.btcUtxoDustLimit;
     this.feeRate = props.feeRate;
   }
@@ -203,6 +205,7 @@ export class TxBuilder {
         address: props.address,
         targetAmount: _targetAmount,
         minUtxoSatoshi: this.minUtxoSatoshi,
+        onlyConfirmedUtxos: this.onlyConfirmedUtxos,
         excludeUtxos: this.inputs.map((row) => row.utxo),
       });
       utxos.forEach((utxo) => {

--- a/packages/btc/src/transaction/build.ts
+++ b/packages/btc/src/transaction/build.ts
@@ -77,6 +77,18 @@ export class TxBuilder {
     });
   }
 
+  async validateInputs() {
+    for (const input of this.inputs) {
+      const transactionConfirmed = await this.source.isTransactionConfirmed(input.data.hash);
+      if (!transactionConfirmed) {
+        throw TxBuildError.withComment(
+          ErrorCodes.UNCONFIRMED_UTXO,
+          `hash: ${input.data.hash}, index: ${input.data.index}`,
+        );
+      }
+    }
+  }
+
   addOutput(output: InitOutput) {
     let result: TxOutput | undefined;
 

--- a/packages/btc/tests/Transaction.test.ts
+++ b/packages/btc/tests/Transaction.test.ts
@@ -627,6 +627,32 @@ describe('Transaction', () => {
       // const res = await service.sendBtcTransaction(tx.toHex());
       // console.log(`explorer: https://mempool.space/testnet/tx/${res.txid}`);
     });
+
+    it('Try transfer non-existence UTXO', async () => {
+      await expect(() =>
+        sendUtxos({
+          from: accounts.charlie.p2wpkh.address,
+          inputs: [
+            {
+              txid: '00'.repeat(32),
+              vout: 0,
+              value: 1000,
+              addressType: AddressType.P2WPKH,
+              address: accounts.charlie.p2wpkh.address,
+              scriptPk: accounts.charlie.p2wpkh.scriptPubkey.toString('hex'),
+            },
+          ],
+          outputs: [
+            {
+              address: accounts.charlie.p2wpkh.address,
+              value: 1000,
+            },
+          ],
+          onlyConfirmedUtxos: true,
+          source,
+        }),
+      ).rejects.toThrow();
+    });
   });
 
   describe.todo('sendRgbppUtxos()', () => {

--- a/packages/service/src/types/btc.ts
+++ b/packages/service/src/types/btc.ts
@@ -60,6 +60,7 @@ export interface BtcApiBalance {
 }
 
 export interface BtcApiUtxoParams {
+  only_confirmed?: boolean;
   min_satoshi?: number;
 }
 export interface BtcApiUtxo {

--- a/packages/service/tests/Service.test.ts
+++ b/packages/service/tests/Service.test.ts
@@ -110,6 +110,15 @@ describe(
 
         expect(filteredUtxos.length).toBe(0);
       });
+      it('Get UTXO[] with only_collected filter', async () => {
+        const confirmedUtxos = await service.getBtcUtxos(btcAddress, {
+          only_confirmed: true,
+        });
+        expect(Array.isArray(confirmedUtxos)).toBe(true);
+        for (const utxo of confirmedUtxos) {
+          expect(utxo.status.confirmed).toBe(true);
+        }
+      }, 0);
       it('Get transactions', async () => {
         const res = await service.getBtcTransactions(btcAddress);
         expect(Array.isArray(res)).toBe(true);

--- a/packages/service/tests/Service.test.ts
+++ b/packages/service/tests/Service.test.ts
@@ -70,7 +70,7 @@ describe(
         expect(res.pending_satoshi).toBeTypeOf('number');
         expect(res.dust_satoshi).toBeTypeOf('number');
         expect(res.utxo_count).toBeTypeOf('number');
-      }, 0);
+      });
       it('Get balance with min_satoshi filter', async () => {
         const originalBalance = await service.getBtcBalance(btcAddress);
         const filteredBalance = await service.getBtcBalance(btcAddress, {
@@ -79,7 +79,7 @@ describe(
 
         expect(filteredBalance.satoshi).toEqual(0);
         expect(filteredBalance.dust_satoshi).toEqual(originalBalance.satoshi + originalBalance.dust_satoshi);
-      }, 0);
+      });
       it('Get UTXO[]', async () => {
         const res = await service.getBtcUtxos(btcAddress);
         expect(Array.isArray(res)).toBe(true);
@@ -99,7 +99,7 @@ describe(
             expect(utxo.status.block_time).toBeTypeOf('number');
           }
         });
-      }, 0);
+      });
       it('Get UTXO[] with min_satoshi filter', async () => {
         const originalUtxos = await service.getBtcUtxos(btcAddress);
 
@@ -118,7 +118,7 @@ describe(
         for (const utxo of confirmedUtxos) {
           expect(utxo.status.confirmed).toBe(true);
         }
-      }, 0);
+      });
       it('Get transactions', async () => {
         const res = await service.getBtcTransactions(btcAddress);
         expect(Array.isArray(res)).toBe(true);
@@ -132,7 +132,7 @@ describe(
             expect(transaction.status.block_time).toBeTypeOf('number');
           }
         });
-      }, 0);
+      });
       it('Get transaction', async () => {
         const res = await service.getBtcTransaction('102d5a002e72f0781944eef636117377da6d3601061e47e03025e7cd29a91579');
         expect(res.txid).toBe('102d5a002e72f0781944eef636117377da6d3601061e47e03025e7cd29a91579');

--- a/packages/service/vitest.config.mts
+++ b/packages/service/vitest.config.mts
@@ -3,6 +3,7 @@ import { defineConfig } from 'vitest/config';
 export default defineConfig({
   test: {
     watch: false,
+    testTimeout: 10000,
     exclude: ['lib', 'node_modules'],
   },
 });


### PR DESCRIPTION
## Changes
1. Support the "only_confirmed" param in the BtcAssetsApi.getUtxos() API (refer to [btc-assets-api#40](https://github.com/ckb-cell/btc-assets-api/pull/40) and [btc-assets-api#41](https://github.com/ckb-cell/btc-assets-api/pull/41))
2. Support the "onlyConfirmedUtxos" option in the BTC APIs (`sendBtc`, `sendUtxos`, `sendRgbppUtxos`, and the BTC Builder APIs), and also validate inputs to check if each UTXO is confirmed

## Details

### Option `onlyConfirmedUtxos` in BTC APIs

This is a `boolean` option that tells the API to look for confirmed UTXOs when collecting inputs for construction and fee. If not enough confirmed UTXOs to construct the transaction, the API will throw an INSUFFICIENT_UTXO error.

```ts
sendBtc({
  // ...
  onlyConfirmedUtxos: true, // optional, default to false
});
```

## Discussion

- The name of  the "onlyConfirmedUtxos" option is inherited from the naming of btc-assets-api (refer to [btc-assets-api#40](https://github.com/ckb-cell/btc-assets-api/pull/40) and [btc-assets-api#41](https://github.com/ckb-cell/btc-assets-api/pull/41)), which is different than the [feature requested](https://github.com/ckb-cell/rgbpp-sdk/issues/87).
- Do you prefer "transactionConfirmed" from the feature request as a better name for the option? Do you think "onlyConfirmedUtxos" is fine for now? Or do you have better naming suggestions? (validateInputs? filterConfirmedUtxos? requireConfirmedInputs? requireConfirmedUtxos? requireConfirmedInputs?)

## Related issues
- Resolves #87 