### PR TITLE
reafactor(rgbpp-sdk/btc)!: support `RecommendedFeeRate` as the feeRate

### DIFF
--- a/examples/rgbpp/local/transfer-btc.ts
+++ b/examples/rgbpp/local/transfer-btc.ts
@@ -31,7 +31,6 @@ const transferBtc = async () => {
         value: 100000, // transfer satoshi amount
       },
     ],
-    feeRate: 1, // optional, default to 1 sat/vbyte
     source,
   });
 

--- a/packages/btc/README.md
+++ b/packages/btc/README.md
@@ -22,7 +22,7 @@ $ pnpm add @rgbpp-sdk/btc
 ### Transfer BTC from a `P2WPKH` address
 
 ```typescript
-import { sendBtc, DataSource, NetworkType } from '@rgbpp-sdk/btc';
+import { sendBtc, DataSource, NetworkType, RecommendedFeeRate } from '@rgbpp-sdk/btc';
 import { BtcAssetsApi } from '@rgbpp-sdk/service';
 
 const service = BtcAssetsApi.fromToken('btc_assets_api_url', 'your_token');
@@ -37,7 +37,7 @@ const psbt = await sendBtc({
     },
   ],
   onlyConfirmedUtxos: false, // optional, default to false, only confirmed utxos are allowed in the transaction
-  feeRate: 1, // optional, default to 1 on the testnet, and it is a floating number on the mainnet
+  feeRate: RecommendedFeeRate.FASTEST, // optional, will fetch from mempool.space API if not provided
   source,
 });
 
@@ -54,7 +54,7 @@ console.log('txid:', res.txid);
 ### Transfer BTC from a `P2TR` address
 
 ```typescript
-import { sendBtc, DataSource, NetworkType } from '@rgbpp-sdk/btc';
+import { sendBtc, DataSource, NetworkType, RecommendedFeeRate } from '@rgbpp-sdk/btc';
 import { BtcAssetsApi } from '@rgbpp-sdk/service';
 
 const service = BtcAssetsApi.fromToken('btc_assets_api_url', 'your_token');
@@ -70,7 +70,7 @@ const psbt = await sendBtc({
     },
   ],
   onlyConfirmedUtxos: false, // optional, default to false, only confirmed utxos are allowed in the transaction
-  feeRate: 1, // optional, default to 1 on the testnet, and it is a floating number on the mainnet
+  feeRate: RecommendedFeeRate.FASTEST, // optional, will fetch from mempool.space API if not provided
   source,
 });
 
@@ -92,7 +92,7 @@ console.log('txid:', res.txid);
 ### Create an `OP_RETURN` output
 
 ```typescript
-import { sendBtc, DataSource, NetworkType } from '@rgbpp-sdk/btc';
+import { sendBtc, DataSource, NetworkType, RecommendedFeeRate } from '@rgbpp-sdk/btc';
 import { BtcAssetsApi } from '@rgbpp-sdk/service';
 
 const service = BtcAssetsApi.fromToken('btc_assets_api_url', 'your_token');
@@ -109,7 +109,7 @@ const psbt = await sendBtc({
   ],
   changeAddress: account.address, // optional, where to return the change
   onlyConfirmedUtxos: false, // optional, default to false, only confirmed utxos are allowed in the transaction
-  feeRate: 1, // optional, default to 1 on the testnet, and it is a floating number on the mainnet
+  feeRate: RecommendedFeeRate.FASTEST, // optional, will fetch from mempool.space API if not provided
   source,
 });
 
@@ -126,7 +126,7 @@ console.log('txid:', res.txid);
 ### Transfer with predefined inputs/outputs
 
 ```typescript
-import { sendUtxos, DataSource, NetworkType } from '@rgbpp-sdk/btc';
+import { sendUtxos, DataSource, NetworkType, RecommendedFeeRate } from '@rgbpp-sdk/btc';
 import { BtcAssetsApi } from '@rgbpp-sdk/service';
 
 const service = BtcAssetsApi.fromToken('btc_assets_api_url', 'your_token');
