### PR TITLE
feat: update getRgbppTransactionState to support withData param

### DIFF
--- a/packages/service/src/service/service.ts
+++ b/packages/service/src/service/service.ts
@@ -13,6 +13,7 @@ import {
   BtcApiTransaction,
   BtcApiUtxo,
   BtcApiUtxoParams,
+  RgbppApiTransactionStateParams,
 } from '../types';
 import {
   RgbppApis,
@@ -99,8 +100,10 @@ export class BtcAssetsApi extends BtcAssetsApiBase implements BtcApis, RgbppApis
     return this.request<RgbppApiCkbTransactionHash>(`/rgbpp/v1/transaction/${btcTxId}`);
   }
 
-  getRgbppTransactionState(btcTxId: string) {
-    return this.request<RgbppApiTransactionState>(`/rgbpp/v1/transaction/${btcTxId}/job`);
+  getRgbppTransactionState(btcTxId: string, params?: RgbppApiTransactionStateParams) {
+    return this.request<RgbppApiTransactionState>(`/rgbpp/v1/transaction/${btcTxId}/job`, {
+      params,
+    });
   }
 
   getRgbppAssetsByBtcTxId(btcTxId: string) {

--- a/packages/service/src/types/rgbpp.ts
+++ b/packages/service/src/types/rgbpp.ts
@@ -23,9 +23,23 @@ export interface RgbppApiCkbTransactionHash {
   txhash: string;
 }
 
+export interface RgbppApiTransactionStateParams {
+  withData?: boolean;
+}
+
 export interface RgbppApiTransactionState {
   state: RgbppTransactionState;
-  failedReason: string;
+  attempts: number;
+  failedReason?: string;
+  data?: {
+    txid: string;
+    ckbVirtualResult: {
+      ckbRawTx: CKBComponents.RawTransaction;
+      needPaymasterCell: boolean;
+      sumInputsCapacity: string;
+      commitment: string;
+    };
+  };
 }
 
 export interface RgbppApiAssetsByAddressParams {


### PR DESCRIPTION
add the query parameter of `with_data` on `/rgbpp/v1/transaction/:btc_txid/job` to return txid and ckbVirtualResult.

## API docs
https://btc-assets-api.testnet.mibao.pro/docs/static/index.html#/RGB%2B%2B/get_rgbpp_v1_transaction__btc_txid__job

### Example URL
'/rgbpp/v1/transaction/ccee39f38e5ad162c21a44bc6add20577811f13e35575fcb9103ef725a73c79d/job?with_data=true'