### PR TITLE
fix(rgbpp): export of NetworkType/AddressType

### DIFF
--- a/.changeset/clean-chairs-nail.md
+++ b/.changeset/clean-chairs-nail.md
@@ -1,0 +1,5 @@
+---
+"rgbpp": patch
+---
+
+Fix the export of NetworkType/AddressType in the rgbpp lib

--- a/packages/rgbpp/src/index.ts
+++ b/packages/rgbpp/src/index.ts
@@ -44,6 +44,8 @@ export { BtcAssetsApi, BtcAssetsApiError } from '@rgbpp-sdk/service';
  */
 export {
   DataSource,
+  NetworkType,
+  AddressType,
   sendBtc,
   sendUtxos,
   sendRgbppUtxos,
@@ -51,4 +53,4 @@ export {
   createSendUtxosBuilder,
   createSendRgbppUtxosBuilder,
 } from '@rgbpp-sdk/btc';
-export type { NetworkType, AddressType, SendBtcProps, SendUtxosProps, SendRgbppUtxosProps } from '@rgbpp-sdk/btc';
+export type { SendBtcProps, SendUtxosProps, SendRgbppUtxosProps } from '@rgbpp-sdk/btc';


### PR DESCRIPTION
## Changes
- Fix the export of NetworkType/AddressType as enums instead of types (reported by @duanyytop)