### PR TITLE
fix(btc): only add paymaster output when needed in sendRgbppUtxos() API

### DIFF
--- a/packages/btc/src/api/sendRgbppUtxos.ts
+++ b/packages/btc/src/api/sendRgbppUtxos.ts
@@ -155,18 +155,21 @@ async function getMergedBtcOutputs(btcOutputs: InitOutput[], props: SendRgbppUtx
   // Add outputs
   merged.push(...btcOutputs);
 
-  // Add paymaster UTXO
-  const paymasterOutput = await props.source.getPaymasterOutput();
-  if (
-    paymasterOutput &&
-    props.paymaster &&
-    (paymasterOutput?.address !== props.paymaster.address || paymasterOutput?.value !== props.paymaster.value)
-  ) {
+  // Check paymaster info
+  const defaultPaymaster = await props.source.getPaymasterOutput();
+  const isPaymasterUnmatched =
+    defaultPaymaster?.address !== props.paymaster?.address || defaultPaymaster?.value !== props.paymaster?.value;
+  if (defaultPaymaster && props.paymaster && isPaymasterUnmatched) {
     throw new TxBuildError(ErrorCodes.PAYMASTER_MISMATCH);
   }
-  if (paymasterOutput || props.paymaster) {
+
+  // Add paymaster output
+  // TODO: can be more accurate if we compare the actual capacity of inputs & outputs
+  const paymaster = defaultPaymaster ?? props.paymaster;
+  const needPaymasterOutput = props.ckbVirtualTx.inputs.length < props.ckbVirtualTx.outputs.length;
+  if (paymaster && needPaymasterOutput) {
     merged.push({
-      ...(paymasterOutput ?? props.paymaster)!,
+      ...paymaster,
       fixed: true,
     });
   }


### PR DESCRIPTION
## Changes
- Add "needPaymasterOutput" check to the sendRgbppUtxos() API, and the paymaster output should be added only when needed, previously the paymaster output was added to an RGBPP-related transaction without conditions

## Details

Currently, the logic of `needPaymasterOutput` is simple:
```ts
const needPaymasterOutput = CKB_VTX.inputs.length < CKB_VTX.outputs.length;
```

As you can see, we're comparing the length of inputs and outputs to see if the CKB virtual transaction needs a paymaster cell. It's a solid solution and can work without issues in most cases. However, in some rare cases, the information can be inaccurate.

For example, if the following conditions are met:
1. Transferring a single spore (the CKB_VTX has 1 input and 1 output)
2. The target spore itself should pay for the transaction fee, but it has ran out of capacity margin
3. Although the length of inputs and outputs are both 1, the transaction still needs extra capacity to pay for the fee

Right now we don't have to worry about those rare cases, but in the future if needed, we can improve the check statement by comparing the capacity sum of the inputs and outputs of the CKB_VTX, instead of comparing their lengths. For that, we need to query each input's corresponding Live Cell (because inputs are OutPoints that don't contain the `capacity` property):
```ts
let inputsCapacity: number = 0;
for (let i = 0; i < CKB_VTX.inputs.length; i++) {
  const input: OutPoint = CKB_VTX.inputs[i];
  const liveCell: LiveCell = await rpc.getLiveCell(input);
  inputsCapacity += BI.from(liveCell.output.capacity).toNumber();
}
```