### PR TITLE
refactor(examples): Add examples eslint

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -43,6 +43,9 @@ jobs:
       - name: Install dependencies
         run: pnpm i
 
+      - name: Lint packages
+        run: pnpm lint:fix
+
       - name: Build packages
         run: pnpm run build:packages
         

--- a/examples/rgbpp/eslint.config.js
+++ b/examples/rgbpp/eslint.config.js
@@ -1,0 +1,6 @@
+// @ts-check
+
+import eslint from '@eslint/js';
+import tseslint from 'typescript-eslint';
+
+export default tseslint.config(eslint.configs.recommended, ...tseslint.configs.recommended);

--- a/examples/rgbpp/local/1-ckb-jump-btc.ts
+++ b/examples/rgbpp/local/1-ckb-jump-btc.ts
@@ -17,8 +17,8 @@ const jumpFromCkbToBtc = async ({ outIndex, btcTxId }: { outIndex: number; btcTx
   });
   const isMainnet = false;
   const address = privateKeyToAddress(CKB_TEST_PRIVATE_KEY, {
-      prefix: isMainnet ? AddressPrefix.Mainnet : AddressPrefix.Testnet,
-    });
+    prefix: isMainnet ? AddressPrefix.Mainnet : AddressPrefix.Testnet,
+  });
   console.log('ckb address: ', address);
 
   const toRgbppLockArgs = buildRgbppLockArgs(outIndex, btcTxId);
@@ -34,11 +34,11 @@ const jumpFromCkbToBtc = async ({ outIndex, btcTxId }: { outIndex: number; btcTx
     toRgbppLockArgs,
     xudtTypeBytes: serializeScript(xudtType),
     transferAmount: BigInt(800_0000_0000),
-    witnessLockPlaceholderSize: 1000
+    witnessLockPlaceholderSize: 1000,
   });
 
   const emptyWitness = { lock: '', inputType: '', outputType: '' };
