### PR TITLE
feat(rgbpp-sdk/ckb): Limit inputs and outputs to length 255 for commitment

### DIFF
--- a/packages/ckb/src/error/index.ts
+++ b/packages/ckb/src/error/index.ts
@@ -1,46 +1,73 @@
+enum ErrorCode {
+  CapacityNotEnough = 100,
+  IndexerRpcError = 101,
+  NoLiveCell = 102,
+  NoXudtLiveCell = 103,
+  NoRgbppLiveCell = 104,
+  UdtAmountNotEnough = 105,
+  InputsCapacityNotEnough = 106,
+  TypeAssetNotSupported = 107,
+  InputsOrOutputsLenInvalid = 108,
+}
+
 export class CapacityNotEnoughError extends Error {
+  code = ErrorCode.CapacityNotEnough;
   constructor(message: string) {
     super(message);
   }
 }
 
 export class IndexerError extends Error {
+  code = ErrorCode.IndexerRpcError;
   constructor(message: string) {
     super(message);
   }
 }
 
 export class NoLiveCellError extends Error {
+  code = ErrorCode.NoLiveCell;
   constructor(message: string) {
     super(message);
   }
 }
 
 export class NoXudtLiveCellError extends Error {
+  code = ErrorCode.NoXudtLiveCell;
   constructor(message: string) {
     super(message);
   }
 }
 
 export class NoRgbppLiveCellError extends Error {
+  code = ErrorCode.NoRgbppLiveCell;
   constructor(message: string) {
     super(message);
   }
 }
 
 export class UdtAmountNotEnoughError extends Error {
+  code = ErrorCode.UdtAmountNotEnough;
   constructor(message: string) {
     super(message);
   }
 }
 
 export class InputsCapacityNotEnoughError extends Error {
+  code = ErrorCode.InputsCapacityNotEnough;
   constructor(message: string) {
     super(message);
   }
 }
 
 export class TypeAssetNotSupportedError extends Error {
+  code = ErrorCode.TypeAssetNotSupported;
+  constructor(message: string) {
+    super(message);
+  }
+}
+
+export class InputsOrOutputsLenError extends Error {
+  code = ErrorCode.InputsOrOutputsLenInvalid;
   constructor(message: string) {
     super(message);
   }

--- a/packages/ckb/src/utils/rgbpp.spec.ts
+++ b/packages/ckb/src/utils/rgbpp.spec.ts
@@ -66,6 +66,38 @@ describe('rgbpp tests', () => {
     };
     const commitment = calculateCommitment(rgbppVirtualTx);
     expect('7cdecc8cc293d491a0cbf44e92feabfc29e79408c1d2f7547b334c42efe13131').toBe(commitment);
+
+    const invalidRgbppVirtualTx: RgbppCkbVirtualTx = {
+      inputs: new Array(300).fill({
+        previousOutput: {
+          txHash: '0x047b6894a0b7a4d7a73b1503d1ae35c51fc5fa6306776dcf22b1fb3daaa32a29',
+          index: '0x0',
+        },
+        since: '0x0',
+      }),
+      outputs: [
+        {
+          lock: {
+            codeHash: '0xd5a4e241104041f6f12f11bddcf30bd7b2f818722f78353fde019f5081cd6b49',
+            hashType: 'type',
+            args: '0x010000000000000000000000000000000000000000000000000000000000000000000000',
+          },
+          capacity: '0x0000000000000000',
+          type: {
+            codeHash: '0xc4957f239eb3db9f5c5fb949e9dd99adbb8068b8ac7fe7ae49495486d5e5d235',
+            hashType: 'type',
+            args: '0x43094caf2f2bcdf6f5ab02c2de744936897278d558a2b6924db98a4f27d629e2',
+          },
+        },
+      ],
+      outputsData: ['0xbc020000000000000000000000000000'],
+    };
+    try {
+      calculateCommitment(invalidRgbppVirtualTx);
+    } catch (error) {
+      expect(108).toBe(error.code);
+      expect('The inputs or outputs length of RGB++ CKB virtual tx cannot be greater than 255').toBe(error.message);
+    }
   });
 
   it('genBtcTimeLockArgs', () => {

--- a/packages/ckb/src/utils/rgbpp.spec.ts
+++ b/packages/ckb/src/utils/rgbpp.spec.ts
@@ -15,6 +15,7 @@ import {
 } from './rgbpp';
 import { RgbppCkbVirtualTx } from '../types';
 import { calculateUdtCellCapacity } from './ckb-tx';
+import { InputsOrOutputsLenError } from '../error';
 
 describe('rgbpp tests', () => {
   it('sha256', () => {
@@ -95,8 +96,10 @@ describe('rgbpp tests', () => {
     try {
       calculateCommitment(invalidRgbppVirtualTx);
     } catch (error) {
-      expect(108).toBe(error.code);
-      expect('The inputs or outputs length of RGB++ CKB virtual tx cannot be greater than 255').toBe(error.message);
+      if (error instanceof InputsOrOutputsLenError) {
+        expect(108).toBe(error.code);
+        expect('The inputs or outputs length of RGB++ CKB virtual tx cannot be greater than 255').toBe(error.message);
+      }
     }
   });
 

--- a/packages/ckb/src/utils/rgbpp.ts
+++ b/packages/ckb/src/utils/rgbpp.ts
@@ -62,7 +62,7 @@ export const calculateCommitment = (rgbppVirtualTx: RgbppCkbVirtualTx | CKBCompo
 
   const { inputs, outputs, outputsData } = rgbppVirtualTx;
 
-  if (inputs.length > MAX_INPUTS_LEN || outputs.length > MAX_INPUTS_LEN) {
+  if (inputs.length > MAX_RGBPP_CELL_NUM || outputs.length > MAX_RGBPP_CELL_NUM) {
     throw new InputsOrOutputsLenError(
       'The inputs or outputs length of RGB++ CKB virtual tx cannot be greater than 255',
     );

--- a/packages/ckb/src/utils/rgbpp.ts
+++ b/packages/ckb/src/utils/rgbpp.ts
@@ -52,7 +52,7 @@ export const genBtcTimeLockScript = (toLock: CKBComponents.Script, isMainnet: bo
 };
 
 // The maximum length of inputs and outputs is 255, and the field type representing the length in the RGB++ protocol is Uint8
-const MAX_INPUTS_LEN = 255;
+const MAX_RGBPP_CELL_NUM = 255;
 // refer to https://github.com/ckb-cell/rgbpp/blob/0c090b039e8d026aad4336395b908af283a70ebf/contracts/rgbpp-lock/src/main.rs#L173-L211
 export const calculateCommitment = (rgbppVirtualTx: RgbppCkbVirtualTx | CKBComponents.RawTransaction): Hex => {
   var hash = sha256.create();


### PR DESCRIPTION
## Main Changes

- Limit inputs and outputs to length 255 for commitment
- Add error code for custom error classes
- Add invalid commitment test case