### PR TITLE
fix(btc): error message when reporting INSUFFICIENT_UTXO

### DIFF
--- a/packages/btc/README.md
+++ b/packages/btc/README.md
@@ -369,6 +369,7 @@ interface DataSource {
     address: string;
     targetAmount: number;
     minUtxoSatoshi?: number;
+    allowInsufficient?: boolean;
     onlyNonRgbppUtxos?: boolean;
     onlyConfirmedUtxos?: boolean;
     excludeUtxos?: {

--- a/packages/btc/src/query/source.ts
+++ b/packages/btc/src/query/source.ts
@@ -105,6 +105,7 @@ export class DataSource {
     address: string;
     targetAmount: number;
     minUtxoSatoshi?: number;
+    allowInsufficient?: boolean;
     onlyNonRgbppUtxos?: boolean;
     onlyConfirmedUtxos?: boolean;
     excludeUtxos?: {
@@ -116,7 +117,15 @@ export class DataSource {
     satoshi: number;
     exceedSatoshi: number;
   }> {
-    const { address, targetAmount, minUtxoSatoshi, onlyConfirmedUtxos, onlyNonRgbppUtxos, excludeUtxos = [] } = props;
+    const {
+      address,
+      targetAmount,
+      minUtxoSatoshi,
+      onlyConfirmedUtxos,
+      onlyNonRgbppUtxos,
+      allowInsufficient = false,
+      excludeUtxos = [],
+    } = props;
     const utxos = await this.getUtxos(address, {
       only_confirmed: onlyConfirmedUtxos,
       min_satoshi: minUtxoSatoshi,
@@ -146,7 +155,7 @@ export class DataSource {
       collectedAmount += utxo.value;
     }
 
-    if (collectedAmount < targetAmount) {
+    if (!allowInsufficient && collectedAmount < targetAmount) {
       throw TxBuildError.withComment(
         ErrorCodes.INSUFFICIENT_UTXO,
         `expected: ${targetAmount}, actual: ${collectedAmount}`,

--- a/packages/btc/src/transaction/build.ts
+++ b/packages/btc/src/transaction/build.ts
@@ -305,7 +305,11 @@ export class TxBuilder {
     // If not collected enough satoshi, throw error
     const insufficientBalance = collected < targetAmount;
     if (insufficientBalance) {
-      throw TxBuildError.withComment(ErrorCodes.INSUFFICIENT_UTXO, `expected: ${targetAmount}, actual: ${collected}`);
+      const recommendedDeposit = collected - targetAmount + this.minUtxoSatoshi;
+      throw TxBuildError.withComment(
+        ErrorCodes.INSUFFICIENT_UTXO,
+        `expected: ${targetAmount}, actual: ${collected}. You may wanna deposit more satoshi to prevent the error, for example: ${recommendedDeposit}`,
+      );
     }
     const insufficientForChange = changeAmount > 0 && changeAmount < this.minUtxoSatoshi;
     if (insufficientForChange) {

--- a/packages/btc/src/transaction/build.ts
+++ b/packages/btc/src/transaction/build.ts
@@ -228,6 +228,7 @@ export class TxBuilder {
       const { utxos, satoshi } = await this.source.collectSatoshi({
         address: props.address,
         targetAmount: _targetAmount,
+        allowInsufficient: true,
         minUtxoSatoshi: this.minUtxoSatoshi,
         onlyNonRgbppUtxos: this.onlyNonRgbppUtxos,
         onlyConfirmedUtxos: this.onlyConfirmedUtxos,
@@ -308,7 +309,7 @@ export class TxBuilder {
     }
     const insufficientForChange = changeAmount > 0 && changeAmount < this.minUtxoSatoshi;
     if (insufficientForChange) {
-      const shiftedExpectAmount = targetAmount + changeUtxoNeedAmount;
+      const shiftedExpectAmount = collected + changeUtxoNeedAmount;
       throw TxBuildError.withComment(
         ErrorCodes.INSUFFICIENT_UTXO,
         `expected: ${shiftedExpectAmount}, actual: ${collected}`,


### PR DESCRIPTION
## Changes
1. Add an `allowInsufficient` option (set to `true` by default) to the DataSource.collectSatoshi() API to allow the collection process to be completed when the balance of the target address is insufficient, instead of throwing the INSUFFICIENT_UTXO error
2. Fix the expected amount of error when collected satoshi and the balance of the target address are both insufficient for a change output to be generated in the transaction (reported by @Dawn-githup)