### PR TITLE
chore(ci): disable btc/service tests temporary

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -47,7 +47,7 @@ jobs:
         run: pnpm run build:packages
         
       - name: Run tests for packages
-        run: pnpm run test:packages
+        run: pnpm run test:ckb
         env:
           VITE_SERVICE_URL: ${{ secrets.SERVICE_URL }}
           VITE_SERVICE_TOKEN: ${{ secrets.SERVICE_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   ],
   "scripts": {
     "prepare": "husky",
+    "test:ckb": "turbo run test --filter=./packages/ckb",
     "test:packages": "turbo run test --filter=./packages/*",
     "build": "turbo run build",
     "build:packages": "turbo run build --filter=./packages/*",


### PR DESCRIPTION
## Changes
- Disable btc/service tests in the `test.yaml` to prevent PRs from being blocked