### PR TITLE
feat(rgbpp-sdk/ckb): Build ckb raw tx for spore creation

### DIFF
--- a/.changeset/stupid-donuts-grin.md
+++ b/.changeset/stupid-donuts-grin.md
@@ -1,0 +1,5 @@
+---
+"@rgbpp-sdk/ckb": minor
+---
+
+feat: Build ckb raw tx to be signed for spores creation

--- a/packages/ckb/README.md
+++ b/packages/ckb/README.md
@@ -147,8 +147,6 @@ export interface SporeCreateVirtualTxResult {
  * @param collector The collector that collects CKB live cells and transactions
  * @param clusterRgbppLockArgs The cluster rgbpp cell lock script args whose data structure is: out_index | bitcoin_tx_id
  * @param sporeDataList The spore's data list, including name and description.
- * @param witnessLockPlaceholderSize The WitnessArgs.lock placeholder bytes array size and the default value is 5000
- * @param ckbFeeRate The CKB transaction fee rate, default value is 1100
  */
 export const genCreateSporeCkbVirtualTx = async ({
   collector,

--- a/packages/ckb/src/spore/spore.ts
+++ b/packages/ckb/src/spore/spore.ts
@@ -9,7 +9,7 @@ import {
 import { buildPreLockArgs, calculateCommitment, genRgbppLockScript } from '../utils/rgbpp';
 import {
   AppendIssuerCellToSporeCreate,
-  BuildAppendingIssuerCellToSporeCreateTx,
+  BuildAppendingIssuerCellTxParams,
   CreateSporeCkbVirtualTxParams,
   Hex,
   SporeCreateVirtualTxResult,
@@ -170,7 +170,7 @@ export const buildAppendingIssuerCellToSporesCreateTx = async ({
   sumInputsCapacity,
   witnessLockPlaceholderSize = SECP256K1_WITNESS_LOCK_SIZE,
   ckbFeeRate,
-}: BuildAppendingIssuerCellToSporeCreateTx): Promise<CKBComponents.RawTransactionToSign> => {
+}: BuildAppendingIssuerCellTxParams): Promise<CKBComponents.RawTransactionToSign> => {
   const isMainnet = issuerAddress.startsWith('ckb');
   const rawTx = ckbRawTx as CKBComponents.RawTransactionToSign;
 

--- a/packages/ckb/src/spore/spore.ts
+++ b/packages/ckb/src/spore/spore.ts
@@ -9,6 +9,7 @@ import {
 import { buildPreLockArgs, calculateCommitment, genRgbppLockScript } from '../utils/rgbpp';
 import {
   AppendIssuerCellToSporeCreate,
+  BuildAppendingIssuerCellToSporeCreateTx,
   CreateSporeCkbVirtualTxParams,
   Hex,
   SporeCreateVirtualTxResult,
@@ -56,8 +57,6 @@ import signWitnesses from '@nervosnetwork/ckb-sdk-core/lib/signWitnesses';
  * @param collector The collector that collects CKB live cells and transactions
  * @param clusterRgbppLockArgs The cluster rgbpp cell lock script args whose data structure is: out_index | bitcoin_tx_id
  * @param sporeDataList The spore's data list, including name and description.
- * @param witnessLockPlaceholderSize The WitnessArgs.lock placeholder bytes array size and the default value is 5000
- * @param ckbFeeRate The CKB transaction fee rate, default value is 1100
  */
 export const genCreateSporeCkbVirtualTx = async ({
   collector,
@@ -156,26 +155,24 @@ export const genCreateSporeCkbVirtualTx = async ({
 };
 
 /**
- * Append paymaster cell to the ckb transaction inputs and sign the transaction with paymaster cell's secp256k1 private key
- * @param secp256k1PrivateKey The Secp256k1 private key of the paymaster cells maintainer
+ * Append paymaster cell to the ckb transaction inputs and build the raw tx to be signed for spores creation
  * @param issuerAddress The issuer ckb address
  * @param collector The collector that collects CKB live cells and transactions
  * @param ckbRawTx CKB raw transaction
  * @param sumInputsCapacity The sum capacity of ckb inputs which is to be used to calculate ckb tx fee
+ * @param witnessLockPlaceholderSize The WitnessArgs.lock placeholder bytes array size and the default value is 65
  * @param ckbFeeRate The CKB transaction fee rate, default value is 1100
  */
-export const appendIssuerCellToSporesCreate = async ({
-  secp256k1PrivateKey,
+export const buildAppendingIssuerCellToSporesCreateTx = async ({
   issuerAddress,
   collector,
   ckbRawTx,
   sumInputsCapacity,
-  isMainnet,
+  witnessLockPlaceholderSize = SECP256K1_WITNESS_LOCK_SIZE,
   ckbFeeRate,
-}: AppendIssuerCellToSporeCreate): Promise<CKBComponents.RawTransaction> => {
+}: BuildAppendingIssuerCellToSporeCreateTx): Promise<CKBComponents.RawTransactionToSign> => {
+  const isMainnet = issuerAddress.startsWith('ckb');
   const rawTx = ckbRawTx as CKBComponents.RawTransactionToSign;
-
-  const rgbppInputsLength = rawTx.inputs.length;
 
   const sumOutputsCapacity: bigint = rawTx.outputs
     .map((output) => BigInt(output.capacity))
@@ -205,12 +202,46 @@ export const appendIssuerCellToSporesCreate = async ({
   rawTx.outputs = [...rawTx.outputs, changeOutput];
   rawTx.outputsData = [...rawTx.outputsData, '0x'];
 
-  rawTx.cellDeps = [...rawTx.cellDeps, getSecp256k1CellDep(isMainnet)];
+  if (witnessLockPlaceholderSize === SECP256K1_WITNESS_LOCK_SIZE) {
+    rawTx.cellDeps = [...rawTx.cellDeps, getSecp256k1CellDep(isMainnet)];
+  }
 
-  const txSize = getTransactionSize(rawTx) + SECP256K1_WITNESS_LOCK_SIZE;
+  const txSize = getTransactionSize(rawTx) + witnessLockPlaceholderSize;
   const estimatedTxFee = calculateTransactionFee(txSize, ckbFeeRate);
   changeCapacity -= estimatedTxFee;
   rawTx.outputs[rawTx.outputs.length - 1].capacity = append0x(changeCapacity.toString(16));
+
+  return rawTx;
+};
+
+/**
+ * Append paymaster cell to the ckb transaction inputs and sign the transaction with paymaster cell's secp256k1 private key
+ * @param secp256k1PrivateKey The Secp256k1 private key of the paymaster cells maintainer
+ * @param issuerAddress The issuer ckb address
+ * @param collector The collector that collects CKB live cells and transactions
+ * @param ckbRawTx CKB raw transaction
+ * @param sumInputsCapacity The sum capacity of ckb inputs which is to be used to calculate ckb tx fee
+ * @param ckbFeeRate The CKB transaction fee rate, default value is 1100
+ */
+export const appendIssuerCellToSporesCreate = async ({
+  secp256k1PrivateKey,
+  issuerAddress,
+  collector,
+  ckbRawTx,
+  sumInputsCapacity,
+  isMainnet,
+  ckbFeeRate,
+}: AppendIssuerCellToSporeCreate): Promise<CKBComponents.RawTransaction> => {
+  const rawTx = await buildAppendingIssuerCellToSporesCreateTx({
+    issuerAddress,
+    collector,
+    ckbRawTx,
+    sumInputsCapacity,
+    ckbFeeRate,
+  });
+
+  const rgbppInputsLength = ckbRawTx.inputs.length;
+  const issuerLock = addressToScript(issuerAddress);
 
   const keyMap = new Map<string, string>();
   keyMap.set(scriptToHash(issuerLock), secp256k1PrivateKey);

--- a/packages/ckb/src/types/spore.ts
+++ b/packages/ckb/src/types/spore.ts
@@ -51,6 +51,21 @@ export interface SporeCreateVirtualTxResult {
   clusterCell: IndexerCell;
 }
 
+export interface BuildAppendingIssuerCellToSporeCreateTx {
+  // The issuer ckb address
+  issuerAddress: Address;
+  // The collector that collects CKB live cells and transactions
+  collector: Collector;
+  // CKB raw transaction
+  ckbRawTx: CKBComponents.RawTransaction;
+  // The sum capacity of the ckb inputs
+  sumInputsCapacity: Hex;
+  // The WitnessArgs.lock placeholder bytes array size and the default value is 5000
+  witnessLockPlaceholderSize?: number;
+  // The CKB transaction fee rate, default value is 1100
+  ckbFeeRate?: bigint;
+}
+
 export interface AppendIssuerCellToSporeCreate {
   // The Secp256k1 private key of the issuer cells maintainer
   secp256k1PrivateKey: Hex;

--- a/packages/ckb/src/types/spore.ts
+++ b/packages/ckb/src/types/spore.ts
@@ -51,7 +51,7 @@ export interface SporeCreateVirtualTxResult {
   clusterCell: IndexerCell;
 }
 
-export interface BuildAppendingIssuerCellToSporeCreateTx {
+export interface BuildAppendingIssuerCellTxParams {
   // The issuer ckb address
   issuerAddress: Address;
   // The collector that collects CKB live cells and transactions


### PR DESCRIPTION
## Main Changes

- Add `buildAppendingIssuerCellToSporesCreateTx` function to build ckb raw tx to be signed for spores creation
- The Dapp can use this function to build ckb raw tx and let the JoyID wallet or other wallets to sign the tx