### PR TITLE
chore(ci): update changelog format

### DIFF
--- a/.changeset/changelog-format.cjs
+++ b/.changeset/changelog-format.cjs
@@ -1,0 +1,130 @@
+// @ts-check
+/**
+ * Based on the following format:
+ * - https://github.com/changesets/changesets/blob/main/packages/changelog-github/src/index.ts
+ * - https://github.com/stylelint/stylelint/blob/main/.changeset/changelog-stylelint.cjs
+ */
+
+const { getInfo, getInfoFromPullRequest } = require('@changesets/get-github-info');
+
+/**
+ * @type {import('@changesets/types').ChangelogFunctions}
+ */
+const changelogFunctions = {
+  async getReleaseLine(changeset, _type, options) {
+    if (!options || !options.repo) {
+      throw new Error(
+        'Please provide a repo to this changelog generator like this:\n"changelog": ["@changesets/changelog-github", { "repo": "org/repo" }]',
+      );
+    }
+
+    /**
+     * @type {number | undefined}
+     */
+    let prFromSummary;
+    /**
+     * @type {string | undefined}
+     */
+    let commitFromSummary;
+    /**
+     * @type {string[]}
+     */
+    let usersFromSummary = [];
+
+    const replacedChangelog = changeset.summary
+      .replace(/^\s*(?:pr|pull|pull\s+request):\s*#?(\d+)/im, (_, pr) => {
+        let num = Number(pr);
+        if (!isNaN(num)) {
+          prFromSummary = num;
+        }
+        return '';
+      })
+      .replace(/^\s*commit:\s*([^\s]+)/im, (_, commit) => {
+        commitFromSummary = commit;
+        return '';
+      })
+      .replace(/^\s*(?:author|user):\s*@?([^\s]+)/gim, (_, user) => {
+        usersFromSummary.push(user);
+        return '';
+      })
+      .trim();
+
+    const [firstLine, ...futureLines] = replacedChangelog
+      .split('\n')
+      .map((l) => l.trimRight());
+
+    const links = await (async () => {
+      if (prFromSummary !== undefined) {
+        let { links } = await getInfoFromPullRequest({
+          repo: options.repo,
+          pull: prFromSummary,
+        });
+        if (commitFromSummary) {
+          const shortCommitId = commitFromSummary.slice(0, 7);
+          links = {
+            ...links,
+            commit: `[\`${shortCommitId}\`](https://github.com/${options.repo}/commit/${commitFromSummary})`,
+          };
+        }
+        return links;
+      }
+      const commitToFetchFrom = commitFromSummary || changeset.commit;
+      if (commitToFetchFrom) {
+        let { links } = await getInfo({
+          repo: options.repo,
+          commit: commitToFetchFrom,
+        });
+        return links;
+      }
+      return {
+        commit: null,
+        pull: null,
+        user: null,
+      };
+    })();
+
+    const users = usersFromSummary.length
+      ? usersFromSummary
+        .map((userFromSummary) => `[@${userFromSummary}](https://github.com/${userFromSummary})`)
+        .join(', ')
+      : links.user;
+
+    const pull = links.pull !== null ? links.pull : '';
+    const commit = links.commit !== null ? links.commit : '';
+    const prefix = pull || commit ? `${pull || commit}:` : '';
+    const mention = users !== null ? `(${users})` : users;
+    const fullFirstLine = `${prefix} ${firstLine} ${mention}`;
+    const futureLinesText = futureLines.map((l) => `  ${l}`).join('\n');
+
+    return `\n\n - ${fullFirstLine}\n${futureLinesText}`;
+  },
+  async getDependencyReleaseLine(changesets, deps, options) {
+    if (!options.repo) {
+      throw new Error(
+        'Please provide a repo to this changelog generator like this:\n"changelog": ["@changesets/changelog-github", { "repo": "org/repo" }]',
+      );
+    }
+    if (deps.length === 0) {
+      return '';
+    }
+
+    const commits = Promise.all(
+      changesets.map(async (cs) => {
+        if (cs.commit) {
+          let { links } = await getInfo({
+            repo: options.repo,
+            commit: cs.commit,
+          });
+          return links.commit;
+        }
+      }),
+    );
+
+    const changesetLink = `- Updated dependencies [${commits.join(', ')}]:`;
+    const updatedDeps = deps.map((dep) => `  - ${dep.name}@${dep.newVersion}`);
+
+    return [changesetLink, ...updatedDeps].join('\n');
+  },
+};
+
+module.exports = changelogFunctions;

