### PR TITLE
refactor(rgbpp-sdk/ckb): Add outputCapacityRange to signBtcTimeCellSpentTx

### DIFF
--- a/packages/ckb/src/collector/index.ts
+++ b/packages/ckb/src/collector/index.ts
@@ -5,6 +5,7 @@ import { CollectResult, CollectUdtResult, IndexerCell } from '../types/collector
 import { MIN_CAPACITY } from '../constants';
 import { CapacityNotEnoughError, IndexerError, UdtAmountNotEnoughError } from '../error';
 import { leToU128 } from '../utils';
+import { Hex } from '../types';
 
 const parseScript = (script: CKBComponents.Script) => ({
   code_hash: script.codeHash,
@@ -29,10 +30,12 @@ export class Collector {
     lock,
     type,
     isDataEmpty = true,
+    outputCapacityRange,
   }: {
     lock?: CKBComponents.Script;
     type?: CKBComponents.Script;
     isDataEmpty?: boolean;
+    outputCapacityRange?: Hex[];
   }): Promise<IndexerCell[] | undefined> {
     let param: any = {
       script_search_mode: 'exact',
@@ -45,6 +48,7 @@ export class Collector {
         filter: {
           script: type ? parseScript(type) : null,
           output_data_len_range: isDataEmpty && !type ? ['0x0', '0x1'] : null,
+          output_capacity_range: outputCapacityRange,
         },
       };
     } else if (type) {

--- a/packages/ckb/src/rgbpp/btc-time.ts
+++ b/packages/ckb/src/rgbpp/btc-time.ts
@@ -114,6 +114,7 @@ export const buildBtcTimeCellsSpentTx = async ({
  * @param ckbRawTx The CKB raw transaction to be signed
  * @param collector The collector that collects CKB live cells and transactions
  * @param masterCkbAddress The master CKB address
+ * @param outputCapacityRange [u64; 2], filter cells by output capacity range, [inclusive, exclusive]
  * @param ckbFeeRate The CKB transaction fee rate, default value is 1100
  * @param isMainnet
  */
@@ -123,11 +124,13 @@ export const signBtcTimeCellSpentTx = async ({
   collector,
   masterCkbAddress,
   isMainnet,
+  outputCapacityRange,
   ckbFeeRate,
 }: SignBtcTimeCellsTxParams): Promise<CKBComponents.RawTransaction> => {
   const masterLock = addressToScript(masterCkbAddress);
   const emptyCells = await collector.getCells({
     lock: masterLock,
+    outputCapacityRange,
   });
   if (!emptyCells || emptyCells.length === 0) {
     throw new Error('No empty cell found');

--- a/packages/ckb/src/types/rgbpp.ts
+++ b/packages/ckb/src/types/rgbpp.ts
@@ -111,6 +111,8 @@ export interface SignBtcTimeCellsTxParams {
   // The master CKB address to pay the time cells spent tx fee
   masterCkbAddress: Address;
   isMainnet: boolean;
+  // [u64; 2], filter cells by output capacity range, [inclusive, exclusive]
+  outputCapacityRange?: Hex[];
   // The CKB transaction fee rate, default value is 1100
   ckbFeeRate?: bigint;
 }


### PR DESCRIPTION
## Main Changes

- Add `outputCapacityRange` to `signBtcTimeCellSpentTx`