### PR TITLE
fix(changeset): missing await in the changelog format file

### DIFF
--- a/.changeset/changelog-format.cjs
+++ b/.changeset/changelog-format.cjs
@@ -108,7 +108,7 @@ const changelogFunctions = {
       return '';
     }
 
-    const commits = Promise.all(
+    const commits = await Promise.all(
       changesets.map(async (cs) => {
         if (cs.commit) {
           let { links } = await getInfo({


### PR DESCRIPTION
## Changes
- Fix an issue in the `.changeset/changelog-format.cjs` file where the `commits` variable was not awaited, it was expected to be an Array instead of a Promise (source: https://github.com/ckb-cell/rgbpp-sdk/actions/runs/9171211422/job/25215054139)