--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -1,11 +1,11 @@
 {
   "$schema": "https://unpkg.com/@changesets/config@3.0.0/schema.json",
-  "changelog": ["@changesets/changelog-github", { "repo": "ckb-cell/rgbpp-sdk" }],
+  "changelog": ["./changelog-format.cjs", { "repo": "ckb-cell/rgbpp-sdk" }],
   "commit": false,
   "fixed": [["@rgbpp-sdk/*", "rgbpp"]],
   "linked": [],
   "access": "public",
-  "baseBranch": "main",
+  "baseBranch": "origin/main",
   "updateInternalDependencies": "patch",
   "ignore": []
 }

--- a/package.json
+++ b/package.json
@@ -18,8 +18,9 @@
     "release:packages": "pnpm run clean:packages && pnpm run build:packages && changeset publish"
   },
   "devDependencies": {
-    "@changesets/changelog-github": "^0.5.0",
     "@changesets/cli": "^2.27.1",
+    "@changesets/types": "^6.0.0",
+    "@changesets/get-github-info": "^0.6.0",
     "@typescript-eslint/eslint-plugin": "^7.8.0",
     "@typescript-eslint/parser": "^7.8.0",
     "eslint": "^8.56.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,12 +8,15 @@ importers:
 
   .:
     devDependencies:
-      '@changesets/changelog-github':
-        specifier: ^0.5.0
-        version: 0.5.0
       '@changesets/cli':
         specifier: ^2.27.1
         version: 2.27.1
+      '@changesets/get-github-info':
+        specifier: ^0.6.0
+        version: 0.6.0
+      '@changesets/types':
+        specifier: ^6.0.0
+        version: 6.0.0
       '@typescript-eslint/eslint-plugin':
         specifier: ^7.8.0
         version: 7.8.0(@typescript-eslint/parser@7.8.0)(eslint@8.56.0)(typescript@5.4.3)
@@ -585,16 +588,6 @@ packages:
     resolution: {integrity: sha512-bHOx97iFI4OClIT35Lok3sJAwM31VbUM++gnMBV16fdbtBhgYu4dxsphBF/0AZZsyAHMrnM0yFcj5gZM1py6uQ==}
     dependencies:
       '@changesets/types': 6.0.0
-    dev: true
-
-  /@changesets/changelog-github@0.5.0:
-    resolution: {integrity: sha512-zoeq2LJJVcPJcIotHRJEEA2qCqX0AQIeFE+L21L8sRLPVqDhSXY8ZWAt2sohtBpFZkBwu+LUwMSKRr2lMy3LJA==}
-    dependencies:
-      '@changesets/get-github-info': 0.6.0
-      '@changesets/types': 6.0.0
-      dotenv: 8.6.0
-    transitivePeerDependencies:
-      - encoding
     dev: true
 
   /@changesets/cli@2.27.1:
@@ -3002,11 +2995,6 @@ packages:
   /dotenv@16.4.5:
     resolution: {integrity: sha512-ZmdL2rui+eB2YwhsWzjInR8LldtZHGDoQ1ugH85ppHKwpUHL7j7rN0Ti9NCnGiQbhaZ11FpR+7ao1dNsmduNUg==}
     engines: {node: '>=12'}
-    dev: true
-
-  /dotenv@8.6.0:
-    resolution: {integrity: sha512-IrPdXQsk2BbzvCBGBOTmmSH5SodmqZNt4ERAZDmW4CT+tL8VtvinqywuANaFu4bOMWki16nqf0e4oC0QIaDr/g==}
-    engines: {node: '>=10'}
     dev: true
 
   /eastasianwidth@0.2.0:


### PR DESCRIPTION
## Changes
- Update changelog format to remove the thank you message, and simplify the change line info
- Compare with the `origin/main` branch instead of `main` when running changesets

## Format

```
- [#{pull_request_id}]: {titleLine} ({users})\n{afterLines}
- [`{commit_hash_if_no_pull_request_id}`]: {titleLine} ({users})\n{afterLines}
- Updated dependencies [{commits.join(', ')}]
  - {packageName1}@{version}
  - {packageName2}@{version}
```

## Preview

## 0.2.0

### Minor Changes

- [#180](https://github.com/ckb-cell/rgbpp-sdk/pull/180): Update changelog format ([@ShookLyngs](https://github.com/ShookLyngs))

- [`f4776ea`](https://github.com/ckb-cell/rgbpp-sdk/commit/f4776ea4796b0070cbcaa9f036d3663aabc0bf0b): Update changelog format ([@ShookLyngs](https://github.com/ShookLyngs))

- Updated dependencies [[`f4776ea`](https://github.com/ckb-cell/rgbpp-sdk/commit/f4776ea4796b0070cbcaa9f036d3663aabc0bf0b)]:
  - @rgbpp-sdk/service@0.2.0