### PR TITLE
feat: add no_cache params to btc/rgbpp service api

### DIFF
--- a/packages/service/src/types/btc.ts
+++ b/packages/service/src/types/btc.ts
@@ -58,6 +58,7 @@ export interface BtcApiRecommendedFeeRates {
 
 export interface BtcApiBalanceParams {
   min_satoshi?: number;
+  no_cache?: boolean;
 }
 export interface BtcApiBalance {
   address: string;
@@ -70,6 +71,7 @@ export interface BtcApiBalance {
 export interface BtcApiUtxoParams {
   only_confirmed?: boolean;
   min_satoshi?: number;
+  no_cache?: boolean;
 }
 export interface BtcApiUtxo {
   txid: string;

--- a/packages/service/src/types/rgbpp.ts
+++ b/packages/service/src/types/rgbpp.ts
@@ -44,6 +44,7 @@ export interface RgbppApiTransactionState {
 
 export interface RgbppApiAssetsByAddressParams {
   type_script?: string;
+  no_cache?: boolean;
 }
 
 export interface RgbppApiSpvProof {

--- a/packages/service/tests/Service.test.ts
+++ b/packages/service/tests/Service.test.ts
@@ -92,6 +92,12 @@ describe(
         expect(filteredBalance.satoshi).toEqual(0);
         expect(filteredBalance.dust_satoshi).toEqual(originalBalance.satoshi + originalBalance.dust_satoshi);
       });
+      it('getBtcBalance() with no_cache', async () => {
+        const res = await service.getBtcBalance(btcAddress, {
+          no_cache: true,
+        });
+        expect(res.address).toEqual(btcAddress);
+      });
       it('getBtcUtxos()', async () => {
         const res = await service.getBtcUtxos(btcAddress);
         expect(Array.isArray(res)).toBe(true);
@@ -130,6 +136,12 @@ describe(
         for (const utxo of confirmedUtxos) {
           expect(utxo.status.confirmed).toBe(true);
         }
+      });
+      it('getBtcUtxos() with no_cache', async () => {
+        const utxos = await service.getBtcUtxos(btcAddress, {
+          no_cache: true,
+        });
+        expect(Array.isArray(utxos)).toBe(true);
       });
       it('getBtcTransactions()', async () => {
         const res = await service.getBtcTransactions(btcAddress);
@@ -247,6 +259,13 @@ describe(
         for (const cell of res) {
           expectCell(cell);
         }
+      });
+      it('getRgbppAssetsByBtcAddress() with no_cache', async () => {
+        const res = await service.getRgbppAssetsByBtcAddress(rgbppBtcAddress, {
+          no_cache: true,
+        });
+        expect(res).toBeDefined();
+        expect(res.length).toBeGreaterThan(0);
       });
       it('getRgbppSpvProof()', async () => {
         const res = await service.getRgbppSpvProof(rgbppBtcTxId, 6);


### PR DESCRIPTION
## Changes
The assets service will cache Bitcoin's UTXO data and RGB++'s cell data in subsequent updates and provide a `no_cache` parameter to skip cache. This PR adds parameter types and corresponding unit tests to support it.