@@ -160,7 +160,7 @@ const psbt = await sendUtxos({
   fromPubkey: account.publicKey, // optional, required if "from" is a P2TR address
   changeAddress: account.address, // optional, an address to return change, default to "from"
   onlyConfirmedUtxos: false, // optional, default to false, only confirmed utxos are allowed in the transaction
-  feeRate: 1, // optional, default to 1 on the testnet, and it is a floating number on the mainnet
+  feeRate: RecommendedFeeRate.FASTEST, // optional, will fetch from mempool.space API if not provided
   source,
 });
 
@@ -177,7 +177,14 @@ console.log('txid:', res.txid);
 ### Construct a isomorphic RGBPP transaction
 
 ```typescript
-import { sendRgbppUtxos, networkTypeToConfig, DataSource, Collector, NetworkType } from '@rgbpp-sdk/btc';
+import {
+  sendRgbppUtxos,
+  networkTypeToConfig,
+  DataSource,
+  Collector,
+  NetworkType,
+  RecommendedFeeRate,
+} from '@rgbpp-sdk/btc';
 import { BtcAssetsApi } from '@rgbpp-sdk/service';
 
 const networkType = NetworkType.TESTNET;
@@ -221,7 +228,7 @@ const psbt = await sendRgbppUtxos({
   minUtxoSatoshi: config.btcUtxoDustLimit, // optional, default to 1000 on the testnet, 1,0000 on the mainnet
   rgbppMinUtxoSatoshi: config.rgbppUtxoDustLimit, // optional, default to 546 on both testnet/mainnet
   onlyConfirmedUtxos: false, // optional, default to false, only confirmed utxos are allowed in the transaction
-  feeRate: 1, // optional, default to 1 on the testnet, and it is a floating number on the mainnet
+  feeRate: RecommendedFeeRate.FASTEST, // optional, will fetch from mempool.space API if not provided
 });
 ```
 
