### PR TITLE
docs: update README related to assets-api

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This repository offers utilities for Bitcoin and RGB++ asset integration.
 
 - [@rgbpp-sdk/btc](./packages/btc): Bitcoin part of the SDK
 - [@rgbpp-sdk/ckb](./packages/ckb): Nervos CKB part of the SDK
-- [@rgbpp-sdk/service](./packages/service): A wrapped class to interact with `Bitcoin/RGB++ Assets Service`
+- [@rgbpp-sdk/service](./packages/service): Wrapped interfaces of `Bitcoin/RGB++ Assets Service`
 
 ## RGB++ Code Examples
 
@@ -15,7 +15,7 @@ This repository offers utilities for Bitcoin and RGB++ asset integration.
 ## Related CKB Scripts (Contracts)
 - [CKB Bitcoin SPV Type Script](https://github.com/ckb-cell/ckb-bitcoin-spv-contracts/tree/master/contracts/ckb-bitcoin-spv-type-lock): A [type script](https://docs.nervos.org/docs/basics/glossary#type-script) for [Bitcoin SPV](https://bitcoinwiki.org/wiki/simplified-payment-verification) clients which synchronize [Bitcoin](https://bitcoin.org) state into [CKB](https://github.com/nervosnetwork/ckb)
 
-- [RgbppLockScript and BtcTimeLockScript](https://github.com/ckb-cell/rgbpp-sdk/blob/cf25ea014d4e0fc24723df8eea8bd61f59e1060a/packages/ckb/src/constants/index.ts#L11-L121)
+- [RgbppLockScript and BtcTimeLockScript](https://github.com/ckb-cell/rgbpp-sdk/blob/63df2dcd95b1b735b5d235e156e4361a3c87b0ac/packages/ckb/src/constants/index.ts#L12-L206)
   * design: https://github.com/ckb-cell/RGBPlusPlus-design/blob/main/docs/light-paper-en.md
   * testnet: https://pudge.explorer.nervos.org/scripts#RGB++
   * mainnet: https://explorer.nervos.org/scripts#RGB++
@@ -36,25 +36,25 @@ This repository offers utilities for Bitcoin and RGB++ asset integration.
     2. **[BTC → CKB](https://github.com/ckb-cell/rgbpp-sdk/blob/develop/packages/ckb/README.md#rgb-spore-leap-from-btc-to-ckb)**
     3. **[CKB → BTC](https://github.com/ckb-cell/rgbpp-sdk/blob/develop/packages/ckb/README.md#rgb-spore-leap-from-ckb-to-btc)** *(isomorphic rgbpp_btc_tx is not required in this workflow)*
 
-  > [!IMPORTANT]  
+  > [!IMPORTANT]
   > It's recommended to save the `rgbpp_ckb_tx_virtual` locally in case you need it in the future.
 
 2. **Creation of `rgbpp_btc_tx` through [@rgbpp-sdk/btc](https://github.com/ckb-cell/rgbpp-sdk/tree/develop/packages/btc)**
-    1. construct isomorphic rgbpp_btc_tx based on rgbpp_ckb_tx_virtual and rgbpp commitment
-    2. sign and broadcast rgbpp_btc_tx to obtain `rgbpp_btc_txid`
+    1. construct isomorphic `rgbpp_btc_tx` based on `rgbpp_ckb_tx_virtual` and rgbpp commitment
+    2. sign and broadcast `rgbpp_btc_tx` to obtain `rgbpp_btc_txid`
 
 3. JoyID or dApp sends `rgbpp_btc_txid` and `rgbpp_ckb_tx_virtual` to RGB++ CKB transaction Queue (API Endpoint: `/rgbpp/v1/transaction/ckb-tx`)
 
 4. `RGB++ CKB transaction Queue` will process the following things:
     1. **verify** the received requests
     2. continuously fetch request from the queue through a **cron job**
-    3. check whether the **confirmations** of req.rgbpp_btc_txid is sufficient
-    4. generate the **witnesses for RgbppLocks** in the rgbpp_ckb_tx_virtual
-    5. add a **paymaster cell** into rgbpp_ckb_tx_virtual.inputs if the CKB capacity is insufficient
+    3. check whether the **confirmations** of `req.rgbpp_btc_txid` is sufficient
+    4. generate the **witnesses for RgbppLocks** in the `rgbpp_ckb_tx_virtual`
+    5. add a **paymaster cell** into `rgbpp_ckb_tx_virtual`.inputs if the CKB capacity is insufficient
         1. need to **verify the existence of paymaster UTXO** in the rgbpp_btc_tx
         2. sign the paymaster cell and the entire transaction if needed
-    6. **finalize** the rgbpp_ckb_tx_virtual to a rgbpp_ckb_tx
-    7. **broadcast** rgbpp_ckb_tx and mark the job as completed upon tx-confirmation
+    6. **finalize** the `rgbpp_ckb_tx_virtual` to a `rgbpp_ckb_tx`
+    7. **broadcast** `rgbpp_ckb_tx` and mark the job as completed upon tx-confirmation
 
 ### Notes
 

--- a/packages/service/README.md
+++ b/packages/service/README.md
@@ -10,6 +10,9 @@ The `@rgbpp-sdk/service` package provides a wrapped class to interact with `Bitc
 - Simplify RGB++ assets workflows with **RGB++ CKB transaction Queue** and cron jobs
 - More detailed API documentation can be found on [Testnet](https://btc-assets-api.testnet.mibao.pro/docs) and [Mainnet](https://api.rgbpp.io/docs)
 
+> [!NOTE]
+> `Bitcoin/RGB++ Assets Service` is designed to streamline the transaction workflow. Developers have the option to implement its features by themselves without limitation.
+
 ## Installation
 
 ```bash
@@ -25,14 +28,22 @@ $ pnpm add @rgbpp-sdk/service
 
 ### Get an access token
 
-The BtcAssetsApi is currently limited to verified apps only.
-If you're a developer and want to access the BtcAssetsApi service,
-please email us to request a JWT token for your app: f@cell.studio.
+#### Testnet
 
-In the email, you should provide us some information about your app:
+You can get a testnet access token through the [/token/generate](https://btc-assets-api.testnet.mibao.pro/docs/static/index.html#/Token/post_token_generate) API directly.
+
+#### Mainnet
+
+The mainnet BtcAssetsApi is currently limited to verified apps only.
+
+When your app development is ready on testnet, and requires a mainnet access token,
+please email us at f@cell.studio to request a mainnet JWT token.
+
+In the email, please provide the following information about your app:
 
 - `name`: Your app name, e.g. "rgbpp-app"
-- `domain`: Your app domain, e.g. "rgbpp.app" (without protocol)
+- `domain`: Your app domain, e.g. "rgbpp.app" (without protocol prefix)
+
 
 ### Initialize the service
 
@@ -83,7 +94,7 @@ console.log(res);
 // }
 ```
 
-All available APIs in the [BtcAssetsApi](#btcassetsapi-1) section.
+All available APIs in the [BtcAssetsApi](#types) section.
 
 ### Handling service errors
 


### PR DESCRIPTION
### Get an access token

#### Testnet

You can get a testnet access token through the [/token/generate](https://btc-assets-api.testnet.mibao.pro/docs/static/index.html#/Token/post_token_generate) API directly.

#### Mainnet

The mainnet BtcAssetsApi is currently limited to verified apps only.

When your app development is ready on testnet, and requires a mainnet access token,
please email us at f@cell.studio to request a mainnet JWT token.

In the email, please provide the following information about your app:

- `name`: Your app name, e.g. "rgbpp-app"
- `domain`: Your app domain, e.g. "rgbpp.app" (without protocol prefix)