### PR TITLE
fix(ci): GITHUB_TOKEN permission in the actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
   push:
     branches:
-    - main
+      - main
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 
@@ -47,7 +47,7 @@ jobs:
       - name: Install dependencies
         run: pnpm i
 
-      - name: Create Release Pull Request or Publish to npm
+      - name: Create bump PR or release version
         id: changesets
         uses: changesets/action@v1
         with:

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -3,11 +3,11 @@
 name: Release Snapshots
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - main
       - develop
-      - feat/transfer-spore
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 
@@ -55,6 +55,8 @@ jobs:
 
       - name: Version packages
         run: npx changeset version --snapshot snap
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Publish to npm (ignore GitHub)
         id: changesets


### PR DESCRIPTION
## Changes
- Fixed an issue where the snapshot workflow failed due to lacks of `GITHUB_TOKEN` (found by @ahonn)
    > Error: Please create a GitHub personal access token at https://github.com/settings/tokens/new with `read:user` and `repo:status` permissions and add it as the GITHUB_TOKEN environment variable
- Added `workflow_dispatch` in the snapshot workflow to allow manually snapshot release
- Removed `feat/transfer-spore` as the trigger of the snapshot workflow
- Other minor text or indent fixes

# Reference

- Here's a snapshot action that worked: https://github.com/ckb-cell/rgbpp-sdk/actions/runs/8875439965