-  let unsignedTx: CKBComponents.RawTransactionToSign = {
+  const unsignedTx: CKBComponents.RawTransactionToSign = {
     ...ckbRawTx,
     cellDeps: [...ckbRawTx.cellDeps, getSecp256k1CellDep(isMainnet)],
     witnesses: [emptyWitness, ...ckbRawTx.witnesses.slice(1)],
@@ -46,7 +46,7 @@ const jumpFromCkbToBtc = async ({ outIndex, btcTxId }: { outIndex: number; btcTx
 
   const signedTx = collector.getCkb().signTransaction(CKB_TEST_PRIVATE_KEY)(unsignedTx);
 
-  let txHash = await collector.getCkb().rpc.sendTransaction(signedTx, 'passthrough');
+  const txHash = await collector.getCkb().rpc.sendTransaction(signedTx, 'passthrough');
   console.info(`Rgbpp asset has been jumped from CKB to BTC and tx hash is ${txHash}`);
 };
 
@@ -55,4 +55,3 @@ jumpFromCkbToBtc({
   outIndex: 1,
   btcTxId: '4ff1855b64b309afa19a8b9be3d4da99dcb18b083b65d2d851662995c7d99e7a',
 });
-

--- a/examples/rgbpp/local/2-btc-transfer.ts
+++ b/examples/rgbpp/local/2-btc-transfer.ts
@@ -109,7 +109,6 @@ const transferRgbppOnBtc = async ({ rgbppLockArgsList, toBtcAddress, transferAmo
   }, 30 * 1000);
 };
 
-
 // Use your real BTC UTXO information on the BTC Testnet
 // rgbppLockArgs: outIndexU32 + btcTxId
 transferRgbppOnBtc({
@@ -118,4 +117,3 @@ transferRgbppOnBtc({
   // To simplify, keep the transferAmount the same as 2-ckb-jump-btc
   transferAmount: BigInt(800_0000_0000),
 });
-

--- a/examples/rgbpp/local/3-btc-jump-ckb.ts
+++ b/examples/rgbpp/local/3-btc-jump-ckb.ts
@@ -7,15 +7,8 @@ import {
   updateCkbTxWithRealBtcTxId,
   buildRgbppLockArgs,
 } from '@rgbpp-sdk/ckb';
-import {
-  sendRgbppUtxos,
-  DataSource,
-  NetworkType,
-  bitcoin,
-  ECPair,
-  transactionToHex,
-} from '@rgbpp-sdk/btc';
-import { BtcAssetsApi, BtcAssetsApiError } from '@rgbpp-sdk/service'
+import { sendRgbppUtxos, DataSource, NetworkType, bitcoin, ECPair, transactionToHex } from '@rgbpp-sdk/btc';
+import { BtcAssetsApi, BtcAssetsApiError } from '@rgbpp-sdk/service';
 
 // CKB SECP256K1 private key
 const CKB_TEST_PRIVATE_KEY = '0x0000000000000000000000000000000000000000000000000000000000000001';
@@ -116,7 +109,7 @@ const jumpFromBtcToCkb = async ({ rgbppLockArgsList, toCkbAddress, transferAmoun
       }
     }
   }, 30 * 1000);
-}
+};
 
 // rgbppLockArgs: outIndexU32 + btcTxId
 jumpFromBtcToCkb({
@@ -127,4 +120,3 @@ jumpFromBtcToCkb({
   // To simplify, keep the transferAmount the same as 2-ckb-jump-btc
   transferAmount: BigInt(800_0000_0000),
 });
-

--- a/examples/rgbpp/local/4-spend-btc-time-cell.ts
+++ b/examples/rgbpp/local/4-spend-btc-time-cell.ts
@@ -1,6 +1,4 @@
-import {
-  AddressPrefix, privateKeyToAddress,
-} from '@nervosnetwork/ckb-sdk-utils';
+import { AddressPrefix, privateKeyToAddress } from '@nervosnetwork/ckb-sdk-utils';
 import {
   Collector,
   sendCkbTx,
@@ -42,10 +40,10 @@ const spendBtcTimeCell = async ({ btcTimeCellArgs }: { btcTimeCellArgs: string }
   if (!btcTimeCells || btcTimeCells.length === 0) {
     throw new Error('No btc time cell found');
   }
-  
+
   const btcAssetsApi = BtcAssetsApi.fromToken(BTC_ASSETS_API_URL, BTC_ASSETS_TOKEN, BTC_ASSETS_ORIGIN);
 
-  let ckbRawTx: CKBComponents.RawTransaction = await buildBtcTimeCellsSpentTx({
+  const ckbRawTx: CKBComponents.RawTransaction = await buildBtcTimeCellsSpentTx({
     btcTimeCells,
     btcAssetsApi,
     isMainnet,

--- a/examples/rgbpp/local/batch/1-ckb-jump-btc.ts
+++ b/examples/rgbpp/local/batch/1-ckb-jump-btc.ts
@@ -35,7 +35,7 @@ const batchJumpFromCkbToBtc = async (rgbppReceivers: RgbppLockArgsReceiver[]) =>
   });
 
   const emptyWitness = { lock: '', inputType: '', outputType: '' };
-  let unsignedTx: CKBComponents.RawTransactionToSign = {
+  const unsignedTx: CKBComponents.RawTransactionToSign = {
     ...ckbRawTx,
     cellDeps: [...ckbRawTx.cellDeps, getSecp256k1CellDep(false)],
     witnesses: [emptyWitness, ...ckbRawTx.witnesses.slice(1)],
@@ -43,7 +43,7 @@ const batchJumpFromCkbToBtc = async (rgbppReceivers: RgbppLockArgsReceiver[]) =>
 
   const signedTx = collector.getCkb().signTransaction(CKB_TEST_PRIVATE_KEY)(unsignedTx);
 
-  let txHash = await collector.getCkb().rpc.sendTransaction(signedTx, 'passthrough');
+  const txHash = await collector.getCkb().rpc.sendTransaction(signedTx, 'passthrough');
   console.info(`Rgbpp asset has been jumped from CKB to BTC and tx hash is ${txHash}`);
 };
 
@@ -61,4 +61,3 @@ const rgbppReceivers: RgbppLockArgsReceiver[] = [
   },
 ];
 batchJumpFromCkbToBtc(rgbppReceivers);
-

--- a/examples/rgbpp/local/launch/0-rgbpp-token-info.ts
+++ b/examples/rgbpp/local/launch/0-rgbpp-token-info.ts
@@ -1,4 +1,4 @@
-import { RgbppTokenInfo } from "@rgbpp-sdk/ckb";
+import { RgbppTokenInfo } from '@rgbpp-sdk/ckb';
 
 export const RGBPP_TOKEN_INFO: RgbppTokenInfo = {
   decimal: 8,

--- a/examples/rgbpp/local/launch/1-prepare-launch.ts
+++ b/examples/rgbpp/local/launch/1-prepare-launch.ts
@@ -1,5 +1,18 @@
 import { AddressPrefix, addressToScript, getTransactionSize, privateKeyToAddress } from '@nervosnetwork/ckb-sdk-utils';
-import { Collector, MAX_FEE, NoLiveCellError, RgbppTokenInfo, SECP256K1_WITNESS_LOCK_SIZE, append0x, buildRgbppLockArgs, calculateRgbppCellCapacity, calculateRgbppTokenInfoCellCapacity, calculateTransactionFee, genRgbppLockScript, getSecp256k1CellDep } from '@rgbpp-sdk/ckb';
+import {
+  Collector,
+  MAX_FEE,
+  NoLiveCellError,
+  RgbppTokenInfo,
+  SECP256K1_WITNESS_LOCK_SIZE,
+  append0x,
+  buildRgbppLockArgs,
+  calculateRgbppCellCapacity,
+  calculateRgbppTokenInfoCellCapacity,
+  calculateTransactionFee,
+  genRgbppLockScript,
+  getSecp256k1CellDep,
+} from '@rgbpp-sdk/ckb';
 import { RGBPP_TOKEN_INFO } from './0-rgbpp-token-info';
 
 // CKB SECP256K1 private key
@@ -35,9 +48,9 @@ const prepareLaunchCell = async ({
   if (!emptyCells || emptyCells.length === 0) {
     throw new NoLiveCellError('The address has no empty cells');
   }
-  emptyCells = emptyCells.filter(cell => !cell.output.type)
+  emptyCells = emptyCells.filter((cell) => !cell.output.type);
 
-  let txFee = MAX_FEE;
+  const txFee = MAX_FEE;
   const { inputs, sumInputsCapacity } = collector.collectInputs(emptyCells, launchCellCapacity, txFee);
 
   const outputs: CKBComponents.CellOutput[] = [
@@ -84,4 +97,3 @@ prepareLaunchCell({
   btcTxId: '6259ea7852e294afbd2aaf9ccd5c9c1f95087b0b08ba7e47ae35ce31170732bc',
   rgbppTokenInfo: RGBPP_TOKEN_INFO,
 });
-

--- a/examples/rgbpp/local/launch/2-launch-rgbpp.ts
+++ b/examples/rgbpp/local/launch/2-launch-rgbpp.ts
@@ -1,4 +1,12 @@
-import { Collector, buildRgbppLockArgs, genRgbppLaunchCkbVirtualTx, RgbppTokenInfo, appendCkbTxWitnesses, updateCkbTxWithRealBtcTxId, sendCkbTx } from '@rgbpp-sdk/ckb';
+import {
+  Collector,
+  buildRgbppLockArgs,
+  genRgbppLaunchCkbVirtualTx,
+  RgbppTokenInfo,
+  appendCkbTxWitnesses,
+  updateCkbTxWithRealBtcTxId,
+  sendCkbTx,
+} from '@rgbpp-sdk/ckb';
 import { DataSource, ECPair, bitcoin, NetworkType, sendRgbppUtxos, transactionToHex } from '@rgbpp-sdk/btc';
 import { BtcAssetsApi, BtcAssetsApiError } from '@rgbpp-sdk/service';
 import { RGBPP_TOKEN_INFO } from './0-rgbpp-token-info';

--- a/examples/rgbpp/local/launch/3-distribute-rgbpp.ts
+++ b/examples/rgbpp/local/launch/3-distribute-rgbpp.ts
@@ -1,5 +1,15 @@
 import { AddressPrefix, privateKeyToAddress, serializeScript } from '@nervosnetwork/ckb-sdk-utils';
-import { Collector, RgbppBtcAddressReceiver, appendCkbTxWitnesses, appendIssuerCellToBtcBatchTransfer, buildRgbppLockArgs, genBtcBatchTransferCkbVirtualTx, getXudtTypeScript, sendCkbTx, updateCkbTxWithRealBtcTxId } from '@rgbpp-sdk/ckb';
+import {
+  Collector,
+  RgbppBtcAddressReceiver,
+  appendCkbTxWitnesses,
+  appendIssuerCellToBtcBatchTransfer,
+  buildRgbppLockArgs,
+  genBtcBatchTransferCkbVirtualTx,
+  getXudtTypeScript,
+  sendCkbTx,
+  updateCkbTxWithRealBtcTxId,
+} from '@rgbpp-sdk/ckb';
 import { sendRgbppUtxos, DataSource, ECPair, bitcoin, NetworkType, transactionToHex } from '@rgbpp-sdk/btc';
 import { BtcAssetsApi, BtcAssetsApiError } from '@rgbpp-sdk/service';
 import { RGBPP_TOKEN_INFO } from './0-rgbpp-token-info';
@@ -113,7 +123,6 @@ const distributeRgbppAssetOnBtc = async ({ rgbppLockArgsList, receivers }: Param
   }, 20 * 1000);
 };
 
-
 // Use your real BTC UTXO information on the BTC Testnet
 // rgbppLockArgs: outIndexU32 + btcTxId
 distributeRgbppAssetOnBtc({
@@ -126,4 +135,3 @@ distributeRgbppAssetOnBtc({
     },
   ],
 });
-

--- a/examples/rgbpp/local/transfer-btc.ts
+++ b/examples/rgbpp/local/transfer-btc.ts
@@ -1,4 +1,3 @@
-
 import { sendBtc, DataSource, NetworkType, bitcoin, ECPair } from '@rgbpp-sdk/btc';
 import { BtcAssetsApi } from '@rgbpp-sdk/service';
 
@@ -41,8 +40,8 @@ const transferBtc = async () => {
 
   // Broadcast transaction
   const tx = psbt.extractTransaction();
-  const { txid: txId} = await service.sendBtcTransaction(tx.toHex());
+  const { txid: txId } = await service.sendBtcTransaction(tx.toHex());
   console.log('txId:', txId);
-}
+};
 
 transferBtc();

--- a/examples/rgbpp/package.json
+++ b/examples/rgbpp/package.json
@@ -3,17 +3,25 @@
   "version": "0.1.0",
   "description": "Examples used for RGBPP assets issuance, transfer, and jumping between BTC and CKB",
   "private": true,
+  "type": "module",
+  "scripts": {
+    "format": "prettier --write '**/*.{js,ts}'",
+    "lint:fix": "pnpm eslint . && prettier --check '**/*.{js,ts}'"
+  },
   "dependencies": {
+    "@exact-realty/multipart-parser": "^1.0.13",
     "@nervosnetwork/ckb-sdk-utils": "^0.109.1",
     "@rgbpp-sdk/btc": "workspace:^",
     "@rgbpp-sdk/ckb": "workspace:^",
     "@rgbpp-sdk/service": "workspace:^",
-    "@exact-realty/multipart-parser": "^1.0.13",
     "@spore-sdk/core": "^0.2.0-beta.6",
     "axios": "^1.6.8"
   },
   "devDependencies": {
+    "@eslint/js": "^9.1.1",
     "@types/node": "^20.11.28",
-    "typescript": "^5.4.2"
+    "eslint": "^8.56.0",
+    "typescript": "^5.4.2",
+    "typescript-eslint": "^7.7.1"
   }
 }

--- a/examples/rgbpp/queue/1-ckb-jump-btc.ts
+++ b/examples/rgbpp/queue/1-ckb-jump-btc.ts
@@ -11,8 +11,8 @@ const jumpFromCkbToBtc = async ({ outIndex, btcTxId }: { outIndex: number; btcTx
   });
   const isMainnet = false;
   const address = privateKeyToAddress(CKB_TEST_PRIVATE_KEY, {
-      prefix: isMainnet ? AddressPrefix.Mainnet : AddressPrefix.Testnet,
-    });
+    prefix: isMainnet ? AddressPrefix.Mainnet : AddressPrefix.Testnet,
+  });
   console.log('ckb address: ', address);
 
   const toRgbppLockArgs = buildRgbppLockArgs(outIndex, btcTxId);
@@ -29,11 +29,11 @@ const jumpFromCkbToBtc = async ({ outIndex, btcTxId }: { outIndex: number; btcTx
     toRgbppLockArgs,
     xudtTypeBytes: serializeScript(xudtType),
     transferAmount: BigInt(800_0000_0000),
-    witnessLockPlaceholderSize: 1000
+    witnessLockPlaceholderSize: 1000,
   });
 
   const emptyWitness = { lock: '', inputType: '', outputType: '' };
-  let unsignedTx: CKBComponents.RawTransactionToSign = {
+  const unsignedTx: CKBComponents.RawTransactionToSign = {
     ...ckbRawTx,
     cellDeps: [...ckbRawTx.cellDeps, getSecp256k1CellDep(false)],
     witnesses: [emptyWitness, ...ckbRawTx.witnesses.slice(1)],
@@ -41,7 +41,7 @@ const jumpFromCkbToBtc = async ({ outIndex, btcTxId }: { outIndex: number; btcTx
 
   const signedTx = collector.getCkb().signTransaction(CKB_TEST_PRIVATE_KEY)(unsignedTx);
 
-  let txHash = await collector.getCkb().rpc.sendTransaction(signedTx, 'passthrough');
+  const txHash = await collector.getCkb().rpc.sendTransaction(signedTx, 'passthrough');
   console.info(`Rgbpp asset has been jumped from CKB to BTC and tx hash is ${txHash}`);
 };
 
@@ -50,4 +50,3 @@ jumpFromCkbToBtc({
   outIndex: 1,
   btcTxId: '4ff1855b64b309afa19a8b9be3d4da99dcb18b083b65d2d851662995c7d99e7a',
 });
-

--- a/examples/rgbpp/queue/2-btc-transfer.ts
+++ b/examples/rgbpp/queue/2-btc-transfer.ts
@@ -1,9 +1,5 @@
 import { AddressPrefix, privateKeyToAddress, serializeScript } from '@nervosnetwork/ckb-sdk-utils';
-import {
-  Collector,
-  buildRgbppLockArgs,
-  genBtcTransferCkbVirtualTx,
-} from '@rgbpp-sdk/ckb';
+import { Collector, buildRgbppLockArgs, genBtcTransferCkbVirtualTx } from '@rgbpp-sdk/ckb';
 import { sendRgbppUtxos, DataSource, ECPair, bitcoin, NetworkType } from '@rgbpp-sdk/btc';
 import { BtcAssetsApi } from '@rgbpp-sdk/service';
 
@@ -87,7 +83,7 @@ const transferRgbppOnBtc = async ({ rgbppLockArgsList, toBtcAddress, transferAmo
       const { state, failedReason } = await service.getRgbppTransactionState(btcTxId);
       console.log('state', state);
       if (state === 'completed' || state === 'failed') {
-        clearInterval(interval)
+        clearInterval(interval);
         if (state === 'completed') {
           const { txhash: txHash } = await service.getRgbppTransactionHash(btcTxId);
           console.info(`Rgbpp asset has been transferred on BTC and the related CKB tx hash is ${txHash}`);
@@ -95,12 +91,11 @@ const transferRgbppOnBtc = async ({ rgbppLockArgsList, toBtcAddress, transferAmo
           console.warn(`Rgbpp CKB transaction failed and the reason is ${failedReason} `);
         }
       }
-    }, 30 * 1000)
+    }, 30 * 1000);
   } catch (error) {
-    console.error(error)
+    console.error(error);
   }
 };
-
 
 // Use your real BTC UTXO information on the BTC Testnet
 // rgbppLockArgs: outIndexU32 + btcTxId
@@ -110,4 +105,3 @@ transferRgbppOnBtc({
   // To simplify, keep the transferAmount the same as 2-ckb-jump-btc
   transferAmount: BigInt(800_0000_0000),
 });
-

--- a/examples/rgbpp/queue/3-btc-jump-ckb.ts
+++ b/examples/rgbpp/queue/3-btc-jump-ckb.ts
@@ -1,17 +1,7 @@
 import { AddressPrefix, privateKeyToAddress, serializeScript } from '@nervosnetwork/ckb-sdk-utils';
-import {
-  Collector,
-  genBtcJumpCkbVirtualTx,
-  buildRgbppLockArgs,
-} from '@rgbpp-sdk/ckb';
-import {
-  sendRgbppUtxos,
-  DataSource,
-  NetworkType,
-  bitcoin,
-  ECPair,
-} from '@rgbpp-sdk/btc';
-import { BtcAssetsApi } from '@rgbpp-sdk/service'
+import { Collector, genBtcJumpCkbVirtualTx, buildRgbppLockArgs } from '@rgbpp-sdk/ckb';
+import { sendRgbppUtxos, DataSource, NetworkType, bitcoin, ECPair } from '@rgbpp-sdk/btc';
+import { BtcAssetsApi } from '@rgbpp-sdk/service';
 
 // CKB SECP256K1 private key
 const CKB_TEST_PRIVATE_KEY = '0x0000000000000000000000000000000000000000000000000000000000000001';
@@ -73,7 +63,7 @@ const jumpFromBtcToCkb = async ({ rgbppLockArgsList, toCkbAddress, transferAmoun
   const psbt = await sendRgbppUtxos({
     ckbVirtualTx: ckbRawTx,
     commitment,
-    tos: [btcAddress!], 
+    tos: [btcAddress!],
     ckbCollector: collector,
     from: btcAddress!,
     source,
@@ -115,4 +105,3 @@ jumpFromBtcToCkb({
   // To simplify, keep the transferAmount the same as 2-ckb-jump-btc
   transferAmount: BigInt(800_0000_0000),
 });
-

--- a/examples/rgbpp/queue/no-merge-outputs/2-btc-transfer.ts
+++ b/examples/rgbpp/queue/no-merge-outputs/2-btc-transfer.ts
@@ -56,7 +56,7 @@ const transferRgbppOnBtc = async ({ rgbppLockArgsList, toBtcAddress, transferAmo
     xudtTypeBytes: serializeScript(xudtType),
     transferAmount,
     isMainnet,
-    noMergeOutputCells: true
+    noMergeOutputCells: true,
   });
 
   const { commitment, ckbRawTx } = ckbVirtualTxResult;

--- a/examples/rgbpp/spore/0-cluster-info.ts
+++ b/examples/rgbpp/spore/0-cluster-info.ts
@@ -1,4 +1,4 @@
 export const CLUSTER_DATA = {
   name: 'Cluster name',
   description: 'Description of the cluster',
-}; 
+};

--- a/examples/rgbpp/spore/1-prepare-cluster.ts
+++ b/examples/rgbpp/spore/1-prepare-cluster.ts
@@ -16,13 +16,7 @@ import { CLUSTER_DATA } from './0-cluster-info';
 // CKB SECP256K1 private key
 const CKB_TEST_PRIVATE_KEY = '0x0000000000000000000000000000000000000000000000000000000000000001';
 
-const prepareClusterCell = async ({
-  outIndex,
-  btcTxId,
-}: {
-  outIndex: number;
-  btcTxId: string;
-}) => {
+const prepareClusterCell = async ({ outIndex, btcTxId }: { outIndex: number; btcTxId: string }) => {
   const collector = new Collector({
     ckbNodeUrl: 'https://testnet.ckb.dev/rpc',
     ckbIndexerUrl: 'https://testnet.ckb.dev/indexer',
@@ -45,7 +39,7 @@ const prepareClusterCell = async ({
   }
   emptyCells = emptyCells.filter((cell) => !cell.output.type);
 
-  let txFee = MAX_FEE;
+  const txFee = MAX_FEE;
   const { inputs, sumInputsCapacity } = collector.collectInputs(emptyCells, clusterCellCapacity, txFee);
 
   const outputs: CKBComponents.CellOutput[] = [

--- a/examples/rgbpp/spore/2-create-cluster.ts
+++ b/examples/rgbpp/spore/2-create-cluster.ts
@@ -45,7 +45,7 @@ const createCluster = async ({ ownerRgbppLockArgs }: { ownerRgbppLockArgs: strin
     rgbppLockArgs: ownerRgbppLockArgs,
     clusterData: CLUSTER_DATA,
     isMainnet,
-    ckbFeeRate: BigInt(5000)
+    ckbFeeRate: BigInt(5000),
   });
 
   const { commitment, ckbRawTx, clusterId } = ckbVirtualTxResult;
@@ -60,7 +60,7 @@ const createCluster = async ({ ownerRgbppLockArgs }: { ownerRgbppLockArgs: strin
     ckbCollector: collector,
     from: btcAddress!,
     source,
-    feeRate: 30
+    feeRate: 30,
   });
   psbt.signAllInputs(keyPair);
   psbt.finalizeAllInputs();
@@ -89,7 +89,7 @@ const createCluster = async ({ ownerRgbppLockArgs }: { ownerRgbppLockArgs: strin
         ckbTx.outputsData[0],
       );
 
-      console.log(JSON.stringify(ckbTx))
+      console.log(JSON.stringify(ckbTx));
 
       const txHash = await sendCkbTx({ collector, signedTx: ckbTx });
       console.info(`RGB++ Cluster has been created and tx hash is ${txHash}`);

--- a/examples/rgbpp/spore/3-create-spores.ts
+++ b/examples/rgbpp/spore/3-create-spores.ts
@@ -9,9 +9,17 @@ import {
   appendIssuerCellToSporesCreate,
   generateSporeCreateCoBuild,
 } from '@rgbpp-sdk/ckb';
-import { DataSource, ECPair, bitcoin, NetworkType, sendRgbppUtxos, transactionToHex, utf8ToBuffer } from '@rgbpp-sdk/btc';
+import {
+  DataSource,
+  ECPair,
+  bitcoin,
+  NetworkType,
+  sendRgbppUtxos,
+  transactionToHex,
+  utf8ToBuffer,
+} from '@rgbpp-sdk/btc';
 import { BtcAssetsApi, BtcAssetsApiError } from '@rgbpp-sdk/service';
-import { RawSporeData } from '@spore-sdk/core'
+import { RawSporeData } from '@spore-sdk/core';
 import { AddressPrefix, privateKeyToAddress } from '@nervosnetwork/ckb-sdk-utils';
 
 // CKB SECP256K1 private key
@@ -28,8 +36,8 @@ const BTC_ASSETS_ORIGIN = 'https://btc-test.app';
 interface Params {
   clusterRgbppLockArgs: Hex;
   receivers: {
-    toBtcAddress: string,
-    sporeData: RawSporeData
+    toBtcAddress: string;
+    sporeData: RawSporeData;
   }[];
 }
 
@@ -40,10 +48,10 @@ const createSpores = async ({ clusterRgbppLockArgs, receivers }: Params) => {
   });
   const isMainnet = false;
 
-   const ckbAddress = privateKeyToAddress(CKB_TEST_PRIVATE_KEY, {
-     prefix: isMainnet ? AddressPrefix.Mainnet : AddressPrefix.Testnet,
-   });
-   console.log('ckb address: ', ckbAddress);
+  const ckbAddress = privateKeyToAddress(CKB_TEST_PRIVATE_KEY, {
+    prefix: isMainnet ? AddressPrefix.Mainnet : AddressPrefix.Testnet,
+  });
+  console.log('ckb address: ', ckbAddress);
 
   const network = isMainnet ? bitcoin.networks.bitcoin : bitcoin.networks.testnet;
   const keyPair = ECPair.fromPrivateKey(Buffer.from(BTC_TEST_PRIVATE_KEY, 'hex'), { network });

--- a/examples/rgbpp/spore/4-transfer-spore.ts
+++ b/examples/rgbpp/spore/4-transfer-spore.ts
@@ -22,7 +22,13 @@ const BTC_ASSETS_TOKEN = '';
 
 const BTC_ASSETS_ORIGIN = 'https://btc-test.app';
 
-const transferSpore = async ({ sporeRgbppLockArgs, toBtcAddress }: { sporeRgbppLockArgs: Hex; toBtcAddress: string}) => {
+const transferSpore = async ({
+  sporeRgbppLockArgs,
+  toBtcAddress,
+}: {
+  sporeRgbppLockArgs: Hex;
+  toBtcAddress: string;
+}) => {
   const collector = new Collector({
     ckbNodeUrl: 'https://testnet.ckb.dev/rpc',
     ckbIndexerUrl: 'https://testnet.ckb.dev/indexer',

--- a/examples/rgbpp/spore/7-leap-spore-to-btc.ts
+++ b/examples/rgbpp/spore/7-leap-spore-to-btc.ts
@@ -37,7 +37,7 @@ const leapSporeFromCkbToBtc = async ({ outIndex, btcTxId }: { outIndex: number; 
   });
 
   const emptyWitness = { lock: '', inputType: '', outputType: '' };
-  let unsignedTx: CKBComponents.RawTransactionToSign = {
+  const unsignedTx: CKBComponents.RawTransactionToSign = {
     ...ckbRawTx,
     cellDeps: [...ckbRawTx.cellDeps, getSecp256k1CellDep(isMainnet)],
     witnesses: [emptyWitness, ...ckbRawTx.witnesses.slice(1)],
@@ -45,7 +45,7 @@ const leapSporeFromCkbToBtc = async ({ outIndex, btcTxId }: { outIndex: number; 
 
   const signedTx = collector.getCkb().signTransaction(CKB_TEST_PRIVATE_KEY)(unsignedTx);
 
-  let txHash = await collector.getCkb().rpc.sendTransaction(signedTx, 'passthrough');
+  const txHash = await collector.getCkb().rpc.sendTransaction(signedTx, 'passthrough');
   console.info(`RGB++ Spore has been jumped from CKB to BTC and tx hash is ${txHash}`);
 };
 

--- a/examples/rgbpp/spore/queue/4-transfer-spore.ts
+++ b/examples/rgbpp/spore/queue/4-transfer-spore.ts
@@ -1,10 +1,4 @@
-import {
-  Collector,
-  buildRgbppLockArgs,
-  getSporeTypeScript,
-  Hex,
-  genTransferSporeCkbVirtualTx,
-} from '@rgbpp-sdk/ckb';
+import { Collector, buildRgbppLockArgs, getSporeTypeScript, Hex, genTransferSporeCkbVirtualTx } from '@rgbpp-sdk/ckb';
 import { DataSource, ECPair, bitcoin, NetworkType, sendRgbppUtxos } from '@rgbpp-sdk/btc';
 import { BtcAssetsApi } from '@rgbpp-sdk/service';
 import { serializeScript } from '@nervosnetwork/ckb-sdk-utils';
@@ -18,7 +12,13 @@ const BTC_ASSETS_TOKEN = '';
 
 const BTC_ASSETS_ORIGIN = 'https://btc-test.app';
 
-const transferSpore = async ({ sporeRgbppLockArgs, toBtcAddress }: { sporeRgbppLockArgs: Hex; toBtcAddress: string}) => {
+const transferSpore = async ({
+  sporeRgbppLockArgs,
+  toBtcAddress,
+}: {
+  sporeRgbppLockArgs: Hex;
+  toBtcAddress: string;
+}) => {
   const collector = new Collector({
     ckbNodeUrl: 'https://testnet.ckb.dev/rpc',
     ckbIndexerUrl: 'https://testnet.ckb.dev/indexer',

--- a/examples/rgbpp/xudt/0-token-info.ts
+++ b/examples/rgbpp/xudt/0-token-info.ts
@@ -1,7 +1,7 @@
-import { RgbppTokenInfo } from "@rgbpp-sdk/ckb";
+import { RgbppTokenInfo } from '@rgbpp-sdk/ckb';
 
 export const XUDT_TOKEN_INFO: RgbppTokenInfo = {
   decimal: 8,
   name: 'XUDT Test Token',
-  symbol: 'XTT'
-}
+  symbol: 'XTT',
+};

--- a/examples/rgbpp/xudt/1-issue-xudt.ts
+++ b/examples/rgbpp/xudt/1-issue-xudt.ts
@@ -1,5 +1,28 @@
-import { AddressPrefix, addressToScript, getTransactionSize, privateKeyToAddress, scriptToHash } from '@nervosnetwork/ckb-sdk-utils';
-import { getSecp256k1CellDep,Collector, NoLiveCellError, calculateUdtCellCapacity, MAX_FEE, MIN_CAPACITY, getXudtTypeScript, append0x, getUniqueTypeScript, u128ToLe, encodeRgbppTokenInfo, getXudtDep, getUniqueTypeDep, SECP256K1_WITNESS_LOCK_SIZE, calculateTransactionFee, generateUniqueTypeArgs } from '@rgbpp-sdk/ckb';
+import {
+  AddressPrefix,
+  addressToScript,
+  getTransactionSize,
+  privateKeyToAddress,
+  scriptToHash,
+} from '@nervosnetwork/ckb-sdk-utils';
+import {
+  getSecp256k1CellDep,
+  Collector,
+  NoLiveCellError,
+  calculateUdtCellCapacity,
+  MAX_FEE,
+  MIN_CAPACITY,
+  getXudtTypeScript,
+  append0x,
+  getUniqueTypeScript,
+  u128ToLe,
+  encodeRgbppTokenInfo,
+  getXudtDep,
+  getUniqueTypeDep,
+  SECP256K1_WITNESS_LOCK_SIZE,
+  calculateTransactionFee,
+  generateUniqueTypeArgs,
+} from '@rgbpp-sdk/ckb';
 import { calculateXudtTokenInfoCellCapacity } from '@rgbpp-sdk/ckb/src/utils';
 import { XUDT_TOKEN_INFO } from './0-token-info';
 
@@ -34,20 +57,17 @@ const issueXudt = async ({ xudtTotalAmount }: { xudtTotalAmount: bigint }) => {
   const xudtCapacity = calculateUdtCellCapacity(issueLock);
   const xudtInfoCapacity = calculateXudtTokenInfoCellCapacity(XUDT_TOKEN_INFO, issueLock);
 
-  let txFee = MAX_FEE;
-  const { inputs, sumInputsCapacity } = collector.collectInputs(
-    emptyCells,
-    xudtCapacity + xudtInfoCapacity,
-    txFee,
-    { minCapacity: MIN_CAPACITY },
-  );
+  const txFee = MAX_FEE;
+  const { inputs, sumInputsCapacity } = collector.collectInputs(emptyCells, xudtCapacity + xudtInfoCapacity, txFee, {
+    minCapacity: MIN_CAPACITY,
+  });
 
   const xudtType: CKBComponents.Script = {
     ...getXudtTypeScript(isMainnet),
-    args: append0x(scriptToHash(issueLock))
-  }
+    args: append0x(scriptToHash(issueLock)),
+  };
 
-  console.log('xUDT type script', xudtType)
+  console.log('xUDT type script', xudtType);
 
   let changeCapacity = sumInputsCapacity - xudtCapacity - xudtInfoCapacity;
   const outputs: CKBComponents.CellOutput[] = [
@@ -58,9 +78,9 @@ const issueXudt = async ({ xudtTotalAmount }: { xudtTotalAmount: bigint }) => {
     },
     {
       lock: issueLock,
-      type: { 
+      type: {
         ...getUniqueTypeScript(isMainnet),
-        args: generateUniqueTypeArgs(inputs[0], 1)
+        args: generateUniqueTypeArgs(inputs[0], 1),
       },
       capacity: append0x(xudtInfoCapacity.toString(16)),
     },
@@ -100,4 +120,4 @@ const issueXudt = async ({ xudtTotalAmount }: { xudtTotalAmount: bigint }) => {
   console.info(`xUDT asset has been issued and tx hash is ${txHash}`);
 };
 
-issueXudt({xudtTotalAmount: BigInt(2100_0000)});
+issueXudt({ xudtTotalAmount: BigInt(2100_0000) });

--- a/examples/rgbpp/xudt/2-transfer-xudt.ts
+++ b/examples/rgbpp/xudt/2-transfer-xudt.ts
@@ -1,12 +1,26 @@
 import { AddressPrefix, addressToScript, getTransactionSize, privateKeyToAddress } from '@nervosnetwork/ckb-sdk-utils';
-import { getSecp256k1CellDep,Collector, NoLiveCellError, calculateUdtCellCapacity, MAX_FEE, MIN_CAPACITY, append0x, u128ToLe, getXudtDep, getUniqueTypeDep, SECP256K1_WITNESS_LOCK_SIZE, calculateTransactionFee, NoXudtLiveCellError } from '@rgbpp-sdk/ckb';
+import {
+  getSecp256k1CellDep,
+  Collector,
+  NoLiveCellError,
+  calculateUdtCellCapacity,
+  MAX_FEE,
+  MIN_CAPACITY,
+  append0x,
+  u128ToLe,
+  getXudtDep,
+  getUniqueTypeDep,
+  SECP256K1_WITNESS_LOCK_SIZE,
+  calculateTransactionFee,
+  NoXudtLiveCellError,
+} from '@rgbpp-sdk/ckb';
 import { XUDT_TOKEN_INFO } from './0-token-info';
 
 // CKB SECP256K1 private key
 const CKB_TEST_PRIVATE_KEY = '0x0000000000000000000000000000000000000000000000000000000000000001';
 
 interface TransferParams {
-  xudtType: CKBComponents.Script,
+  xudtType: CKBComponents.Script;
   receivers: {
     toAddress: string;
     transferAmount: bigint;
@@ -42,8 +56,8 @@ const transferXudt = async ({ xudtType, receivers }: TransferParams) => {
     .map((receiver) => receiver.transferAmount)
     .reduce((prev, current) => prev + current, BigInt(0));
 
-  let {
-    inputs,
+  const {
+    inputs: udtInputs,
     sumInputsCapacity: sumXudtInputsCapacity,
     sumAmount,
   } = collector.collectUdtInputs({
@@ -51,6 +65,7 @@ const transferXudt = async ({ xudtType, receivers }: TransferParams) => {
     needAmount: sumTransferAmount,
   });
   let actualInputsCapacity = sumXudtInputsCapacity;
+  let inputs = udtInputs;
 
   const xudtCapacity = calculateUdtCellCapacity(fromLock);
   const sumXudtCapacity = xudtCapacity * BigInt(receivers.length);
@@ -62,7 +77,7 @@ const transferXudt = async ({ xudtType, receivers }: TransferParams) => {
   }));
   const outputsData = receivers.map((receiver) => append0x(u128ToLe(receiver.transferAmount)));
 
-  let txFee = MAX_FEE;
+  const txFee = MAX_FEE;
   if (sumXudtInputsCapacity < sumXudtCapacity) {
     let emptyCells = await collector.getCells({
       lock: fromLock,
@@ -127,7 +142,6 @@ const transferXudt = async ({ xudtType, receivers }: TransferParams) => {
 
   console.info(`xUDT asset has been minted or transferred and tx hash is ${txHash}`);
 };
-
 
 transferXudt({
   // The xudtType comes from 1-issue-xudt

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -149,12 +149,21 @@ importers:
         specifier: ^1.6.8
         version: 1.6.8
     devDependencies:
+      '@eslint/js':
+        specifier: ^9.1.1
+        version: 9.1.1
       '@types/node':
         specifier: ^20.11.28
         version: 20.11.28
+      eslint:
+        specifier: ^8.56.0
+        version: 8.56.0
       typescript:
         specifier: ^5.4.2
         version: 5.4.2
+      typescript-eslint:
+        specifier: ^7.7.1
+        version: 7.7.1(eslint@8.56.0)(typescript@5.4.2)
 
   packages/btc:
     dependencies:
@@ -1405,6 +1414,11 @@ packages:
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dev: true
 
+  /@eslint/js@9.1.1:
+    resolution: {integrity: sha512-5WoDz3Y19Bg2BnErkZTp0en+c/i9PvgFS7MBe1+m60HjFr0hrphlAGp4yzI7pxpt4xShln4ZyYp4neJm8hmOkQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    dev: true
+
   /@exact-realty/multipart-parser@1.0.13:
     resolution: {integrity: sha512-BGnB0VVn18dkz85rvBmp/CyxAMvUcVrsNf3qw8Fdx80V6+MsQUTxRdQnC0PzLIxbN8PKGFs8afd+ur8V1JLv8g==}
     engines: {node: '>=16.0.0', npm: '>=8.0.0'}
@@ -2107,6 +2121,35 @@ packages:
       - supports-color
     dev: true
 
+  /@typescript-eslint/eslint-plugin@7.7.1(@typescript-eslint/parser@7.7.1)(eslint@8.56.0)(typescript@5.4.2):
+    resolution: {integrity: sha512-KwfdWXJBOviaBVhxO3p5TJiLpNuh2iyXyjmWN0f1nU87pwyvfS0EmjC6ukQVYVFJd/K1+0NWGPDXiyEyQorn0Q==}
+    engines: {node: ^18.18.0 || >=20.0.0}
+    peerDependencies:
+      '@typescript-eslint/parser': ^7.0.0
+      eslint: ^8.56.0
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@eslint-community/regexpp': 4.10.0
+      '@typescript-eslint/parser': 7.7.1(eslint@8.56.0)(typescript@5.4.2)
+      '@typescript-eslint/scope-manager': 7.7.1
+      '@typescript-eslint/type-utils': 7.7.1(eslint@8.56.0)(typescript@5.4.2)
+      '@typescript-eslint/utils': 7.7.1(eslint@8.56.0)(typescript@5.4.2)
+      '@typescript-eslint/visitor-keys': 7.7.1
+      debug: 4.3.4
+      eslint: 8.56.0
+      graphemer: 1.4.0
+      ignore: 5.3.1
+      natural-compare: 1.4.0
+      semver: 7.6.0
+      ts-api-utils: 1.3.0(typescript@5.4.2)
+      typescript: 5.4.2
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
   /@typescript-eslint/parser@7.0.2(eslint@8.56.0)(typescript@5.4.2):
     resolution: {integrity: sha512-GdwfDglCxSmU+QTS9vhz2Sop46ebNCXpPPvsByK7hu0rFGRHL+AusKQJ7SoN+LbLh6APFpQwHKmDSwN35Z700Q==}
     engines: {node: ^16.0.0 || >=18.0.0}
@@ -2128,12 +2171,41 @@ packages:
       - supports-color
     dev: true
 
+  /@typescript-eslint/parser@7.7.1(eslint@8.56.0)(typescript@5.4.2):
+    resolution: {integrity: sha512-vmPzBOOtz48F6JAGVS/kZYk4EkXao6iGrD838sp1w3NQQC0W8ry/q641KU4PrG7AKNAf56NOcR8GOpH8l9FPCw==}
+    engines: {node: ^18.18.0 || >=20.0.0}
+    peerDependencies:
+      eslint: ^8.56.0
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@typescript-eslint/scope-manager': 7.7.1
+      '@typescript-eslint/types': 7.7.1
+      '@typescript-eslint/typescript-estree': 7.7.1(typescript@5.4.2)
+      '@typescript-eslint/visitor-keys': 7.7.1
+      debug: 4.3.4
+      eslint: 8.56.0
+      typescript: 5.4.2
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
   /@typescript-eslint/scope-manager@7.0.2:
     resolution: {integrity: sha512-l6sa2jF3h+qgN2qUMjVR3uCNGjWw4ahGfzIYsCtFrQJCjhbrDPdiihYT8FnnqFwsWX+20hK592yX9I2rxKTP4g==}
     engines: {node: ^16.0.0 || >=18.0.0}
     dependencies:
       '@typescript-eslint/types': 7.0.2
       '@typescript-eslint/visitor-keys': 7.0.2
+    dev: true
+
+  /@typescript-eslint/scope-manager@7.7.1:
+    resolution: {integrity: sha512-PytBif2SF+9SpEUKynYn5g1RHFddJUcyynGpztX3l/ik7KmZEv19WCMhUBkHXPU9es/VWGD3/zg3wg90+Dh2rA==}
+    engines: {node: ^18.18.0 || >=20.0.0}
+    dependencies:
+      '@typescript-eslint/types': 7.7.1
+      '@typescript-eslint/visitor-keys': 7.7.1
     dev: true
 
   /@typescript-eslint/type-utils@7.0.2(eslint@8.56.0)(typescript@5.4.2):
@@ -2156,9 +2228,34 @@ packages:
       - supports-color
     dev: true
 
+  /@typescript-eslint/type-utils@7.7.1(eslint@8.56.0)(typescript@5.4.2):
+    resolution: {integrity: sha512-ZksJLW3WF7o75zaBPScdW1Gbkwhd/lyeXGf1kQCxJaOeITscoSl0MjynVvCzuV5boUz/3fOI06Lz8La55mu29Q==}
+    engines: {node: ^18.18.0 || >=20.0.0}
+    peerDependencies:
+      eslint: ^8.56.0
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@typescript-eslint/typescript-estree': 7.7.1(typescript@5.4.2)
+      '@typescript-eslint/utils': 7.7.1(eslint@8.56.0)(typescript@5.4.2)
+      debug: 4.3.4
+      eslint: 8.56.0
+      ts-api-utils: 1.3.0(typescript@5.4.2)
+      typescript: 5.4.2
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
   /@typescript-eslint/types@7.0.2:
     resolution: {integrity: sha512-ZzcCQHj4JaXFjdOql6adYV4B/oFOFjPOC9XYwCaZFRvqN8Llfvv4gSxrkQkd2u4Ci62i2c6W6gkDwQJDaRc4nA==}
     engines: {node: ^16.0.0 || >=18.0.0}
+    dev: true
+
+  /@typescript-eslint/types@7.7.1:
+    resolution: {integrity: sha512-AmPmnGW1ZLTpWa+/2omPrPfR7BcbUU4oha5VIbSbS1a1Tv966bklvLNXxp3mrbc+P2j4MNOTfDffNsk4o0c6/w==}
+    engines: {node: ^18.18.0 || >=20.0.0}
     dev: true
 
   /@typescript-eslint/typescript-estree@7.0.2(typescript@5.4.2):
@@ -2176,6 +2273,28 @@ packages:
       globby: 11.1.0
       is-glob: 4.0.3
       minimatch: 9.0.3
+      semver: 7.6.0
+      ts-api-utils: 1.3.0(typescript@5.4.2)
+      typescript: 5.4.2
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /@typescript-eslint/typescript-estree@7.7.1(typescript@5.4.2):
+    resolution: {integrity: sha512-CXe0JHCXru8Fa36dteXqmH2YxngKJjkQLjxzoj6LYwzZ7qZvgsLSc+eqItCrqIop8Vl2UKoAi0StVWu97FQZIQ==}
+    engines: {node: ^18.18.0 || >=20.0.0}
+    peerDependencies:
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@typescript-eslint/types': 7.7.1
+      '@typescript-eslint/visitor-keys': 7.7.1
+      debug: 4.3.4
+      globby: 11.1.0
+      is-glob: 4.0.3
+      minimatch: 9.0.4
       semver: 7.6.0
       ts-api-utils: 1.3.0(typescript@5.4.2)
       typescript: 5.4.2
@@ -2202,11 +2321,38 @@ packages:
       - typescript
     dev: true
 
+  /@typescript-eslint/utils@7.7.1(eslint@8.56.0)(typescript@5.4.2):
+    resolution: {integrity: sha512-QUvBxPEaBXf41ZBbaidKICgVL8Hin0p6prQDu6bbetWo39BKbWJxRsErOzMNT1rXvTll+J7ChrbmMCXM9rsvOQ==}
+    engines: {node: ^18.18.0 || >=20.0.0}
+    peerDependencies:
+      eslint: ^8.56.0
+    dependencies:
+      '@eslint-community/eslint-utils': 4.4.0(eslint@8.56.0)
+      '@types/json-schema': 7.0.15
+      '@types/semver': 7.5.8
+      '@typescript-eslint/scope-manager': 7.7.1
+      '@typescript-eslint/types': 7.7.1
+      '@typescript-eslint/typescript-estree': 7.7.1(typescript@5.4.2)
+      eslint: 8.56.0
+      semver: 7.6.0
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
+    dev: true
+
   /@typescript-eslint/visitor-keys@7.0.2:
     resolution: {integrity: sha512-8Y+YiBmqPighbm5xA2k4wKTxRzx9EkBu7Rlw+WHqMvRJ3RPz/BMBO9b2ru0LUNmXg120PHUXD5+SWFy2R8DqlQ==}
     engines: {node: ^16.0.0 || >=18.0.0}
     dependencies:
       '@typescript-eslint/types': 7.0.2
+      eslint-visitor-keys: 3.4.3
+    dev: true
+
+  /@typescript-eslint/visitor-keys@7.7.1:
+    resolution: {integrity: sha512-gBL3Eq25uADw1LQ9kVpf3hRM+DWzs0uZknHYK3hq4jcTPqVCClHGDnB6UUUV2SFeBeA4KWHWbbLqmbGcZ4FYbw==}
+    engines: {node: ^18.18.0 || >=20.0.0}
+    dependencies:
+      '@typescript-eslint/types': 7.7.1
       eslint-visitor-keys: 3.4.3
     dev: true
 
@@ -6091,6 +6237,25 @@ packages:
   /typeforce@1.18.0:
     resolution: {integrity: sha512-7uc1O8h1M1g0rArakJdf0uLRSSgFcYexrVoKo+bzJd32gd4gDy2L/Z+8/FjPnU9ydY3pEnVPtr9FyscYY60K1g==}
     dev: false
+
+  /typescript-eslint@7.7.1(eslint@8.56.0)(typescript@5.4.2):
+    resolution: {integrity: sha512-ykEBfa3xx3odjZy6GRED4SCPrjo0rgHwstLlEgLX4EMEuv7QeIDSmfV+S6Kk+XkbsYn4BDEcPvsci1X26lRpMQ==}
+    engines: {node: ^18.18.0 || >=20.0.0}
+    peerDependencies:
+      eslint: ^8.56.0
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@typescript-eslint/eslint-plugin': 7.7.1(@typescript-eslint/parser@7.7.1)(eslint@8.56.0)(typescript@5.4.2)
+      '@typescript-eslint/parser': 7.7.1(eslint@8.56.0)(typescript@5.4.2)
+      '@typescript-eslint/utils': 7.7.1(eslint@8.56.0)(typescript@5.4.2)
+      eslint: 8.56.0
+      typescript: 5.4.2
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
 
   /typescript@5.4.2:
     resolution: {integrity: sha512-+2/g0Fds1ERlP6JsakQQDXjZdZMM+rqpamFZJEKh4kwTIn3iDkgKtby0CeNd5ATNZ4Ry1ax15TMx0W2V+miizQ==}


### PR DESCRIPTION
## Main Changes

- Use `typescript-eslint` to check and format examples code
- Add `lint:fix` to the Github Actions test CI