### PR TITLE
refactor: use ESLint globally in the repo

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,20 @@
+{
+  "env": {
+    "browser": true,
+    "es2021": true
+  },
+  "extends": [
+    "eslint:recommended",
+    "plugin:@typescript-eslint/recommended"
+  ],
+  "parser": "@typescript-eslint/parser",
+  "parserOptions": {
+    "ecmaVersion": "latest",
+    "sourceType": "module"
+  },
+  "plugins": [
+    "@typescript-eslint"
+  ],
+  "rules": {
+  }
+}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -43,11 +43,11 @@ jobs:
       - name: Install dependencies
         run: pnpm i
 
-      - name: Lint packages
-        run: pnpm lint:fix
-
       - name: Build packages
         run: pnpm run build:packages
+
+      - name: Lint packages
+        run: pnpm run lint:packages
         
       - name: Run tests for packages
         run: pnpm run test:packages

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,1 @@
-#!/usr/bin/env sh
-. "$(dirname -- "$0")/_/husky.sh"
-
-npx lint-staged
+pnpm exec lint-staged

--- a/examples/rgbpp/eslint.config.js
+++ b/examples/rgbpp/eslint.config.js
@@ -1,6 +1,0 @@
-// @ts-check
-
-import eslint from '@eslint/js';
-import tseslint from 'typescript-eslint';
-
-export default tseslint.config(eslint.configs.recommended, ...tseslint.configs.recommended);

--- a/examples/rgbpp/package.json
+++ b/examples/rgbpp/package.json
@@ -6,7 +6,8 @@
   "type": "module",
   "scripts": {
     "format": "prettier --write '**/*.{js,ts}'",
-    "lint:fix": "pnpm eslint . && prettier --check '**/*.{js,ts}'"
+    "lint": "tsc && eslint . && prettier --check '**/*.{js,ts}'",
+    "lint:fix": "tsc && eslint --fix --ext .js,.ts . && prettier --write '**/*.{js,ts}'"
   },
   "dependencies": {
     "@exact-realty/multipart-parser": "^1.0.13",
@@ -18,10 +19,7 @@
     "axios": "^1.6.8"
   },
   "devDependencies": {
-    "@eslint/js": "^9.1.1",
     "@types/node": "^20.11.28",
-    "eslint": "^8.56.0",
-    "typescript": "^5.4.2",
-    "typescript-eslint": "^7.7.1"
+    "typescript": "^5.4.2"
   }
 }

--- a/examples/rgbpp/tsconfig.json
+++ b/examples/rgbpp/tsconfig.json
@@ -7,6 +7,7 @@
     "composite": false,
     "resolveJsonModule": true,
     "strictNullChecks": true,
+    "noEmit": true,
     "declaration": true,
     "declarationMap": true,
     "esModuleInterop": true,
@@ -18,7 +19,7 @@
     "noUnusedParameters": false,
     "preserveWatchOutput": true,
     "skipLibCheck": true,
-    "strict": true,
+    "strict": true
   },
   "include": ["local/**/*.ts", "queue/**/*.ts"],
   "exclude": ["node_modules"]

