### PR TITLE
feat(btc): add "onlyNonRgbppUtxos" option in DataSource/TxBuilder

### DIFF
--- a/packages/btc/README.md
+++ b/packages/btc/README.md
@@ -369,6 +369,7 @@ interface DataSource {
     address: string;
     targetAmount: number;
     minUtxoSatoshi?: number;
+    onlyNonRgbppUtxos?: boolean;
     onlyConfirmedUtxos?: boolean;
     excludeUtxos?: {
       txid: string;

--- a/packages/btc/src/query/source.ts
+++ b/packages/btc/src/query/source.ts
@@ -102,6 +102,7 @@ export class DataSource {
     address: string;
     targetAmount: number;
     minUtxoSatoshi?: number;
+    onlyNonRgbppUtxos?: boolean;
     onlyConfirmedUtxos?: boolean;
     excludeUtxos?: {
       txid: string;
@@ -112,7 +113,7 @@ export class DataSource {
     satoshi: number;
     exceedSatoshi: number;
   }> {
-    const { address, targetAmount, minUtxoSatoshi, onlyConfirmedUtxos, excludeUtxos = [] } = props;
+    const { address, targetAmount, minUtxoSatoshi, onlyConfirmedUtxos, onlyNonRgbppUtxos, excludeUtxos = [] } = props;
     const utxos = await this.getUtxos(address, {
       only_confirmed: onlyConfirmedUtxos,
       min_satoshi: minUtxoSatoshi,
@@ -129,6 +130,12 @@ export class DataSource {
           return exclude.txid === utxo.txid && exclude.vout === utxo.vout;
         });
         if (excluded) {
+          continue;
+        }
+      }
+      if (onlyNonRgbppUtxos) {
+        const ckbRgbppAssets = await this.service.getRgbppAssetsByBtcUtxo(utxo.txid, utxo.vout);
+        if (ckbRgbppAssets && ckbRgbppAssets.length > 0) {
           continue;
         }
       }

--- a/packages/btc/src/transaction/build.ts
+++ b/packages/btc/src/transaction/build.ts
@@ -45,14 +45,22 @@ export class TxBuilder {
   source: DataSource;
   config: RgbppBtcConfig;
   networkType: NetworkType;
+  onlyNonRgbppUtxos: boolean;
   onlyConfirmedUtxos: boolean;
   minUtxoSatoshi: number;
   feeRate?: number;
 
-  constructor(props: { source: DataSource; onlyConfirmedUtxos?: boolean; minUtxoSatoshi?: number; feeRate?: number }) {
+  constructor(props: {
+    source: DataSource;
+    onlyNonRgbppUtxos?: boolean;
+    onlyConfirmedUtxos?: boolean;
+    minUtxoSatoshi?: number;
+    feeRate?: number;
+  }) {
     this.source = props.source;
     this.networkType = this.source.networkType;
     this.config = networkTypeToConfig(this.networkType);
+    this.onlyNonRgbppUtxos = props.onlyNonRgbppUtxos ?? true;
     this.onlyConfirmedUtxos = props.onlyConfirmedUtxos ?? false;
     this.minUtxoSatoshi = props.minUtxoSatoshi ?? this.config.btcUtxoDustLimit;
     this.feeRate = props.feeRate;
@@ -220,6 +228,7 @@ export class TxBuilder {
         address: props.address,
         targetAmount: _targetAmount,
         minUtxoSatoshi: this.minUtxoSatoshi,
+        onlyNonRgbppUtxos: this.onlyNonRgbppUtxos,
         onlyConfirmedUtxos: this.onlyConfirmedUtxos,
         excludeUtxos: this.inputs.map((row) => row.utxo),
       });

--- a/packages/btc/tests/DataSource.test.ts
+++ b/packages/btc/tests/DataSource.test.ts
@@ -39,4 +39,35 @@ describe('DataSource', () => {
       source.getUtxo('70b250e2a3cc7a33b47f7a4e94e41e1ee2501ce73b393d824db1dd4c872c5348', 0),
     ).rejects.toHaveProperty('code', ErrorCodes.UNSPENDABLE_OUTPUT);
   });
+  it('Get UTXO[] via collectSatoshi()', async () => {
+    const address = 'tb1qnxdtut9vpycmpnjpp77rmx33mfxsr86dl3ce6a';
+    const nonRgbppSatoshi = 2546;
+    const totalSatoshi = 3092;
+    const nonRgbppUtxo = 2;
+    const totalUtxo = 3;
+
+    const c1 = await source.collectSatoshi({
+      address,
+      targetAmount: totalSatoshi,
+      onlyNonRgbppUtxos: false,
+    });
+    expect(c1.utxos).toHaveLength(totalUtxo);
+    expect(c1.satoshi).toEqual(totalSatoshi);
+
+    const c2 = await source.collectSatoshi({
+      address,
+      targetAmount: nonRgbppSatoshi,
+      onlyNonRgbppUtxos: true,
+    });
+    expect(c2.utxos).toHaveLength(nonRgbppUtxo);
+    expect(c2.satoshi).toEqual(nonRgbppSatoshi);
+
+    await expect(() =>
+      source.collectSatoshi({
+        address,
+        targetAmount: totalSatoshi,
+        onlyNonRgbppUtxos: true,
+      }),
+    ).rejects.toThrowError();
+  });
 });


### PR DESCRIPTION
## Changes
- Add `onlyNonRgbppUtxos` option in the DataSource.collectSatoshi() API, tests are also updated
- Set `onlyNonRgbppUtxos = true` by default in the TxBuilder when collecting UTXOs

## What is it

Previously, if the value of a RGBPP UTXO is `>= 546`, it may be used to pay fee in a transaction. With the `onlyNonRgbppUtxos` option added, the SDK can filter out RGBPP UTXOs in the satoshi collection process, therefore preventing misuse of RGBPP UTXOs.

## Related issues
- Resolves #122 