### PR TITLE
fix(ckb/btc): Check rgbpp capacity for change and paymaster cell

### DIFF
--- a/packages/ckb/src/utils/rgbpp.spec.ts
+++ b/packages/ckb/src/utils/rgbpp.spec.ts
@@ -16,6 +16,7 @@ import {
   transformSpvProof,
   throwErrorWhenTxInputsExceeded,
   throwErrorWhenRgbppCellsInvalid,
+  isRgbppCapacitySufficientForChange,
 } from './rgbpp';
 import { getXudtTypeScript } from '../constants';
 import { IndexerCell, RgbppCkbVirtualTx } from '../types';
@@ -375,5 +376,17 @@ describe('rgbpp tests', () => {
         expect('No rgbpp cells found with the xudt type script and the rgbpp lock args').toBe(error.message);
       }
     }
+  });
+
+  it('isRgbppCapacityEnoughForChange', () => {
+    expect(false).toBe(
+      isRgbppCapacitySufficientForChange(BigInt(500) * BigInt(10000_0000), BigInt(254) * BigInt(10000_0000)),
+    );
+    expect(false).toBe(
+      isRgbppCapacitySufficientForChange(BigInt(507) * BigInt(10000_0000), BigInt(254) * BigInt(10000_0000)),
+    );
+    expect(true).toBe(
+      isRgbppCapacitySufficientForChange(BigInt(508) * BigInt(10000_0000), BigInt(254) * BigInt(10000_0000)),
+    );
   });
 });

--- a/packages/ckb/src/utils/rgbpp.ts
+++ b/packages/ckb/src/utils/rgbpp.ts
@@ -255,6 +255,9 @@ export const throwErrorWhenRgbppCellsInvalid = (
   }
 };
 
+/**
+ * Check if the tx's unoccupied capacity is enough to create a new rgbpp-cell as a UDT change cell
+ */
 export const isRgbppCapacitySufficientForChange = (
   sumUdtInputsCapacity: bigint,
   receiverOutputCapacity: bigint,

--- a/packages/ckb/src/utils/rgbpp.ts
+++ b/packages/ckb/src/utils/rgbpp.ts
@@ -3,6 +3,7 @@ import { Hex, IndexerCell, RgbppCkbVirtualTx, RgbppTokenInfo, SpvClientCellTxPro
 import { append0x, remove0x, reverseHex, u32ToLe, u8ToHex, utf8ToHex } from './hex';
 import {
   BTC_JUMP_CONFIRMATION_BLOCKS,
+  CKB_UNIT,
   RGBPP_TX_ID_PLACEHOLDER,
   RGBPP_TX_INPUTS_MAX_LENGTH,
   RGBPP_TX_WITNESS_MAX_SIZE,
@@ -28,7 +29,7 @@ import {
   RgbppCkbTxInputsExceededError,
   RgbppUtxoBindMultiTypeAssetsError,
 } from '../error';
-import { isScriptEqual, isUDTTypeSupported } from './ckb-tx';
+import { calculateRgbppCellCapacity, isScriptEqual, isUDTTypeSupported } from './ckb-tx';
 
 export const genRgbppLockScript = (rgbppLockArgs: Hex, isMainnet: boolean) => {
   return {
@@ -252,4 +253,12 @@ export const throwErrorWhenRgbppCellsInvalid = (
   if (!isTargetExist) {
     throw new NoRgbppLiveCellError('No rgbpp cells found with the xudt type script and the rgbpp lock args');
   }
+};
+
+export const isRgbppCapacitySufficientForChange = (
+  sumUdtInputsCapacity: bigint,
+  receiverOutputCapacity: bigint,
+): boolean => {
+  const rgbppOccupiedCapacity = calculateRgbppCellCapacity() - CKB_UNIT;
+  return sumUdtInputsCapacity > receiverOutputCapacity + rgbppOccupiedCapacity;
 };


### PR DESCRIPTION
## Main Changes

### CKB package
- Add `isRgbppCapacitySufficientForChange` function to check whether the capacity of inputs is sufficient for outputs
- Return the rest of the capacity to sender when the RGB++ change cell is needed
- Determine whether a paymaster cell is needed based on whether the capacity of the inputs is sufficient for the outputs
- Add `checkCkbTxInputsCapacitySufficient` function for BTC package to determine whether a paymaster cell is needed

### BTC package
- Update paymaster cell logic with new function `checkCkbTxInputsCapacitySufficient`