@@ -248,7 +255,7 @@ interface SendBtcProps {
   from: string;
   tos: InitOutput[];
   source: DataSource;
-  feeRate?: number;
+  feeRate?: FeeRateOption;
   fromPubkey?: string;
   changeAddress?: string;
   minUtxoSatoshi?: number;
@@ -276,7 +283,7 @@ interface SendUtxosProps {
   outputs: InitOutput[];
   source: DataSource;
   from: string;
-  feeRate?: number;
+  feeRate?: FeeRateOption;
   fromPubkey?: string;
   changeAddress?: string;
   minUtxoSatoshi?: number;
@@ -312,7 +319,7 @@ interface SendRgbppUtxosProps {
 
   source: DataSource;
   from: string;
-  feeRate?: number;
+  feeRate?: FeeRateOption;
   fromPubkey?: string;
   changeAddress?: string;
   minUtxoSatoshi?: number;
@@ -357,6 +364,12 @@ interface BaseOutput {
 }
 ```
 
+#### FeeRateOption
+
+```typescript
+type FeeRateOption = number | RecommendedFeeRate;
+```
+
 #### DataSource
 
 ```typescript
@@ -380,7 +393,7 @@ interface DataSource {
     exceedSatoshi: number;
   }>;
   getRecommendedFeeRates(): Promise<FeesRecommended>;
-  getAverageFeeRate(): Promise<number>;
+  getRecommendedFeeRate(feeRate?: RecommendedFeeRate): Promise<number>;
 }
 ```
 
@@ -392,6 +405,17 @@ interface FeesRecommended {
   halfHourFee: number;
   hourFee: number;
   minimumFee: number;
+}
+```
+
+#### RecommendedFeeRate
+
+```typescript
+enum RecommendedFeeRate {
+  FASTEST = 'fastestFee',
+  AVERAGE = 'halfHourFee',
+  SLOW = 'hourFee',
+  MINIMUM = 'minimumFee',
 }
 ```
 

--- a/packages/btc/src/api/sendBtc.ts
+++ b/packages/btc/src/api/sendBtc.ts
@@ -1,12 +1,12 @@
 import { bitcoin } from '../bitcoin';
 import { DataSource } from '../query/source';
-import { InitOutput, TxBuilder } from '../transaction/build';
+import { FeeRateOption, InitOutput, TxBuilder } from '../transaction/build';
 
 export interface SendBtcProps {
   from: string;
   tos: InitOutput[];
   source: DataSource;
-  feeRate?: number;
+  feeRate?: FeeRateOption;
   fromPubkey?: string;
   changeAddress?: string;
   minUtxoSatoshi?: number;

--- a/packages/btc/src/api/sendRgbppUtxos.ts
+++ b/packages/btc/src/api/sendRgbppUtxos.ts
@@ -4,7 +4,7 @@ import { Utxo } from '../transaction/utxo';
 import { DataSource } from '../query/source';
 import { NetworkType } from '../preset/types';
 import { ErrorCodes, TxBuildError } from '../error';
-import { InitOutput, TxAddressOutput, TxBuilder } from '../transaction/build';
+import { FeeRateOption, InitOutput, TxAddressOutput, TxBuilder } from '../transaction/build';
 import { networkTypeToConfig } from '../preset/config';
 import { unpackRgbppLockArgs } from '../ckb/molecule';
 import { createSendUtxosBuilder } from './sendUtxos';
@@ -20,7 +20,7 @@ export interface SendRgbppUtxosProps {
 
   source: DataSource;
   from: string;
-  feeRate?: number;
+  feeRate?: FeeRateOption;
   fromPubkey?: string;
   changeAddress?: string;
   minUtxoSatoshi?: number;

--- a/packages/btc/src/api/sendUtxos.ts
+++ b/packages/btc/src/api/sendUtxos.ts
@@ -1,14 +1,14 @@
 import { bitcoin } from '../bitcoin';
 import { Utxo } from '../transaction/utxo';
 import { DataSource } from '../query/source';
-import { TxBuilder, InitOutput } from '../transaction/build';
+import { TxBuilder, InitOutput, FeeRateOption } from '../transaction/build';
 
 export interface SendUtxosProps {
   inputs: Utxo[];
   outputs: InitOutput[];
   source: DataSource;
   from: string;
-  feeRate?: number;
+  feeRate?: FeeRateOption;
   fromPubkey?: string;
   changeAddress?: string;
   minUtxoSatoshi?: number;

--- a/packages/btc/src/error.ts
+++ b/packages/btc/src/error.ts
@@ -23,6 +23,7 @@ export enum ErrorCodes {
   CKB_RGBPP_LOCK_UNPACK_ERROR,
 
   MEMPOOL_API_RESPONSE_ERROR = 60,
+  MEMPOOL_API_INVALID_FEE_TYPE,
 }
 
 export const ErrorMessages = {
@@ -50,6 +51,7 @@ export const ErrorMessages = {
   [ErrorCodes.CKB_RGBPP_LOCK_UNPACK_ERROR]: 'Failed to unpack RgbppLockArgs from the CKB cell lock',
 
   [ErrorCodes.MEMPOOL_API_RESPONSE_ERROR]: 'Mempool.space API returned an error',
+  [ErrorCodes.MEMPOOL_API_INVALID_FEE_TYPE]: 'Invalid feeType specified to the Mempool.space API',
 };
 
 export class TxBuildError extends Error {

--- a/packages/btc/src/index.ts
+++ b/packages/btc/src/index.ts
@@ -8,6 +8,7 @@ export * from './bitcoin';
 export * from './address';
 
 export * from './query/source';
+export * from './query/mempool';
 
 export * from './transaction/build';
 export * from './transaction/embed';

--- a/packages/btc/src/query/mempool.ts
+++ b/packages/btc/src/query/mempool.ts
@@ -1,5 +1,6 @@
 import Mempool from '@mempool/mempool.js';
 import { NetworkType } from '../preset/types';
+import { FeesRecommended } from '@mempool/mempool.js/lib/interfaces/bitcoin/fees';
 
 export type MempoolInstance = ReturnType<typeof Mempool>;
 
@@ -38,4 +39,20 @@ export function networkTypeToMempoolConfig(network: NetworkType) {
 export function createMempool(network: NetworkType) {
   const config = networkTypeToMempoolConfig(network);
   return Mempool(config);
+}
+
+export enum RecommendedFeeRate {
+  FASTEST = 'fastestFee',
+  AVERAGE = 'halfHourFee',
+  SLOW = 'hourFee',
+  MINIMUM = 'minimumFee',
+}
+
+/**
+ * Check if target string is a recommended fee type.
+ * Acceptable fee types: "fastestFee", "halfHourFee", "hourFee", "minimumFee"
+ */
+export function isMempoolRecommendedFeeType(feeType: unknown): feeType is keyof FeesRecommended {
+  const values: string[] = Object.values(RecommendedFeeRate);
+  return typeof feeType === 'string' && values.includes(feeType);
 }

--- a/packages/btc/tests/DataSource.test.ts
+++ b/packages/btc/tests/DataSource.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { source } from './shared/env';
-import { ErrorCodes } from '../src';
+import { ErrorCodes, RecommendedFeeRate } from '../src';
 
 describe('DataSource', () => {
   it('Get recommended fee rates', async () => {
@@ -15,13 +15,18 @@ describe('DataSource', () => {
     expect(fees.fastestFee).toBeGreaterThanOrEqual(fees.halfHourFee);
     expect(fees.halfHourFee).toBeGreaterThanOrEqual(fees.hourFee);
     expect(fees.hourFee).toBeGreaterThanOrEqual(fees.minimumFee);
-  });
-  it('Get average fee rate', async () => {
-    const [feeRates, averageFeeRate] = await Promise.all([source.getRecommendedFeeRates(), source.getAverageFeeRate()]);
 
-    expect(averageFeeRate).toBeTypeOf('number');
-    expect(feeRates.halfHourFee).toBeTypeOf('number');
-    expect(averageFeeRate).toEqual(feeRates.halfHourFee);
+    expect(fees[RecommendedFeeRate.FASTEST]).toBeTypeOf('number');
+    expect(fees[RecommendedFeeRate.AVERAGE]).toBeTypeOf('number');
+    expect(fees[RecommendedFeeRate.SLOW]).toBeTypeOf('number');
+    expect(fees[RecommendedFeeRate.MINIMUM]).toBeTypeOf('number');
+  });
+  it('Get default recommended fee rate', async () => {
+    const [feeRates, feeRate] = await Promise.all([source.getRecommendedFeeRates(), source.getRecommendedFeeRate()]);
+
+    expect(feeRate).toBeTypeOf('number');
+    expect(feeRates.fastestFee).toBeTypeOf('number');
+    expect(feeRate).toEqual(feeRates.fastestFee);
   });
   it('Get OP_RETURN output via getOutput()', async () => {
     const output = await source.getOutput('70b250e2a3cc7a33b47f7a4e94e41e1ee2501ce73b393d824db1dd4c872c5348', 0);


### PR DESCRIPTION
## Changes
1. BREAKING CHANGE: Remove `DataSource.getAverageFeeRate()`, add `DataSource.getRecommendedFeeRate()`
2. Update the type of `feeRate` in BTC APIs: `feeRate?: number` -> `feeRate?: number | RecommendedFeeRate`
3. Change the default fee rate: `RecommendedFeeRate.AVERAGE` -> `RecommendedFeeRate.FASTEST`
4. Remove the specified `feeRate: 1` in the transfer-btc example

## Related issues

- Resolves #92 

## Details

### Added `RecommendedFeeRate`

You can specify fee rate level with the new `RecommendedFeeRate` enum in the BTC APIs: 
```ts
export enum RecommendedFeeRate {
  FASTEST = 'fastestFee',
  AVERAGE = 'halfHourFee',
  SLOW = 'hourFee',
  MINIMUM = 'minimumFee',
}

sendBtc({
  ...
  feeRate: RecommendedFeeRate.AVERAGE, // optional, default to RecommendedFeeRate.FASTEST
});
```

### Removed `DataSource.getAverageFeeRate()`

The PR includes a breaking change where the `DataSource.getAverageFeeRate()` is deleted due to deprecation, and I noticed that the Mempool-related APIs are not used during the JoyID integration (cc @yuche). Based on the situation, I think it's still safe to delete it before the main release (if possible). However, this change can be reverted, tell me if you think keeping the API is better than removing it.
