### PR TITLE
feat(rgbpp-sdk/service): sync apis from btc-assets-api #13 and #21

### DIFF
--- a/packages/service/README.md
+++ b/packages/service/README.md
@@ -182,6 +182,7 @@ interface BtcApiBalance {
 }
 
 interface BtcApiUtxoParams {
+  only_confirmed?: boolean;
   min_satoshi?: number;
 }
 
@@ -244,16 +245,23 @@ interface BtcApiTransaction {
 
 ```typescript
 interface RgbppApis {
-  getRgbppTransactionHash(btcTxId: string): Promise<RgbppApiCkbTransactionHash | undefined>;
-  getRgbppTransactionState(btcTxId: string): Promise<RgbppApiTransactionState | undefined>;
+  getRgbppPaymasterInfo(): Promise<RgbppApiPaymasterInfo>;
+  getRgbppTransactionHash(btcTxId: string): Promise<RgbppApiCkbTransactionHash>;
+  getRgbppTransactionState(btcTxId: string): Promise<RgbppApiTransactionState>;
   getRgbppAssetsByBtcTxId(btcTxId: string): Promise<Cell[]>;
   getRgbppAssetsByBtcUtxo(btcTxId: string, vout: number): Promise<Cell[]>;
   getRgbppAssetsByBtcAddress(btcAddress: string, params?: RgbppApiAssetsByAddressParams): Promise<Cell[]>;
-  getRgbppSpvProof(btcTxId: string, confirmations: number): Promise<RgbppApiSpvProof | undefined>;
+  getRgbppSpvProof(btcTxId: string, confirmations: number): Promise<RgbppApiSpvProof>;
   sendRgbppCkbTransaction(payload: RgbppApiSendCkbTransactionPayload): Promise<RgbppApiTransactionState>;
+  retryRgbppCkbTransaction(payload: RgbppApiRetryCkbTransactionPayload): Promise<RgbppApiTransactionRetry>;
 }
 
 type RgbppTransactionState = 'completed' | 'failed' | 'delayed' | 'active' | 'waiting';
+
+interface RgbppApiPaymasterInfo {
+  btc_address: string;
+  fee: number;
+}
 
 interface RgbppApiCkbTransactionHash {
   txhash: string;
@@ -283,5 +291,14 @@ interface RgbppApiSendCkbTransactionPayload {
     sumInputsCapacity: string;
     commitment: string;
   };
+}
+
+interface RgbppApiRetryCkbTransactionPayload {
+  btc_txid: string;
+}
+
+interface RgbppApiTransactionRetry {
+  success: boolean;
+  state: RgbppTransactionState;
 }
 ```

--- a/packages/service/src/service/service.ts
+++ b/packages/service/src/service/service.ts
@@ -22,6 +22,8 @@ import {
   RgbppApiSendCkbTransactionPayload,
   RgbppApiCkbTransactionHash,
   RgbppApiAssetsByAddressParams,
+  RgbppApiRetryCkbTransactionPayload,
+  RgbppApiTransactionRetry,
 } from '../types';
 
 export class BtcAssetsApi extends BtcAssetsApiBase implements BtcApis, RgbppApis {
@@ -124,8 +126,14 @@ export class BtcAssetsApi extends BtcAssetsApiBase implements BtcApis, RgbppApis
     });
   }
 