--- a/package.json
+++ b/package.json
@@ -7,10 +7,10 @@
   "scripts": {
     "prepare": "husky",
     "test:packages": "turbo run test --filter=./packages/*",
-    "build": "turbo run build",
     "build:packages": "turbo run build --filter=./packages/*",
     "lint:fix": "turbo run lint:fix",
-    "lint:fix-all": "prettier --write '{packages,apps, examples}/**/*.{js,jsx,ts,tsx,md,json}'",
+    "lint:packages": "turbo run lint --filter=./{packages,examples}/*",
+    "lint:fix-all": "prettier --write '{packages,apps,examples}/**/*.{js,jsx,ts,tsx,md,json}'",
     "clean": "turbo run clean",
     "clean:packages": "turbo run clean --filter=./packags/*",
     "clean:dependencies": "pnpm clean:sub-dependencies && rimraf node_modules",
@@ -20,6 +20,9 @@
   "devDependencies": {
     "@changesets/changelog-github": "^0.5.0",
     "@changesets/cli": "^2.27.1",
+    "@typescript-eslint/eslint-plugin": "^7.8.0",
+    "@typescript-eslint/parser": "^7.8.0",
+    "eslint": "^8.56.0",
     "husky": "^9.0.11",
     "lint-staged": "^15.2.2",
     "prettier": "^3.2.5",
@@ -29,7 +32,10 @@
     "typescript": "^5.4.3"
   },
   "lint-staged": {
-    "{packages,apps, examples}/**/*.{js,jsx,ts,tsx,md,json}": "prettier --ignore-unknown --write"
+    "{packages,apps,examples}/**/*.{js,jsx,ts,tsx,md,json}": [
+      "eslint --fix",
+      "prettier --ignore-unknown --write"
+    ]
   },
   "packageManager": "^pnpm@8.0.0",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "build:packages": "turbo run build --filter=./packages/*",
     "lint:fix": "turbo run lint:fix",
     "lint:packages": "turbo run lint --filter=./{packages,examples}/*",
-    "lint:fix-all": "prettier --write '{packages,apps,examples}/**/*.{js,jsx,ts,tsx,md,json}'",
+    "format": "prettier --write '{packages,apps,examples}/**/*.{js,jsx,ts,tsx,md,json}'",
     "clean": "turbo run clean",
     "clean:packages": "turbo run clean --filter=./packags/*",
     "clean:dependencies": "pnpm clean:sub-dependencies && rimraf node_modules",

--- a/packages/btc/package.json
+++ b/packages/btc/package.json
@@ -4,8 +4,8 @@
   "scripts": {
     "test": "vitest",
     "build": "tsc -p tsconfig.build.json",
-    "lint": "tsc && eslint --ext .js,.ts {src,tests}/** && prettier --check '{src,tests}/**/*.{js,ts}'",
-    "lint:fix": "tsc && eslint --fix --ext .js,.ts {src,tests}/** && prettier --write '{src,tests}/**/*.{js,ts}'",
+    "lint": "tsc && eslint '{src,tests}/**/*.{js,ts}' && prettier --check '{src,tests}/**/*.{js,ts}'",
+    "lint:fix": "tsc && eslint --fix '{src,tests}/**/*.{js,ts}' && prettier --write '{src,tests}/**/*.{js,ts}'",
     "clean": "pnpm run clean:cache & pnpm run clean:build",
     "clean:build": "rimraf lib && pnpm run clean:buildinfo",
     "clean:buildinfo": "rimraf tsconfig.*tsbuildinfo",

--- a/packages/btc/package.json
+++ b/packages/btc/package.json
@@ -4,8 +4,8 @@
   "scripts": {
     "test": "vitest",
     "build": "tsc -p tsconfig.build.json",
-    "lint": "prettier --check '{src,tests}/**/*.{js,jsx,ts,tsx}'",
-    "lint:fix": "prettier --write '{src,tests}/**/*.{js,jsx,ts,tsx}'",
+    "lint": "tsc && eslint --ext .js,.ts {src,tests}/** && prettier --check '{src,tests}/**/*.{js,ts}'",
+    "lint:fix": "tsc && eslint --fix --ext .js,.ts {src,tests}/** && prettier --write '{src,tests}/**/*.{js,ts}'",
     "clean": "pnpm run clean:cache & pnpm run clean:build",
     "clean:build": "rimraf lib && pnpm run clean:buildinfo",
     "clean:buildinfo": "rimraf tsconfig.*tsbuildinfo",

--- a/packages/btc/src/address.ts
+++ b/packages/btc/src/address.ts
@@ -154,7 +154,9 @@ export function decodeAddress(address: string): {
           dust: getAddressTypeDust(addressType),
         };
       }
-    } catch (e) {}
+    } catch (e) {
+      // Do nothing (no need to throw here)
+    }
   } else {
     try {
       decodeBase58 = bitcoin.address.fromBase58Check(address);
@@ -187,7 +189,9 @@ export function decodeAddress(address: string): {
           dust: getAddressTypeDust(addressType),
         };
       }
-    } catch (e) {}
+    } catch (e) {
+      // Do nothing (no need to throw here)
+    }
   }
 
   return {

--- a/packages/btc/src/query/source.ts
+++ b/packages/btc/src/query/source.ts
@@ -1,10 +1,4 @@
-import {
-  BtcApiRecommendedFeeRates,
-  BtcApiUtxoParams,
-  BtcAssetsApi,
-  BtcAssetsApiError,
-  ErrorCodes as ServiceErrorCodes,
-} from '@rgbpp-sdk/service';
+import { BtcApiUtxoParams, BtcAssetsApi, BtcAssetsApiError, ErrorCodes as ServiceErrorCodes } from '@rgbpp-sdk/service';
 import { Output, Utxo } from '../transaction/utxo';
 import { NetworkType } from '../preset/types';
 import { ErrorCodes, TxBuildError } from '../error';

--- a/packages/btc/src/transaction/embed.ts
+++ b/packages/btc/src/transaction/embed.ts
@@ -33,8 +33,8 @@ export function opReturnScriptPubKeyToData(script: Buffer): Buffer {
     throw TxBuildError.withComment(ErrorCodes.UNSUPPORTED_OP_RETURN_SCRIPT, script.toString('hex'));
   }
 
-  const [_op, data] = bitcoin.script.decompile(script)!;
-  return data as Buffer;
+  const res = bitcoin.script.decompile(script)!;
+  return res[1] as Buffer;
 }
 
 /**

--- a/packages/btc/src/utils.ts
+++ b/packages/btc/src/utils.ts
@@ -22,7 +22,7 @@ export function tweakSigner<T extends TweakableSigner>(
     tweakHash?: Buffer;
   },
 ): bitcoin.Signer {
-  let privateKey: Uint8Array | undefined = signer.privateKey ? new Uint8Array(signer.privateKey) : undefined;
+  let privateKey: Uint8Array | undefined = signer.privateKey;
   if (!privateKey) {
     throw new Error('Private key is required for tweaking signer!');
   }

--- a/packages/btc/src/utils.ts
+++ b/packages/btc/src/utils.ts
@@ -1,6 +1,10 @@
 import { bitcoin, ecc, ECPair } from './bitcoin';
 import { bytes } from '@ckb-lumos/codec';
 
+interface TweakableSigner extends bitcoin.Signer {
+  privateKey?: Buffer;
+}
+
 const textEncoder = new TextEncoder();
 
 export function toXOnly(pubKey: Buffer): Buffer {
@@ -11,14 +15,14 @@ function tapTweakHash(publicKey: Buffer, hash: Buffer | undefined): Buffer {
   return bitcoin.crypto.taggedHash('TapTweak', Buffer.concat(hash ? [publicKey, hash] : [publicKey]));
 }
 
-export function tweakSigner<T extends bitcoin.Signer>(
+export function tweakSigner<T extends TweakableSigner>(
   signer: T,
   options?: {
     network?: bitcoin.Network;
     tweakHash?: Buffer;
   },
 ): bitcoin.Signer {
-  let privateKey: Uint8Array | undefined = (signer as any).privateKey;
+  let privateKey: Uint8Array | undefined = signer.privateKey ? new Uint8Array(signer.privateKey) : undefined;
   if (!privateKey) {
     throw new Error('Private key is required for tweaking signer!');
   }
@@ -54,7 +58,7 @@ export function remove0x(hex: string): string {
  * utf8ToBuffer('hello') // => Uint8Array(5) [ 104, 101, 108, 108, 111 ]
  */
 export function utf8ToBuffer(text: string): Uint8Array {
-  let result = text.trim();
+  const result = text.trim();
   if (result.startsWith('0x')) {
     return bytes.bytify(result);
   }

--- a/packages/btc/src/utils.ts
+++ b/packages/btc/src/utils.ts
@@ -22,10 +22,11 @@ export function tweakSigner<T extends TweakableSigner>(
     tweakHash?: Buffer;
   },
 ): bitcoin.Signer {
-  let privateKey: Uint8Array | undefined = signer.privateKey;
-  if (!privateKey) {
+  if (!signer.privateKey) {
     throw new Error('Private key is required for tweaking signer!');
   }
+
+  let privateKey: Uint8Array = signer.privateKey;
   if (signer.publicKey[0] === 3) {
     privateKey = ecc.privateNegate(privateKey);
   }

--- a/packages/btc/tests/DataSource.test.ts
+++ b/packages/btc/tests/DataSource.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { service, source } from './shared/env';
+import { source } from './shared/env';
 import { ErrorCodes } from '../src';
 
 describe('DataSource', { retry: 3 }, () => {

--- a/packages/btc/vitest.config.mts
+++ b/packages/btc/vitest.config.mts
@@ -3,7 +3,8 @@ import { defineConfig } from 'vitest/config';
 export default defineConfig({
   test: {
     watch: false,
-    testTimeout: 10000,
+    testTimeout: 60000,
+    reporters: ['verbose'],
     exclude: ['lib', 'node_modules'],
   },
 });

--- a/packages/ckb/example/launch.ts
+++ b/packages/ckb/example/launch.ts
@@ -36,7 +36,7 @@ const launchRgbppAsset = async () => {
   });
 
   const emptyWitness = { lock: '', inputType: '', outputType: '' };
-  let unsignedTx: CKBComponents.RawTransactionToSign = {
+  const unsignedTx: CKBComponents.RawTransactionToSign = {
     ...ckbRawTx,
     cellDeps: [...ckbRawTx.cellDeps, getSecp256k1CellDep(false)],
     witnesses: [emptyWitness, ...ckbRawTx.witnesses.slice(1)],
@@ -44,7 +44,7 @@ const launchRgbppAsset = async () => {
 
   const signedTx = collector.getCkb().signTransaction(LAUNCH_SECP256K1_PRIVATE_KEY)(unsignedTx);
 
-  let txHash = await collector.getCkb().rpc.sendTransaction(signedTx, 'passthrough');
+  const txHash = await collector.getCkb().rpc.sendTransaction(signedTx, 'passthrough');
   console.info(`Rgbpp asset has been jumping from CKB to BTC and tx hash is ${txHash}`);
 };
 

--- a/packages/ckb/package.json
+++ b/packages/ckb/package.json
@@ -4,8 +4,8 @@
   "scripts": {
     "test": "vitest",
     "build": "tsc -p tsconfig.build.json",
-    "lint": "prettier --check 'src/**/*.{js,jsx,ts,tsx}'",
-    "lint:fix": "prettier --write 'src/**/*.{js,jsx,ts,tsx}'",
+    "lint": "tsc && eslint --ext .ts {src,example}/* && prettier --check '{src,example}/**/*.{js,ts}'",
+    "lint:fix": "tsc && eslint --fix --ext .ts {src,example}/* && prettier --write '{src,example}/**/*.{js,ts}'",
     "splitCells": "npx ts-node example/paymaster.ts",
     "clean": "pnpm run clean:cache & pnpm run clean:build",
     "clean:build": "rimraf lib && pnpm run clean:buildinfo",

--- a/packages/ckb/src/collector/index.ts
+++ b/packages/ckb/src/collector/index.ts
@@ -56,7 +56,7 @@ export class Collector {
     type?: CKBComponents.Script;
     isDataMustBeEmpty?: boolean;
     outputCapacityRange?: Hex[];
-  }): Promise<IndexerCell[] | undefined> {
+  }): Promise<IndexerCell[]> {
     let searchKey: IndexerSearchKey = {};
     if (lock) {
       searchKey = {
@@ -98,7 +98,11 @@ export class Collector {
       console.error(response.error);
       throw new IndexerError('Get cells from indexer error');
     } else {
-      return toCamelcase(response.result.objects);
+      const res = toCamelcase<IndexerCell[]>(response.result.objects);
+      if (res === null) {
+        throw new IndexerError('The response of indexer RPC get_cells is invalid');
+      }
+      return res;
     }
   }
 

--- a/packages/ckb/src/collector/index.ts
+++ b/packages/ckb/src/collector/index.ts
@@ -37,12 +37,12 @@ export class Collector {
     isDataMustBeEmpty?: boolean;
     outputCapacityRange?: Hex[];
   }): Promise<IndexerCell[] | undefined> {
-    let param: any = {
+    let param: unknown = {
       script_search_mode: 'exact',
     };
     if (lock) {
       param = {
-        ...param,
+        ...param!,
         script: parseScript(lock),
         script_type: 'lock',
         filter: {
@@ -53,19 +53,19 @@ export class Collector {
       };
     } else if (type) {
       param = {
-        ...param,
+        ...param!,
         script: parseScript(type),
         script_type: 'type',
       };
     }
-    let payload = {
+    const payload = {
       id: Math.floor(Math.random() * 100000),
       jsonrpc: '2.0',
       method: 'get_cells',
       params: [param, 'asc', '0x3E8'],
     };
     const body = JSON.stringify(payload, null, '  ');
-    let response = (
+    const response = (
       await axios({
         method: 'post',
         url: this.ckbIndexerUrl,
@@ -86,9 +86,9 @@ export class Collector {
 
   collectInputs(liveCells: IndexerCell[], needCapacity: bigint, fee: bigint, config?: CollectConfig): CollectResult {
     const changeCapacity = config?.minCapacity ?? MIN_CAPACITY;
-    let inputs: CKBComponents.CellInput[] = [];
+    const inputs: CKBComponents.CellInput[] = [];
     let sumInputsCapacity = BigInt(0);
-    for (let cell of liveCells) {
+    for (const cell of liveCells) {
       inputs.push({
         previousOutput: {
           txHash: cell.outPoint.txHash,
@@ -109,11 +109,11 @@ export class Collector {
   }
 
   collectUdtInputs({ liveCells, needAmount }: { liveCells: IndexerCell[]; needAmount: bigint }): CollectUdtResult {
-    let inputs: CKBComponents.CellInput[] = [];
+    const inputs: CKBComponents.CellInput[] = [];
     let sumInputsCapacity = BigInt(0);
     let sumAmount = BigInt(0);
     const isRgbppLock = liveCells.length > 0 && isRgbppLockCellIgnoreChain(liveCells[0].output);
-    for (let cell of liveCells) {
+    for (const cell of liveCells) {
       inputs.push({
         previousOutput: {
           txHash: cell.outPoint.txHash,

--- a/packages/ckb/src/collector/index.ts
+++ b/packages/ckb/src/collector/index.ts
@@ -7,7 +7,27 @@ import { CapacityNotEnoughError, IndexerError, UdtAmountNotEnoughError } from '.
 import { isRgbppLockCellIgnoreChain, leToU128 } from '../utils';
 import { Hex } from '../types';
 
-const parseScript = (script: CKBComponents.Script) => ({
+interface IndexerScript {
+  code_hash: Hex;
+  hash_type: Hex;
+  args: Hex;
+}
+
+interface IndexerSearchKey {
+  script?: IndexerScript;
+  script_type?: 'lock' | 'type';
+  script_search_mode?: 'prefix' | 'exact';
+  filter?: {
+    script?: IndexerScript;
+    script_len_range?: Hex[];
+    output_data_len_range?: Hex[];
+    output_capacity_range?: Hex[];
+    block_range?: Hex[];
+  };
+  with_data?: boolean;
+}
+
+const parseScript = (script: CKBComponents.Script): IndexerScript => ({
   code_hash: script.codeHash,
   hash_type: script.hashType,
   args: script.args,
@@ -37,23 +57,21 @@ export class Collector {
     isDataMustBeEmpty?: boolean;
     outputCapacityRange?: Hex[];
   }): Promise<IndexerCell[] | undefined> {
-    let param: unknown = {
-      script_search_mode: 'exact',
-    };
+    let searchKey: IndexerSearchKey = {};
     if (lock) {
-      param = {
-        ...param!,
+      searchKey = {
+        script_search_mode: 'exact',
         script: parseScript(lock),
         script_type: 'lock',
         filter: {
-          script: type ? parseScript(type) : null,
-          output_data_len_range: isDataMustBeEmpty && !type ? ['0x0', '0x1'] : null,
+          script: type ? parseScript(type) : undefined,
+          output_data_len_range: isDataMustBeEmpty && !type ? ['0x0', '0x1'] : undefined,
           output_capacity_range: outputCapacityRange,
         },
       };
     } else if (type) {
-      param = {
-        ...param!,
+      searchKey = {
+        script_search_mode: 'exact',
         script: parseScript(type),
         script_type: 'type',
       };
@@ -62,7 +80,7 @@ export class Collector {
       id: Math.floor(Math.random() * 100000),
       jsonrpc: '2.0',
       method: 'get_cells',
-      params: [param, 'asc', '0x3E8'],
+      params: [searchKey, 'asc', '0x3E8'],
     };
     const body = JSON.stringify(payload, null, '  ');
     const response = (
@@ -78,7 +96,7 @@ export class Collector {
     ).data;
     if (response.error) {
       console.error(response.error);
-      throw new IndexerError('Get cells error');
+      throw new IndexerError('Get cells from indexer error');
     } else {
       return toCamelcase(response.result.objects);
     }

--- a/packages/ckb/src/paymaster/index.ts
+++ b/packages/ckb/src/paymaster/index.ts
@@ -29,7 +29,7 @@ export const splitMultiCellsWithSecp256k1 = async ({
 
   const cellCapacity = BigInt(capacityWithCKB) * CKB_UNIT;
   const needCapacity = cellCapacity * BigInt(cellAmount);
-  let txFee = MAX_FEE;
+  const txFee = MAX_FEE;
   const { inputs, sumInputsCapacity } = collector.collectInputs(emptyCells, needCapacity, txFee, {
     minCapacity: SECP256K1_MIN_CAPACITY,
   });

--- a/packages/ckb/src/rgbpp/btc-time.ts
+++ b/packages/ckb/src/rgbpp/btc-time.ts
@@ -157,7 +157,7 @@ export const signBtcTimeCellSpentTx = async ({
   const changeCapacity = BigInt(emptyCells[0].output.capacity) - estimatedTxFee;
   rawTx.outputs[0].capacity = append0x(changeCapacity.toString(16));
 
-  let keyMap = new Map<string, string>();
+  const keyMap = new Map<string, string>();
   keyMap.set(scriptToHash(masterLock), secp256k1PrivateKey);
   keyMap.set(scriptToHash(getBtcTimeLockScript(isMainnet)), '');
 

--- a/packages/ckb/src/rgbpp/btc-transfer.ts
+++ b/packages/ckb/src/rgbpp/btc-transfer.ts
@@ -94,8 +94,8 @@ export const genBtcTransferCkbVirtualTx = async ({
 
   let inputs: CKBComponents.CellInput[] = [];
   let sumInputsCapacity = BigInt(0);
-  let outputs: CKBComponents.CellOutput[] = [];
-  let outputsData: Hex[] = [];
+  const outputs: CKBComponents.CellOutput[] = [];
+  const outputsData: Hex[] = [];
 
   // The non-target RGBPP outputs correspond to the RGBPP inputs one-to-one, and the outputs are still bound to the sender’s BTC UTXOs
   const handleNonTargetRgbppCells = (targetRgbppOutputLen: number) => {
@@ -333,7 +333,7 @@ export const appendIssuerCellToBtcBatchTransfer = async ({
   isMainnet,
   ckbFeeRate,
 }: AppendIssuerCellToBtcBatchTransfer): Promise<CKBComponents.RawTransaction> => {
-  let rawTx = ckbRawTx as CKBComponents.RawTransactionToSign;
+  const rawTx = ckbRawTx as CKBComponents.RawTransactionToSign;
 
   const rgbppInputsLength = rawTx.inputs.length;
 
@@ -349,7 +349,7 @@ export const appendIssuerCellToBtcBatchTransfer = async ({
   emptyCells = emptyCells.filter((cell) => !cell.output.type);
 
   let actualInputsCapacity = BigInt(sumInputsCapacity);
-  let txFee = MAX_FEE;
+  const txFee = MAX_FEE;
   if (actualInputsCapacity <= sumOutputsCapacity) {
     const needCapacity = sumOutputsCapacity - actualInputsCapacity + MIN_CAPACITY;
     const { inputs, sumInputsCapacity: sumEmptyCapacity } = collector.collectInputs(emptyCells, needCapacity, txFee);
@@ -370,7 +370,7 @@ export const appendIssuerCellToBtcBatchTransfer = async ({
   changeCapacity -= estimatedTxFee;
   rawTx.outputs[rawTx.outputs.length - 1].capacity = append0x(changeCapacity.toString(16));
 
-  let keyMap = new Map<string, string>();
+  const keyMap = new Map<string, string>();
   keyMap.set(scriptToHash(issuerLock), secp256k1PrivateKey);
   keyMap.set(scriptToHash(getRgbppLockScript(isMainnet)), '');
 

--- a/packages/ckb/src/rgbpp/ckb-builder.ts
+++ b/packages/ckb/src/rgbpp/ckb-builder.ts
@@ -61,7 +61,7 @@ export const appendCkbTxWitnesses = async ({
   btcTxBytes,
   rgbppApiSpvProof,
 }: AppendWitnessesParams): Promise<CKBComponents.RawTransaction> => {
-  let rawTx = ckbRawTx;
+  const rawTx = ckbRawTx;
 
   const { spvClient, proof } = transformSpvProof(rgbppApiSpvProof);
   rawTx.cellDeps.push(buildSpvClientCellDep(spvClient));
@@ -89,7 +89,7 @@ export const appendPaymasterCellAndSignCkbTx = async ({
   isMainnet,
   ckbFeeRate,
 }: AppendPaymasterCellAndSignTxParams): Promise<CKBComponents.RawTransaction> => {
-  let rawTx = ckbRawTx as CKBComponents.RawTransactionToSign;
+  const rawTx = ckbRawTx as CKBComponents.RawTransactionToSign;
   const paymasterInput = { previousOutput: paymasterCell.outPoint, since: '0x0' };
   rawTx.inputs = [...rawTx.inputs, paymasterInput];
   const inputsCapacity = BigInt(sumInputsCapacity) + BigInt(paymasterCell.output.capacity);
@@ -115,7 +115,7 @@ export const appendPaymasterCellAndSignCkbTx = async ({
   changeCapacity -= estimatedTxFee;
   rawTx.outputs[rawTx.outputs.length - 1].capacity = append0x(changeCapacity.toString(16));
 
-  let keyMap = new Map<string, string>();
+  const keyMap = new Map<string, string>();
   keyMap.set(scriptToHash(paymasterCell.output.lock), secp256k1PrivateKey);
   keyMap.set(scriptToHash(getRgbppLockScript(isMainnet)), '');
 

--- a/packages/ckb/src/rgbpp/ckb-jump-btc.ts
+++ b/packages/ckb/src/rgbpp/ckb-jump-btc.ts
@@ -46,10 +46,13 @@ export const genCkbJumpBtcVirtualTx = async ({
     throw new NoXudtLiveCellError('No rgbpp cells found with the xudt type script and the rgbpp lock args');
   }
 
-  let { inputs, sumInputsCapacity, sumAmount } = collector.collectUdtInputs({
+  const collected = collector.collectUdtInputs({
     liveCells: xudtCells,
     needAmount: transferAmount,
   });
+
+  let { inputs, sumInputsCapacity } = collected;
+  const { sumAmount } = collected;
 
   const rpbppCellCapacity = calculateRgbppCellCapacity(xudtType);
   const outputsData = [append0x(u128ToLe(transferAmount))];
@@ -62,7 +65,7 @@ export const genCkbJumpBtcVirtualTx = async ({
     },
   ];
 
-  let txFee = MAX_FEE;
+  const txFee = MAX_FEE;
   const xudtCellCapacity = calculateUdtCellCapacity(fromLock, xudtType);
   if (sumInputsCapacity < xudtCellCapacity + rpbppCellCapacity + MIN_CAPACITY + txFee) {
     let emptyCells = await collector.getCells({ lock: fromLock });
@@ -96,7 +99,7 @@ export const genCkbJumpBtcVirtualTx = async ({
   outputsData.push('0x');
 
   const cellDeps = [getXudtDep(isMainnet)];
-  const witnesses = inputs.map((_) => '0x');
+  const witnesses = inputs.map(() => '0x');
 
   const ckbRawTx: CKBComponents.RawTransaction = {
     version: '0x0',
@@ -153,10 +156,13 @@ export const genCkbBatchJumpBtcVirtualTx = async ({
     .map((receiver) => receiver.transferAmount)
     .reduce((prev, current) => prev + current, BigInt(0));
 
-  let { inputs, sumInputsCapacity, sumAmount } = collector.collectUdtInputs({
+  const collected = collector.collectUdtInputs({
     liveCells: xudtCells,
     needAmount: sumTransferAmount,
   });
+
+  let { inputs, sumInputsCapacity } = collected;
+  const { sumAmount } = collected;
 
   const rpbppCellCapacity = calculateRgbppCellCapacity(xudtType);
   const sumRgbppCellCapacity = rpbppCellCapacity * BigInt(rgbppReceivers.length);
@@ -167,7 +173,7 @@ export const genCkbBatchJumpBtcVirtualTx = async ({
   }));
   const outputsData = rgbppReceivers.map((receiver) => append0x(u128ToLe(receiver.transferAmount)));
 
-  let txFee = MAX_FEE;
+  const txFee = MAX_FEE;
   const xudtCellCapacity = calculateUdtCellCapacity(fromLock, xudtType);
   if (sumInputsCapacity < xudtCellCapacity + sumRgbppCellCapacity + MIN_CAPACITY + txFee) {
     let emptyCells = await collector.getCells({ lock: fromLock });
@@ -201,7 +207,7 @@ export const genCkbBatchJumpBtcVirtualTx = async ({
   outputsData.push('0x');
 
   const cellDeps = [getXudtDep(isMainnet)];
-  const witnesses = inputs.map((_) => '0x');
+  const witnesses = inputs.map(() => '0x');
 
   const ckbRawTx: CKBComponents.RawTransaction = {
     version: '0x0',

--- a/packages/ckb/src/rgbpp/launch.ts
+++ b/packages/ckb/src/rgbpp/launch.ts
@@ -2,7 +2,6 @@ import { RgbppCkbVirtualTx, RgbppLaunchCkbVirtualTxParams, RgbppLaunchVirtualTxR
 import { NoLiveCellError } from '../error';
 import {
   append0x,
-  calculateRgbppCellCapacity,
   calculateRgbppTokenInfoCellCapacity,
   calculateTransactionFee,
   generateUniqueTypeArgs,
@@ -57,7 +56,7 @@ export const genRgbppLaunchCkbVirtualTx = async ({
   emptyCells = emptyCells.filter((cell) => !cell.output.type);
   const infoCellCapacity = calculateRgbppTokenInfoCellCapacity(rgbppTokenInfo, isMainnet);
 
-  let txFee = MAX_FEE;
+  const txFee = MAX_FEE;
   const { inputs, sumInputsCapacity } = collector.collectInputs(emptyCells, infoCellCapacity, txFee, { isMax: true });
 
   let rgbppCellCapacity = sumInputsCapacity - infoCellCapacity;

--- a/packages/ckb/src/spore/spore.ts
+++ b/packages/ckb/src/spore/spore.ts
@@ -5,14 +5,12 @@ import {
   calculateRgbppSporeCellCapacity,
   calculateTransactionFee,
   isClusterSporeTypeSupported,
-  isScriptEqual,
 } from '../utils';
-import { buildPreLockArgs, calculateCommitment, genBtcTimeLockScript, genRgbppLockScript } from '../utils/rgbpp';
+import { buildPreLockArgs, calculateCommitment, genRgbppLockScript } from '../utils/rgbpp';
 import {
   AppendIssuerCellToSporeCreate,
   CreateSporeCkbVirtualTxParams,
   Hex,
-  LeapSporeFromBtcToCkbVirtualTxParams,
   SporeCreateVirtualTxResult,
   SporeTransferVirtualTxResult,
   TransferSporeCkbVirtualTxParams,
@@ -40,7 +38,6 @@ import {
 import {
   NoLiveCellError,
   NoRgbppLiveCellError,
-  RgbppSporeTypeMismatchError,
   RgbppUtxoBindMultiTypeAssetsError,
   TypeAssetNotSupportedError,
 } from '../error';
@@ -176,7 +173,7 @@ export const appendIssuerCellToSporesCreate = async ({
   isMainnet,
   ckbFeeRate,
 }: AppendIssuerCellToSporeCreate): Promise<CKBComponents.RawTransaction> => {
-  let rawTx = ckbRawTx as CKBComponents.RawTransactionToSign;
+  const rawTx = ckbRawTx as CKBComponents.RawTransactionToSign;
 
   const rgbppInputsLength = rawTx.inputs.length;
 
@@ -192,7 +189,7 @@ export const appendIssuerCellToSporesCreate = async ({
   emptyCells = emptyCells.filter((cell) => !cell.output.type);
 
   let actualInputsCapacity = BigInt(sumInputsCapacity);
-  let txFee = MAX_FEE;
+  const txFee = MAX_FEE;
   if (actualInputsCapacity <= sumOutputsCapacity) {
     const needCapacity = sumOutputsCapacity - actualInputsCapacity + MIN_CAPACITY;
     const { inputs, sumInputsCapacity: sumEmptyCapacity } = collector.collectInputs(emptyCells, needCapacity, txFee);
@@ -215,7 +212,7 @@ export const appendIssuerCellToSporesCreate = async ({
   changeCapacity -= estimatedTxFee;
   rawTx.outputs[rawTx.outputs.length - 1].capacity = append0x(changeCapacity.toString(16));
 
-  let keyMap = new Map<string, string>();
+  const keyMap = new Map<string, string>();
   keyMap.set(scriptToHash(issuerLock), secp256k1PrivateKey);
   keyMap.set(scriptToHash(getRgbppLockScript(isMainnet)), '');
 

--- a/packages/ckb/src/types/spore.ts
+++ b/packages/ckb/src/types/spore.ts
@@ -1,4 +1,4 @@
-import { RawClusterData, RawSporeData, transferSpore } from '@spore-sdk/core';
+import { RawClusterData, RawSporeData } from '@spore-sdk/core';
 import { Address, Hex } from './common';
 import { Collector } from '../collector';
 import { IndexerCell } from './collector';

--- a/packages/ckb/src/utils/case-parser.spec.ts
+++ b/packages/ckb/src/utils/case-parser.spec.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from 'vitest';
+import { toCamelcase } from './case-parser';
+
+interface TestType {
+  firstField: number;
+  secondField: string[];
+  thirdField: { subFirstField: boolean; subSecondField: 'abc' };
+}
+
+describe('case parser', () => {
+  it('toCamelcase', () => {
+    const result = toCamelcase<TestType>({
+      first_field: 1,
+      second_field: ['0', '1'],
+      third_field: { sub_first_field: false, sub_second_field: 'abc' },
+    });
+    expect(1).toBe(result?.firstField);
+    expect('0').toBe(result?.secondField[0]);
+    expect('abc').toBe(result?.thirdField.subSecondField);
+
+    const list = toCamelcase<TestType[]>([
+      {
+        first_field: 1,
+        second_field: ['0', '1'],
+        third_field: { sub_first_field: false, sub_second_field: 'abc' },
+      },
+    ]);
+    expect(1).toBe(list![0].firstField);
+    expect('0').toBe(list![0].secondField[0]);
+    expect('abc').toBe(list![0].thirdField.subSecondField);
+  });
+});

--- a/packages/ckb/src/utils/case-parser.ts
+++ b/packages/ckb/src/utils/case-parser.ts
@@ -1,10 +1,10 @@
 import camelcaseKeys from 'camelcase-keys';
 
-export const toCamelcase = (object: any) => {
+export const toCamelcase = (object: unknown) => {
   try {
     return JSON.parse(
       JSON.stringify(
-        camelcaseKeys(object, {
+        camelcaseKeys(object!, {
           deep: true,
         }),
       ),

--- a/packages/ckb/src/utils/case-parser.ts
+++ b/packages/ckb/src/utils/case-parser.ts
@@ -1,14 +1,10 @@
 import camelcaseKeys from 'camelcase-keys';
 
-export const toCamelcase = (object: unknown) => {
+export const toCamelcase = <T>(obj: object): T | null => {
   try {
-    return JSON.parse(
-      JSON.stringify(
-        camelcaseKeys(object!, {
-          deep: true,
-        }),
-      ),
-    );
+    return camelcaseKeys(obj, {
+      deep: true,
+    }) as T;
   } catch (error) {
     console.error(error);
   }

--- a/packages/ckb/src/utils/ckb-tx.ts
+++ b/packages/ckb/src/utils/ckb-tx.ts
@@ -11,7 +11,6 @@ import {
 import { Hex, RgbppTokenInfo } from '../types';
 import { PERSONAL, blake2b, hexToBytes, serializeInput, serializeScript } from '@nervosnetwork/ckb-sdk-utils';
 import { encodeRgbppTokenInfo, genBtcTimeLockScript } from './rgbpp';
-import { blockchain } from '@ckb-lumos/base';
 
 export const calculateTransactionFee = (txSize: number, feeRate?: bigint): bigint => {
   const rate = feeRate ?? BigInt(1100);

--- a/packages/ckb/src/utils/hex.ts
+++ b/packages/ckb/src/utils/hex.ts
@@ -17,22 +17,22 @@ const ArrayBufferToHex = (arrayBuffer: ArrayBuffer): string => {
 };
 
 export const u8ToHex = (u8: number): string => {
-  let buffer = new ArrayBuffer(1);
-  let view = new DataView(buffer);
+  const buffer = new ArrayBuffer(1);
+  const view = new DataView(buffer);
   view.setUint8(0, u8);
   return ArrayBufferToHex(buffer);
 };
 
 export const u16ToLe = (u16: number): string => {
-  let buffer = new ArrayBuffer(2);
-  let view = new DataView(buffer);
+  const buffer = new ArrayBuffer(2);
+  const view = new DataView(buffer);
   view.setUint16(0, u16, true);
   return ArrayBufferToHex(buffer);
 };
 
 const u32ToHex = (u32: string | number, littleEndian?: boolean): string => {
-  let buffer = new ArrayBuffer(4);
-  let view = new DataView(buffer);
+  const buffer = new ArrayBuffer(4);
+  const view = new DataView(buffer);
   view.setUint32(0, Number(u32), littleEndian);
   return ArrayBufferToHex(buffer);
 };

--- a/packages/ckb/src/utils/rgbpp.ts
+++ b/packages/ckb/src/utils/rgbpp.ts
@@ -62,7 +62,7 @@ export const genBtcTimeLockScript = (toLock: CKBComponents.Script, isMainnet: bo
 const MAX_RGBPP_CELL_NUM = 255;
 // refer to https://github.com/ckb-cell/rgbpp/blob/0c090b039e8d026aad4336395b908af283a70ebf/contracts/rgbpp-lock/src/main.rs#L173-L211
 export const calculateCommitment = (rgbppVirtualTx: RgbppCkbVirtualTx | CKBComponents.RawTransaction): Hex => {
-  var hash = sha256.create();
+  const hash = sha256.create();
   hash.update(hexToBytes(utf8ToHex('RGB++')));
   const version = [0, 0];
   hash.update(version);

--- a/packages/ckb/src/utils/spore.spec.ts
+++ b/packages/ckb/src/utils/spore.spec.ts
@@ -9,7 +9,6 @@ import { IndexerCell } from '../types';
 import { getSporeTypeScript } from '../constants';
 import { serializeScript } from '@nervosnetwork/ckb-sdk-utils';
 import { NoRgbppLiveCellError, RgbppSporeTypeMismatchError, RgbppUtxoBindMultiTypeAssetsError } from '../error';
-import { throwErrorWhenRgbppCellsInvalid } from './rgbpp';
 
 describe('spore utils', () => {
   it('generateClusterId', () => {

--- a/packages/ckb/src/utils/spore.ts
+++ b/packages/ckb/src/utils/spore.ts
@@ -1,6 +1,8 @@
 import { PERSONAL, blake2b, hexToBytes, serializeInput } from '@nervosnetwork/ckb-sdk-utils';
 import { Cell as LumosCell } from '@ckb-lumos/base';
+import { UnpackResult } from '@ckb-lumos/codec';
 import {
+  Action,
   assembleTransferSporeAction,
   assembleCobuildWitnessLayout,
   assembleCreateClusterAction,
@@ -47,7 +49,7 @@ export const generateSporeCreateCoBuild = ({
   if (sporeOutputs.length !== sporeOutputsData.length) {
     throw new Error('The length of spore outputs and spore cell data are not same');
   }
-  let sporeActions: any[] = [];
+  let sporeActions: UnpackResult<typeof Action>[] = [];
 
   // cluster transfer actions
   const clusterInput = {
@@ -80,10 +82,10 @@ export const generateSporeTransferCoBuild = (
   if (sporeCells.length !== outputCells.length) {
     throw new Error('The length of spore input cells and spore output cells are not same');
   }
-  let sporeActions: any[] = [];
+  let sporeActions: UnpackResult<typeof Action>[] = [];
   for (let index = 0; index < sporeCells.length; index++) {
     const sporeCell = sporeCells[index];
-    const outputData = 'outputData' in sporeCell ? sporeCell.outputData : sporeCell.data?.content!;
+    const outputData = 'outputData' in sporeCell ? sporeCell.outputData : sporeCell.data!.content!;
     const sporeInput = {
       cellOutput: sporeCells[index].output,
       data: outputData,

--- a/packages/ckb/tsconfig.json
+++ b/packages/ckb/tsconfig.json
@@ -15,6 +15,7 @@
     "composite": false,
     "resolveJsonModule": true,
     "strictNullChecks": true,
+    "noEmit": true,
     "declaration": true,
     "declarationMap": true,
     "esModuleInterop": true,

--- a/packages/ckb/vitest.config.mts
+++ b/packages/ckb/vitest.config.mts
@@ -3,6 +3,7 @@ import { defineConfig } from 'vitest/config';
 export default defineConfig({
   test: {
     watch: false,
+    reporters: ['verbose'],
     exclude: ['lib', 'node_modules'],
   },
 });

--- a/packages/service/package.json
+++ b/packages/service/package.json
@@ -4,8 +4,8 @@
   "scripts": {
     "test": "vitest",
     "build": "tsc -p tsconfig.build.json",
-    "lint": "tsc && eslint --ext .js,.ts {src,tests}/** && prettier --check '{src,tests}/**/*.{js,ts}'",
-    "lint:fix": "tsc && eslint --fix --ext .js,.ts {src,tests}/** && prettier --write '{src,tests}/**/*.{js,ts}'",
+    "lint": "tsc && eslint '{src,tests}/**/*.{js,ts}' && prettier --check '{src,tests}/**/*.{js,ts}'",
+    "lint:fix": "tsc && eslint --fix '{src,tests}/**/*.{js,ts}' && prettier --write '{src,tests}/**/*.{js,ts}'",
     "clean": "pnpm run clean:cache & pnpm run clean:build",
     "clean:build": "rimraf lib && pnpm run clean:buildinfo",
     "clean:buildinfo": "rimraf tsconfig.*tsbuildinfo",

--- a/packages/service/package.json
+++ b/packages/service/package.json
@@ -4,8 +4,8 @@
   "scripts": {
     "test": "vitest",
     "build": "tsc -p tsconfig.build.json",
-    "lint": "prettier --check '{src,tests}/**/*.{js,jsx,ts,tsx}'",
-    "lint:fix": "prettier --write '{src,tests}/**/*.{js,jsx,ts,tsx}'",
+    "lint": "tsc && eslint --ext .js,.ts {src,tests}/** && prettier --check '{src,tests}/**/*.{js,ts}'",
+    "lint:fix": "tsc && eslint --fix --ext .js,.ts {src,tests}/** && prettier --write '{src,tests}/**/*.{js,ts}'",
     "clean": "pnpm run clean:cache & pnpm run clean:build",
     "clean:build": "rimraf lib && pnpm run clean:buildinfo",
     "clean:buildinfo": "rimraf tsconfig.*tsbuildinfo",

--- a/packages/service/src/service/base.ts
+++ b/packages/service/src/service/base.ts
@@ -1,7 +1,7 @@
 import pickBy from 'lodash/pickBy';
 import { isDomain } from '../utils';
 import { BtcAssetsApiError, ErrorCodes } from '../error';
-import { BaseApis, BaseApiRequestOptions, BtcAssetsApiToken, BtcAssetsApiContext } from '../types';
+import { BaseApis, BaseApiRequestOptions, BtcAssetsApiToken, BtcAssetsApiContext, Json } from '../types';
 
 export class BtcAssetsApiBase implements BaseApis {
   public url: string;
@@ -47,7 +47,7 @@ export class BtcAssetsApiBase implements BaseApis {
     } as RequestInit);
 
     let text: string | undefined;
-    let json: Record<string, any> | undefined;
+    let json: Json | undefined;
     let ok: boolean = false;
     try {
       text = await res.text();
@@ -139,7 +139,7 @@ export class BtcAssetsApiBase implements BaseApis {
   }
 }
 
-function tryParseBody(body: unknown): Record<string, any> | undefined {
+function tryParseBody(body: unknown): Record<string, unknown> | undefined {
   try {
     return typeof body === 'string' ? JSON.parse(body) : void 0;
   } catch {

--- a/packages/service/src/types/base.ts
+++ b/packages/service/src/types/base.ts
@@ -1,3 +1,6 @@
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type Json = Record<string, any>;
+
 export interface BaseApis {
   request<T>(route: string, options?: BaseApiRequestOptions): Promise<T>;
   post<T>(route: string, options?: BaseApiRequestOptions): Promise<T>;
@@ -6,7 +9,7 @@ export interface BaseApis {
 }
 
 export interface BaseApiRequestOptions extends RequestInit {
-  params?: Record<string, any>;
+  params?: Json;
   method?: 'GET' | 'POST';
   requireToken?: boolean;
   allow404?: boolean;
@@ -19,11 +22,11 @@ export interface BtcAssetsApiToken {
 export interface BtcAssetsApiContext {
   request: {
     url: string;
-    body?: Record<string, any>;
-    params?: Record<string, any>;
+    body?: Json;
+    params?: Json;
   };
   response: {
     status: number;
-    data?: Record<string, any> | string;
+    data?: Json | string;
   };
 }

--- a/packages/service/vitest.config.mts
+++ b/packages/service/vitest.config.mts
@@ -3,7 +3,8 @@ import { defineConfig } from 'vitest/config';
 export default defineConfig({
   test: {
     watch: false,
-    testTimeout: 10000,
+    testTimeout: 15000,
+    reporters: ['verbose'],
     exclude: ['lib', 'node_modules'],
   },
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,15 @@ importers:
       '@changesets/cli':
         specifier: ^2.27.1
         version: 2.27.1
+      '@typescript-eslint/eslint-plugin':
+        specifier: ^7.8.0
+        version: 7.8.0(@typescript-eslint/parser@7.8.0)(eslint@8.56.0)(typescript@5.4.3)
+      '@typescript-eslint/parser':
+        specifier: ^7.8.0
+        version: 7.8.0(eslint@8.56.0)(typescript@5.4.3)
+      eslint:
+        specifier: ^8.56.0
+        version: 8.56.0
       husky:
         specifier: ^9.0.11
         version: 9.0.11
@@ -149,21 +158,12 @@ importers:
         specifier: ^1.6.8
         version: 1.6.8
     devDependencies:
-      '@eslint/js':
-        specifier: ^9.1.1
-        version: 9.1.1
       '@types/node':
         specifier: ^20.11.28
         version: 20.11.28
-      eslint:
-        specifier: ^8.56.0
-        version: 8.56.0
       typescript:
         specifier: ^5.4.2
         version: 5.4.2
-      typescript-eslint:
-        specifier: ^7.7.1
-        version: 7.7.1(eslint@8.56.0)(typescript@5.4.2)
 
   packages/btc:
     dependencies:
@@ -1411,11 +1411,6 @@ packages:
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dev: true
 
-  /@eslint/js@9.1.1:
-    resolution: {integrity: sha512-5WoDz3Y19Bg2BnErkZTp0en+c/i9PvgFS7MBe1+m60HjFr0hrphlAGp4yzI7pxpt4xShln4ZyYp4neJm8hmOkQ==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    dev: true
-
   /@exact-realty/multipart-parser@1.0.13:
     resolution: {integrity: sha512-BGnB0VVn18dkz85rvBmp/CyxAMvUcVrsNf3qw8Fdx80V6+MsQUTxRdQnC0PzLIxbN8PKGFs8afd+ur8V1JLv8g==}
     engines: {node: '>=16.0.0', npm: '>=8.0.0'}
@@ -2107,8 +2102,8 @@ packages:
       - supports-color
     dev: true
 
-  /@typescript-eslint/eslint-plugin@7.7.1(@typescript-eslint/parser@7.7.1)(eslint@8.56.0)(typescript@5.4.2):
-    resolution: {integrity: sha512-KwfdWXJBOviaBVhxO3p5TJiLpNuh2iyXyjmWN0f1nU87pwyvfS0EmjC6ukQVYVFJd/K1+0NWGPDXiyEyQorn0Q==}
+  /@typescript-eslint/eslint-plugin@7.8.0(@typescript-eslint/parser@7.8.0)(eslint@8.56.0)(typescript@5.4.3):
+    resolution: {integrity: sha512-gFTT+ezJmkwutUPmB0skOj3GZJtlEGnlssems4AjkVweUPGj7jRwwqg0Hhg7++kPGJqKtTYx+R05Ftww372aIg==}
     engines: {node: ^18.18.0 || >=20.0.0}
     peerDependencies:
       '@typescript-eslint/parser': ^7.0.0
@@ -2119,19 +2114,19 @@ packages:
         optional: true
     dependencies:
       '@eslint-community/regexpp': 4.10.0
-      '@typescript-eslint/parser': 7.7.1(eslint@8.56.0)(typescript@5.4.2)
-      '@typescript-eslint/scope-manager': 7.7.1
-      '@typescript-eslint/type-utils': 7.7.1(eslint@8.56.0)(typescript@5.4.2)
-      '@typescript-eslint/utils': 7.7.1(eslint@8.56.0)(typescript@5.4.2)
-      '@typescript-eslint/visitor-keys': 7.7.1
+      '@typescript-eslint/parser': 7.8.0(eslint@8.56.0)(typescript@5.4.3)
+      '@typescript-eslint/scope-manager': 7.8.0
+      '@typescript-eslint/type-utils': 7.8.0(eslint@8.56.0)(typescript@5.4.3)
+      '@typescript-eslint/utils': 7.8.0(eslint@8.56.0)(typescript@5.4.3)
+      '@typescript-eslint/visitor-keys': 7.8.0
       debug: 4.3.4
       eslint: 8.56.0
       graphemer: 1.4.0
       ignore: 5.3.1
       natural-compare: 1.4.0
       semver: 7.6.0
-      ts-api-utils: 1.3.0(typescript@5.4.2)
-      typescript: 5.4.2
+      ts-api-utils: 1.3.0(typescript@5.4.3)
+      typescript: 5.4.3
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -2157,8 +2152,8 @@ packages:
       - supports-color
     dev: true
 
-  /@typescript-eslint/parser@7.7.1(eslint@8.56.0)(typescript@5.4.2):
-    resolution: {integrity: sha512-vmPzBOOtz48F6JAGVS/kZYk4EkXao6iGrD838sp1w3NQQC0W8ry/q641KU4PrG7AKNAf56NOcR8GOpH8l9FPCw==}
+  /@typescript-eslint/parser@7.8.0(eslint@8.56.0)(typescript@5.4.3):
+    resolution: {integrity: sha512-KgKQly1pv0l4ltcftP59uQZCi4HUYswCLbTqVZEJu7uLX8CTLyswqMLqLN+2QFz4jCptqWVV4SB7vdxcH2+0kQ==}
     engines: {node: ^18.18.0 || >=20.0.0}
     peerDependencies:
       eslint: ^8.56.0
@@ -2167,13 +2162,13 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/scope-manager': 7.7.1
-      '@typescript-eslint/types': 7.7.1
-      '@typescript-eslint/typescript-estree': 7.7.1(typescript@5.4.2)
-      '@typescript-eslint/visitor-keys': 7.7.1
+      '@typescript-eslint/scope-manager': 7.8.0
+      '@typescript-eslint/types': 7.8.0
+      '@typescript-eslint/typescript-estree': 7.8.0(typescript@5.4.3)
+      '@typescript-eslint/visitor-keys': 7.8.0
       debug: 4.3.4
       eslint: 8.56.0
-      typescript: 5.4.2
+      typescript: 5.4.3
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -2186,12 +2181,12 @@ packages:
       '@typescript-eslint/visitor-keys': 7.0.2
     dev: true
 
-  /@typescript-eslint/scope-manager@7.7.1:
-    resolution: {integrity: sha512-PytBif2SF+9SpEUKynYn5g1RHFddJUcyynGpztX3l/ik7KmZEv19WCMhUBkHXPU9es/VWGD3/zg3wg90+Dh2rA==}
+  /@typescript-eslint/scope-manager@7.8.0:
+    resolution: {integrity: sha512-viEmZ1LmwsGcnr85gIq+FCYI7nO90DVbE37/ll51hjv9aG+YZMb4WDE2fyWpUR4O/UrhGRpYXK/XajcGTk2B8g==}
     engines: {node: ^18.18.0 || >=20.0.0}
     dependencies:
-      '@typescript-eslint/types': 7.7.1
-      '@typescript-eslint/visitor-keys': 7.7.1
+      '@typescript-eslint/types': 7.8.0
+      '@typescript-eslint/visitor-keys': 7.8.0
     dev: true
 
   /@typescript-eslint/type-utils@7.0.2(eslint@8.56.0)(typescript@5.4.2):
@@ -2214,8 +2209,8 @@ packages:
       - supports-color
     dev: true
 
-  /@typescript-eslint/type-utils@7.7.1(eslint@8.56.0)(typescript@5.4.2):
-    resolution: {integrity: sha512-ZksJLW3WF7o75zaBPScdW1Gbkwhd/lyeXGf1kQCxJaOeITscoSl0MjynVvCzuV5boUz/3fOI06Lz8La55mu29Q==}
+  /@typescript-eslint/type-utils@7.8.0(eslint@8.56.0)(typescript@5.4.3):
+    resolution: {integrity: sha512-H70R3AefQDQpz9mGv13Uhi121FNMh+WEaRqcXTX09YEDky21km4dV1ZXJIp8QjXc4ZaVkXVdohvWDzbnbHDS+A==}
     engines: {node: ^18.18.0 || >=20.0.0}
     peerDependencies:
       eslint: ^8.56.0
@@ -2224,12 +2219,12 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/typescript-estree': 7.7.1(typescript@5.4.2)
-      '@typescript-eslint/utils': 7.7.1(eslint@8.56.0)(typescript@5.4.2)
+      '@typescript-eslint/typescript-estree': 7.8.0(typescript@5.4.3)
+      '@typescript-eslint/utils': 7.8.0(eslint@8.56.0)(typescript@5.4.3)
       debug: 4.3.4
       eslint: 8.56.0
-      ts-api-utils: 1.3.0(typescript@5.4.2)
-      typescript: 5.4.2
+      ts-api-utils: 1.3.0(typescript@5.4.3)
+      typescript: 5.4.3
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -2239,8 +2234,8 @@ packages:
     engines: {node: ^16.0.0 || >=18.0.0}
     dev: true
 
-  /@typescript-eslint/types@7.7.1:
-    resolution: {integrity: sha512-AmPmnGW1ZLTpWa+/2omPrPfR7BcbUU4oha5VIbSbS1a1Tv966bklvLNXxp3mrbc+P2j4MNOTfDffNsk4o0c6/w==}
+  /@typescript-eslint/types@7.8.0:
+    resolution: {integrity: sha512-wf0peJ+ZGlcH+2ZS23aJbOv+ztjeeP8uQ9GgwMJGVLx/Nj9CJt17GWgWWoSmoRVKAX2X+7fzEnAjxdvK2gqCLw==}
     engines: {node: ^18.18.0 || >=20.0.0}
     dev: true
 
@@ -2266,8 +2261,8 @@ packages:
       - supports-color
     dev: true
 
-  /@typescript-eslint/typescript-estree@7.7.1(typescript@5.4.2):
-    resolution: {integrity: sha512-CXe0JHCXru8Fa36dteXqmH2YxngKJjkQLjxzoj6LYwzZ7qZvgsLSc+eqItCrqIop8Vl2UKoAi0StVWu97FQZIQ==}
+  /@typescript-eslint/typescript-estree@7.8.0(typescript@5.4.3):
+    resolution: {integrity: sha512-5pfUCOwK5yjPaJQNy44prjCwtr981dO8Qo9J9PwYXZ0MosgAbfEMB008dJ5sNo3+/BN6ytBPuSvXUg9SAqB0dg==}
     engines: {node: ^18.18.0 || >=20.0.0}
     peerDependencies:
       typescript: '*'
@@ -2275,15 +2270,15 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/types': 7.7.1
-      '@typescript-eslint/visitor-keys': 7.7.1
+      '@typescript-eslint/types': 7.8.0
+      '@typescript-eslint/visitor-keys': 7.8.0
       debug: 4.3.4
       globby: 11.1.0
       is-glob: 4.0.3
       minimatch: 9.0.4
       semver: 7.6.0
-      ts-api-utils: 1.3.0(typescript@5.4.2)
-      typescript: 5.4.2
+      ts-api-utils: 1.3.0(typescript@5.4.3)
+      typescript: 5.4.3
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -2307,8 +2302,8 @@ packages:
       - typescript
     dev: true
 
-  /@typescript-eslint/utils@7.7.1(eslint@8.56.0)(typescript@5.4.2):
-    resolution: {integrity: sha512-QUvBxPEaBXf41ZBbaidKICgVL8Hin0p6prQDu6bbetWo39BKbWJxRsErOzMNT1rXvTll+J7ChrbmMCXM9rsvOQ==}
+  /@typescript-eslint/utils@7.8.0(eslint@8.56.0)(typescript@5.4.3):
+    resolution: {integrity: sha512-L0yFqOCflVqXxiZyXrDr80lnahQfSOfc9ELAAZ75sqicqp2i36kEZZGuUymHNFoYOqxRT05up760b4iGsl02nQ==}
     engines: {node: ^18.18.0 || >=20.0.0}
     peerDependencies:
       eslint: ^8.56.0
@@ -2316,9 +2311,9 @@ packages:
       '@eslint-community/eslint-utils': 4.4.0(eslint@8.56.0)
       '@types/json-schema': 7.0.15
       '@types/semver': 7.5.8
-      '@typescript-eslint/scope-manager': 7.7.1
-      '@typescript-eslint/types': 7.7.1
-      '@typescript-eslint/typescript-estree': 7.7.1(typescript@5.4.2)
+      '@typescript-eslint/scope-manager': 7.8.0
+      '@typescript-eslint/types': 7.8.0
+      '@typescript-eslint/typescript-estree': 7.8.0(typescript@5.4.3)
       eslint: 8.56.0
       semver: 7.6.0
     transitivePeerDependencies:
@@ -2334,11 +2329,11 @@ packages:
       eslint-visitor-keys: 3.4.3
     dev: true
 
-  /@typescript-eslint/visitor-keys@7.7.1:
-    resolution: {integrity: sha512-gBL3Eq25uADw1LQ9kVpf3hRM+DWzs0uZknHYK3hq4jcTPqVCClHGDnB6UUUV2SFeBeA4KWHWbbLqmbGcZ4FYbw==}
+  /@typescript-eslint/visitor-keys@7.8.0:
+    resolution: {integrity: sha512-q4/gibTNBQNA0lGyYQCmWRS5D15n8rXh4QjK3KV+MBPlTYHpfBUT3D3PaPR/HeNiI9W6R7FvlkcGhNyAoP+caA==}
     engines: {node: ^18.18.0 || >=20.0.0}
     dependencies:
-      '@typescript-eslint/types': 7.7.1
+      '@typescript-eslint/types': 7.8.0
       eslint-visitor-keys: 3.4.3
     dev: true
 
@@ -6014,6 +6009,15 @@ packages:
       typescript: 5.4.2
     dev: true
 
+  /ts-api-utils@1.3.0(typescript@5.4.3):
+    resolution: {integrity: sha512-UQMIo7pb8WRomKR1/+MFVLTroIvDVtMX3K6OUir8ynLyzB8Jeriont2bTAtmNPa1ekAgN7YPDyf6V+ygrdU+eQ==}
+    engines: {node: '>=16'}
+    peerDependencies:
+      typescript: '>=4.2.0'
+    dependencies:
+      typescript: 5.4.3
+    dev: true
+
   /ts-node@10.9.2(@types/node@20.12.2)(typescript@5.4.3):
     resolution: {integrity: sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==}
     hasBin: true
@@ -6215,25 +6219,6 @@ packages:
   /typeforce@1.18.0:
     resolution: {integrity: sha512-7uc1O8h1M1g0rArakJdf0uLRSSgFcYexrVoKo+bzJd32gd4gDy2L/Z+8/FjPnU9ydY3pEnVPtr9FyscYY60K1g==}
     dev: false
-
-  /typescript-eslint@7.7.1(eslint@8.56.0)(typescript@5.4.2):
-    resolution: {integrity: sha512-ykEBfa3xx3odjZy6GRED4SCPrjo0rgHwstLlEgLX4EMEuv7QeIDSmfV+S6Kk+XkbsYn4BDEcPvsci1X26lRpMQ==}
-    engines: {node: ^18.18.0 || >=20.0.0}
-    peerDependencies:
-      eslint: ^8.56.0
-      typescript: '*'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-    dependencies:
-      '@typescript-eslint/eslint-plugin': 7.7.1(@typescript-eslint/parser@7.7.1)(eslint@8.56.0)(typescript@5.4.2)
-      '@typescript-eslint/parser': 7.7.1(eslint@8.56.0)(typescript@5.4.2)
-      '@typescript-eslint/utils': 7.7.1(eslint@8.56.0)(typescript@5.4.2)
-      eslint: 8.56.0
-      typescript: 5.4.2
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
 
   /typescript@5.4.2:
     resolution: {integrity: sha512-+2/g0Fds1ERlP6JsakQQDXjZdZMM+rqpamFZJEKh4kwTIn3iDkgKtby0CeNd5ATNZ4Ry1ax15TMx0W2V+miizQ==}

--- a/turbo.json
+++ b/turbo.json
@@ -14,11 +14,16 @@
     },
     "test": {
       "outputs": ["coverage/**"],
-      "dependsOn": ["^build"],
+      "dependsOn": ["build"],
       "cache": false
     },
+    "lint": {
+      "cache": false,
+      "dependsOn": ["^lint"]
+    },
     "lint:fix": {
-      "cache": false
+      "cache": false,
+      "dependsOn": ["^lint:fix"]
     },
     "clean": {
       "cache": false

--- a/turbo.json
+++ b/turbo.json
@@ -9,7 +9,7 @@
     },
     "build": {
       "outputs": ["lib/**", "dist/**", ".next/**", "!.next/cache/**"],
-      "dependsOn": ["^build"],
+      "dependsOn": ["clean", "^build"],
       "cache": false
     },
     "test": {


### PR DESCRIPTION
## Changes
- Add `ESLint` in the root of the repo
- Reformat the code of the service/btc/ckb lib with the `ESLint`
- Refactor the examples to use global `ESLint` config and format rules
- Use `lint` command in packages/examples to check code in the `test.yaml` (instead of fixing)
- Tune the timeout of btc/service lib to allow longer tests (mempool-based APIs take longer to process)

## Related issues
- Resolves #131 