### PR TITLE
refactor(service|btc): use org mempool api

### DIFF
--- a/packages/btc/src/query/mempool.ts
+++ b/packages/btc/src/query/mempool.ts
@@ -10,11 +10,11 @@ export interface MempoolConfig {
 
 export const mempoolConfigs: Record<'mainnet' | 'testnet', MempoolConfig> = {
   testnet: {
-    hostname: 'mempool.space',
+    hostname: 'cell.mempool.space',
     network: 'testnet',
   },
   mainnet: {
-    hostname: 'mempool.space',
+    hostname: 'cell.mempool.space',
     network: 'mainnet',
   },
 };

--- a/packages/btc/tests/DataSource.test.ts
+++ b/packages/btc/tests/DataSource.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest';
 import { source } from './shared/env';
 import { ErrorCodes } from '../src';
 
-describe('DataSource', () => {
+describe('DataSource', { retry: 5 }, () => {
   it('Get recommended fee rates', async () => {
     const fees = await source.getRecommendedFeeRates();
 

--- a/packages/btc/tests/Transaction.test.ts
+++ b/packages/btc/tests/Transaction.test.ts
@@ -19,6 +19,7 @@ describe('Transaction', () => {
             value: 1000,
           },
         ],
+        feeRate: STATIC_FEE_RATE,
         source,
       });
 
@@ -45,6 +46,7 @@ describe('Transaction', () => {
             value: 1000,
           },
         ],
+        feeRate: STATIC_FEE_RATE,
         source,
       });
 
@@ -61,7 +63,7 @@ describe('Transaction', () => {
       console.log(psbt.txOutputs);
 
       console.log('tx paid fee:', psbt.getFee());
-      expectPsbtFeeInRange(psbt);
+      expectPsbtFeeInRange(psbt, STATIC_FEE_RATE);
 
       // Broadcast transaction
       // const tx = psbt.extractTransaction();
@@ -78,6 +80,7 @@ describe('Transaction', () => {
               value: 546,
             },
           ],
+          feeRate: STATIC_FEE_RATE,
           source,
         }),
       ).rejects.toThrow();
@@ -99,6 +102,7 @@ describe('Transaction', () => {
             },
           ],
           minUtxoSatoshi: impossibleLimit,
+          feeRate: STATIC_FEE_RATE,
           source,
         }),
       ).rejects.toThrow(ErrorMessages[ErrorCodes.INSUFFICIENT_UTXO]);
@@ -116,6 +120,7 @@ describe('Transaction', () => {
             value: 1000,
           },
         ],
+        feeRate: STATIC_FEE_RATE,
         source,
       });
 