-  sendRgbppCkbTransaction(payload: RgbppApiSendCkbTransactionPayload): Promise<RgbppApiTransactionState> {
+  sendRgbppCkbTransaction(payload: RgbppApiSendCkbTransactionPayload) {
     return this.post<RgbppApiTransactionState>('/rgbpp/v1/transaction/ckb-tx', {
+      body: JSON.stringify(payload),
+    });
+  }
+
+  retryRgbppCkbTransaction(payload: RgbppApiRetryCkbTransactionPayload) {
+    return this.post<RgbppApiTransactionRetry>('/rgbpp/v1/transaction/retry', {
       body: JSON.stringify(payload),
     });
   }

--- a/packages/service/src/service/service.ts
+++ b/packages/service/src/service/service.ts
@@ -17,6 +17,7 @@ import {
 import {
   RgbppApis,
   RgbppApiSpvProof,
+  RgbppApiPaymasterInfo,
   RgbppApiTransactionState,
   RgbppApiSendCkbTransactionPayload,
   RgbppApiCkbTransactionHash,
@@ -87,6 +88,10 @@ export class BtcAssetsApi extends BtcAssetsApiBase implements BtcApis, RgbppApis
   /**
    * RGBPP APIs, under the /rgbpp/v1 prefix.
    */
+
+  getRgbppPaymasterInfo() {
+    return this.request<RgbppApiPaymasterInfo>('/rgbpp/v1/paymaster/info');
+  }
 
   getRgbppTransactionHash(btcTxId: string) {
     return this.request<RgbppApiCkbTransactionHash>(`/rgbpp/v1/transaction/${btcTxId}`);

--- a/packages/service/src/types/rgbpp.ts
+++ b/packages/service/src/types/rgbpp.ts
@@ -1,6 +1,7 @@
 import { Cell } from '@ckb-lumos/lumos';
 
 export interface RgbppApis {
+  getRgbppPaymasterInfo(): Promise<RgbppApiPaymasterInfo>;
   getRgbppTransactionHash(btcTxId: string): Promise<RgbppApiCkbTransactionHash>;
   getRgbppTransactionState(btcTxId: string): Promise<RgbppApiTransactionState>;
   getRgbppAssetsByBtcTxId(btcTxId: string): Promise<Cell[]>;
@@ -11,6 +12,11 @@ export interface RgbppApis {
 }
 
 export type RgbppTransactionState = 'completed' | 'failed' | 'delayed' | 'active' | 'waiting';
+
+export interface RgbppApiPaymasterInfo {
+  btc_address: string;
+  fee: number;
+}
 
 export interface RgbppApiCkbTransactionHash {
   txhash: string;

--- a/packages/service/src/types/rgbpp.ts
+++ b/packages/service/src/types/rgbpp.ts
@@ -9,6 +9,7 @@ export interface RgbppApis {
   getRgbppAssetsByBtcAddress(btcAddress: string, params?: RgbppApiAssetsByAddressParams): Promise<Cell[]>;
   getRgbppSpvProof(btcTxId: string, confirmations: number): Promise<RgbppApiSpvProof>;
   sendRgbppCkbTransaction(payload: RgbppApiSendCkbTransactionPayload): Promise<RgbppApiTransactionState>;
+  retryRgbppCkbTransaction(payload: RgbppApiRetryCkbTransactionPayload): Promise<RgbppApiTransactionRetry>;
 }
 
 export type RgbppTransactionState = 'completed' | 'failed' | 'delayed' | 'active' | 'waiting';
@@ -47,4 +48,13 @@ export interface RgbppApiSendCkbTransactionPayload {
     sumInputsCapacity: string;
     commitment: string;
   };
+}
+
+export interface RgbppApiRetryCkbTransactionPayload {
+  btc_txid: string;
+}
+
+export interface RgbppApiTransactionRetry {
+  success: boolean;
+  state: RgbppTransactionState;
 }

--- a/packages/service/tests/Service.test.ts
+++ b/packages/service/tests/Service.test.ts
@@ -1,7 +1,7 @@
 import { Cell } from '@ckb-lumos/lumos';
 import { blockchain, bytes } from '@ckb-lumos/lumos/codec';
 import { describe, expect, it } from 'vitest';
-import { BtcAssetsApi, ErrorCodes, ErrorMessages } from '../src';
+import { BtcAssetsApiError, BtcAssetsApi, ErrorCodes, ErrorMessages } from '../src';
 
 describe(
   'BtcServiceApi',
@@ -153,6 +153,17 @@ describe(
 
       const emptyBtcTxId = '0000000000000000000000000000000000000000000000000000000000000001';
 
+      it('Get paymaster info', async () => {
+        try {
+          const res = await service.getRgbppPaymasterInfo();
+          expect(res).toBeDefined();
+          expect(res.btc_address).toBeTypeOf('string');
+          expect(res.fee).toBeTypeOf('number');
+        } catch (e) {
+          expect(e).toBeInstanceOf(BtcAssetsApiError);
+          expect(e.code).toBe(ErrorCodes.ASSETS_API_RESOURCE_NOT_FOUND);
+        }
+      });
       it('Get the hash of RGBPP CKB_TX', async () => {
         const res = await service.getRgbppTransactionHash(rgbppBtcTxId);
         expect(res).toBeDefined();


### PR DESCRIPTION
## Changes
- Sync the `/rgbpp/v1/paymaster/info` api from [btc-assets-api/pull/13](https://github.com/ckb-cell/btc-assets-api/pull/13)
- Sync the `/rgbpp/v1/transaction/retry` api from [btc-assets-api/pull/21](https://github.com/ckb-cell/btc-assets-api/pull/21)