### PR TITLE
fix(rgbpp-sdk/ckb): Deduplicate rgbpp lock args list

### DIFF
--- a/packages/ckb/src/rgbpp/btc-transfer.ts
+++ b/packages/ckb/src/rgbpp/btc-transfer.ts
@@ -8,7 +8,14 @@ import {
 } from '../types/rgbpp';
 import { blockchain } from '@ckb-lumos/base';
 import { NoLiveCellError, NoRgbppLiveCellError, TypeAssetNotSupportedError } from '../error';
-import { append0x, calculateRgbppCellCapacity, calculateTransactionFee, isUDTTypeSupported, u128ToLe } from '../utils';
+import {
+  append0x,
+  calculateRgbppCellCapacity,
+  calculateTransactionFee,
+  deduplicateList,
+  isUDTTypeSupported,
+  u128ToLe,
+} from '../utils';
 import {
   buildPreLockArgs,
   calculateCommitment,
@@ -65,7 +72,9 @@ export const genBtcTransferCkbVirtualTx = async ({
     throw new TypeAssetNotSupportedError('The type script asset is not supported now');
   }
 
-  const rgbppLocks = rgbppLockArgsList.map((args) => genRgbppLockScript(args, isMainnet));
+  const deduplicatedLockArgsList = deduplicateList(rgbppLockArgsList);
+
+  const rgbppLocks = deduplicatedLockArgsList.map((args) => genRgbppLockScript(args, isMainnet));
   let rgbppCells: IndexerCell[] = [];
   for await (const rgbppLock of rgbppLocks) {
     const cells = await collector.getCells({ lock: rgbppLock, type: xudtType });
@@ -159,7 +168,7 @@ export const genBtcTransferCkbVirtualTx = async ({
 
   if (!needPaymasterCell) {
     const txSize =
-      getTransactionSize(ckbRawTx) + (witnessLockPlaceholderSize ?? estimateWitnessSize(rgbppLockArgsList));
+      getTransactionSize(ckbRawTx) + (witnessLockPlaceholderSize ?? estimateWitnessSize(deduplicatedLockArgsList));
     const estimatedTxFee = calculateTransactionFee(txSize, ckbFeeRate);
 
     changeCapacity -= estimatedTxFee;

--- a/packages/ckb/src/utils/ckb-tx.spec.ts
+++ b/packages/ckb/src/utils/ckb-tx.spec.ts
@@ -4,6 +4,7 @@ import {
   calculateRgbppClusterCellCapacity,
   calculateRgbppSporeCellCapacity,
   calculateTransactionFee,
+  deduplicateList,
   generateUniqueTypeArgs,
   isClusterSporeTypeSupported,
   isLockArgsSizeExceeded,
@@ -132,5 +133,13 @@ describe('ckb tx utils', () => {
     };
     const capacity = calculateRgbppSporeCellCapacity(sporeData);
     expect(capacity).toBe(BigInt(319_0000_0000));
+  });
+
+  it('deduplicateList', () => {
+    const rgbppLockArgsList = [
+      '0x01000000c12747f21eb725b02d8ce3fd062547756b30879504093389cd74f9b3cf357f05',
+      '0x01000000c12747f21eb725b02d8ce3fd062547756b30879504093389cd74f9b3cf357f05',
+    ];
+    expect(1).toBe(deduplicateList(rgbppLockArgsList).length);
   });
 });

--- a/packages/ckb/src/utils/ckb-tx.ts
+++ b/packages/ckb/src/utils/ckb-tx.ts
@@ -128,3 +128,7 @@ export const calculateRgbppSporeCellCapacity = (sporeData: SporeDataProps): bigi
   const cellSize = RGBPP_LOCK_SIZE + sporeTypeSize + 8 + sporeDataSize + BTC_TIME_CELL_INCREASED_SIZE;
   return BigInt(cellSize + 1) * CKB_UNIT;
 };
+
+export const deduplicateList = (rgbppLockArgsList: Hex[]): Hex[] => {
+  return Array.from(new Set(rgbppLockArgsList));
+};


### PR DESCRIPTION
## Main Changes

- Deduplicate rgbppLockArgsList for xUDT transfer on BTC and leap from BTC to CKB
- CKB transaction inputs will have duplicate cells if duplication is not removed.