@@ -142,7 +147,7 @@ describe('Transaction', () => {
       expect((data as Buffer).toString('hex')).toEqual('00'.repeat(32));
 
       console.log('tx paid fee:', psbt.getFee());
-      expectPsbtFeeInRange(psbt);
+      expectPsbtFeeInRange(psbt, STATIC_FEE_RATE);
 
       // Broadcast transaction
       // const tx = psbt.extractTransaction();
@@ -153,7 +158,7 @@ describe('Transaction', () => {
 
   describe('sendUtxos()', () => {
     it('Transfer fixed UTXO, sum(ins) = sum(outs)', async () => {
-      const { builder, feeRate } = await createSendUtxosBuilder({
+      const { builder } = await createSendUtxosBuilder({
         from: accounts.charlie.p2wpkh.address,
         inputs: [
           {
@@ -172,6 +177,7 @@ describe('Transaction', () => {
             fixed: true,
           },
         ],
+        feeRate: STATIC_FEE_RATE,
         source,
       });
 
@@ -184,7 +190,7 @@ describe('Transaction', () => {
       expect(psbt.txOutputs).toHaveLength(2);
 
       console.log('tx paid fee:', psbt.getFee());
-      expectPsbtFeeInRange(psbt, feeRate);
+      expectPsbtFeeInRange(psbt, STATIC_FEE_RATE);
 
       // Broadcast transaction
       // const tx = psbt.extractTransaction();
@@ -192,7 +198,7 @@ describe('Transaction', () => {
       // console.log(`explorer: https://mempool.space/testnet/tx/${res.txid}`);
     });
     it('Transfer fixed UTXO, sum(ins) = sum(outs) = 0', async () => {
-      const { builder, feeRate } = await createSendUtxosBuilder({
+      const { builder } = await createSendUtxosBuilder({
         from: accounts.charlie.p2wpkh.address,
         inputs: [],
         outputs: [
@@ -202,6 +208,7 @@ describe('Transaction', () => {
             value: 0,
           },
         ],
+        feeRate: STATIC_FEE_RATE,
         source,
       });
 
@@ -214,7 +221,7 @@ describe('Transaction', () => {
       expect(psbt.txOutputs).toHaveLength(2);
 
       console.log('tx paid fee:', psbt.getFee());
-      expectPsbtFeeInRange(psbt, feeRate);
+      expectPsbtFeeInRange(psbt, STATIC_FEE_RATE);
 
       // Broadcast transaction
       // const tx = psbt.extractTransaction();
@@ -241,6 +248,7 @@ describe('Transaction', () => {
             fixed: true,
           },
         ],
+        feeRate: STATIC_FEE_RATE,
         source,
       });
 
@@ -252,7 +260,7 @@ describe('Transaction', () => {
       expect(psbt.txOutputs).toHaveLength(2);
 
       console.log('tx paid fee:', psbt.getFee());
-      expectPsbtFeeInRange(psbt);
+      expectPsbtFeeInRange(psbt, STATIC_FEE_RATE);
 
       // Broadcast transaction
       // const tx = psbt.extractTransaction();
@@ -279,6 +287,7 @@ describe('Transaction', () => {
             fixed: true,
           },
         ],
+        feeRate: STATIC_FEE_RATE,
         source,
       });
 
@@ -290,7 +299,7 @@ describe('Transaction', () => {
       expect(psbt.txOutputs).toHaveLength(2);
 
       console.log('tx paid fee:', psbt.getFee());
-      expectPsbtFeeInRange(psbt);
+      expectPsbtFeeInRange(psbt, STATIC_FEE_RATE);
 
       // Broadcast transaction
       // const tx = psbt.extractTransaction();
@@ -529,6 +538,7 @@ describe('Transaction', () => {
             protected: true,
           },
         ],
+        feeRate: STATIC_FEE_RATE,
         source,
       });
 
@@ -540,7 +550,7 @@ describe('Transaction', () => {
       expect(psbt.txOutputs).toHaveLength(1);
 
       console.log('tx paid fee:', psbt.getFee());
-      expectPsbtFeeInRange(psbt);
+      expectPsbtFeeInRange(psbt, STATIC_FEE_RATE);
 
       // Broadcast transaction
       // const tx = psbt.extractTransaction();
@@ -663,6 +673,7 @@ describe('Transaction', () => {
             protected: true,
           },
         ],
+        feeRate: STATIC_FEE_RATE,
         source,
       });
 
@@ -676,7 +687,7 @@ describe('Transaction', () => {
       expect(psbt.txOutputs[1].value).toBe(RGBPP_UTXO_DUST_LIMIT);
 
       console.log('tx paid fee:', psbt.getFee());
-      expectPsbtFeeInRange(psbt);
+      expectPsbtFeeInRange(psbt, STATIC_FEE_RATE);
 
       // Broadcast transaction
       // const tx = psbt.extractTransaction();
@@ -809,6 +820,7 @@ describe('Transaction', () => {
             },
           ],
           onlyConfirmedUtxos: true,
+          feeRate: STATIC_FEE_RATE,
           source,
         }),
       ).rejects.toThrow();

--- a/packages/service/tests/Service.test.ts
+++ b/packages/service/tests/Service.test.ts
@@ -140,13 +140,13 @@ describe(
     });
 
     describe('RGBPP', () => {
-      const rgbppBtcAddress = 'tb1q3k837txmex9p294h6trmzquf9vyx36k740dpv4';
-      const rgbppBtcTxId = 'a7c3f37227a2becbaeb5840be2bdaa33bb4bc88d0ffb5f90f814c92982b8c367';
-      const rgbppBtcVout = 1;
+      const rgbppBtcAddress = 'tb1qwksrmna6emxrerrgyc8hrlxvl2z4x4tdhzzyej';
+      const rgbppBtcTxId = 'da1f32672e3fb0432e1c94ed41298820c8dcca9495cf04a49d992ca4dfc5853d';
+      const rgbppBtcVout = 0;
       const rgbppCellType = bytes.hexify(
         blockchain.Script.pack({
           codeHash: '0x25c29dc317811a6f6f3985a7a9ebc4838bd388d19d0feeecf0bcd60f6c0975bb',
-          args: '0x1ba116c119d1cfd98a53e9d1a615cf2af2bb87d95515c9d217d367054cfc696b',
+          args: '0x661cfbe2124b3e79e50e505c406be5b2dcf9da15d8654b749ec536fa4c2eaaae',
           hashType: 'type',
         }),
       );

--- a/packages/service/tests/Service.test.ts
+++ b/packages/service/tests/Service.test.ts
@@ -6,7 +6,7 @@ import { BtcAssetsApiError, BtcAssetsApi, ErrorCodes, ErrorMessages } from '../s
 describe(
   'BtcServiceApi',
   {
-    retry: 3,
+    retry: 5,
   },
   () => {
     const btcAddress = 'tb1qm06rvrq8jyyckzc5v709u7qpthel9j4d9f7nh3';


### PR DESCRIPTION
## Changes
1. Use `cell.mempool.space` as the Mempool API hostname
2. Allow some btc/service tests to retry more times: 3 -> 5 times
3. Updated some tests to prevent using the Mempool API too much