### PR TITLE
feat(btc|service): support internal query data caching in TxBuilder.payFee()

### DIFF
--- a/.changeset/afraid-pianos-do.md
+++ b/.changeset/afraid-pianos-do.md
@@ -1,0 +1,5 @@
+---
+"@rgbpp-sdk/btc": minor
+---
+
+Support query data caching internally in TxBuilder/DataSource, preventing query from the BtcAssetsApi too often when paying fee 

--- a/packages/btc/README.md
+++ b/packages/btc/README.md
@@ -372,6 +372,8 @@ interface DataSource {
     allowInsufficient?: boolean;
     onlyNonRgbppUtxos?: boolean;
     onlyConfirmedUtxos?: boolean;
+    noUtxosCache?: boolean;
+    cacheKey?: string;
     excludeUtxos?: {
       txid: string;
       vout: number;

--- a/packages/btc/README.md
+++ b/packages/btc/README.md
@@ -372,8 +372,8 @@ interface DataSource {
     allowInsufficient?: boolean;
     onlyNonRgbppUtxos?: boolean;
     onlyConfirmedUtxos?: boolean;
-    noUtxosCache?: boolean;
-    cacheKey?: string;
+    noAssetsApiCache?: boolean;
+    internalCacheKey?: string;
     excludeUtxos?: {
       txid: string;
       vout: number;

--- a/packages/btc/src/query/cache.ts
+++ b/packages/btc/src/query/cache.ts
@@ -1,0 +1,62 @@
+import { Utxo } from '../transaction/utxo';
+
+export class DataCache {
+  private utxos: Map<string, Utxo[]>; // Map<Key, Utxo[]>
+  private hasRgbppAssets: Map<string, boolean>; // Map<`{txid}:{vout}`, HasAssets>
+
+  constructor() {
+    this.utxos = new Map();
+    this.hasRgbppAssets = new Map();
+  }
+
+  setUtxos(key: string, utxos: Utxo[]) {
+    this.utxos.set(key, utxos);
+  }
+  getUtxos(key: string): Utxo[] | undefined {
+    return this.utxos.get(key);
+  }
+  cleanUtxos(key: string) {
+    if (this.utxos.has(key)) {
+      this.utxos.delete(key);
+    }
+  }
+  async optionalCacheUtxos(props: { key?: string; getter: () => Promise<Utxo[]> | Utxo[] }): Promise<Utxo[]> {
+    if (props.key && this.utxos.has(props.key)) {
+      return this.getUtxos(props.key) as Utxo[];
+    }
+
+    const utxos = await props.getter();
+    if (props.key) {
+      this.setUtxos(props.key, utxos);
+    }
+
+    return utxos;
+  }
+
+  setHasRgbppAssets(key: string, hasAssets: boolean) {
+    this.hasRgbppAssets.set(key, hasAssets);
+  }
+  getHasRgbppAssets(key: string): boolean | undefined {
+    return this.hasRgbppAssets.get(key);
+  }
+  cleanHasRgbppAssets(key: string) {
+    if (this.hasRgbppAssets.has(key)) {
+      this.hasRgbppAssets.delete(key);
+    }
+  }
+  async optionalCacheHasRgbppAssets(props: {
+    key?: string;
+    getter: () => Promise<boolean> | boolean;
+  }): Promise<boolean> {
+    if (props.key && this.hasRgbppAssets.has(props.key)) {
+      return this.getHasRgbppAssets(props.key) as boolean;
+    }
+
+    const hasRgbppAssets = await props.getter();
+    if (props.key) {
+      this.setHasRgbppAssets(props.key, hasRgbppAssets);
+    }
+
+    return hasRgbppAssets;
+  }
+}

--- a/packages/btc/src/query/source.ts
+++ b/packages/btc/src/query/source.ts
@@ -105,8 +105,8 @@ export class DataSource {
     allowInsufficient?: boolean;
     onlyNonRgbppUtxos?: boolean;
     onlyConfirmedUtxos?: boolean;
-    noUtxosCache?: boolean;
-    cacheKey?: string;
+    noAssetsApiCache?: boolean;
+    internalCacheKey?: string;
     excludeUtxos?: {
       txid: string;
       vout: number;
@@ -122,19 +122,19 @@ export class DataSource {
       minUtxoSatoshi,
       onlyConfirmedUtxos,
       onlyNonRgbppUtxos,
-      noUtxosCache,
-      cacheKey,
+      noAssetsApiCache,
+      internalCacheKey,
       allowInsufficient = false,
       excludeUtxos = [],
     } = props;
 
     const utxos = await this.cache.optionalCacheUtxos({
-      key: cacheKey,
+      key: internalCacheKey,
       getter: () =>
         this.getUtxos(address, {
           only_confirmed: onlyConfirmedUtxos,
           min_satoshi: minUtxoSatoshi,
-          no_cache: noUtxosCache,
+          no_cache: noAssetsApiCache,
         }),
     });
 

--- a/packages/btc/src/query/source.ts
+++ b/packages/btc/src/query/source.ts
@@ -6,14 +6,17 @@ import { TxAddressOutput } from '../transaction/build';
 import { isOpReturnScriptPubkey } from '../transaction/embed';
 import { addressToScriptPublicKeyHex, getAddressType } from '../address';
 import { remove0x } from '../utils';
+import { DataCache } from './cache';
 
 export class DataSource {
+  public cache: DataCache;
   public service: BtcAssetsApi;
   public networkType: NetworkType;
 
   constructor(service: BtcAssetsApi, networkType: NetworkType) {
     this.service = service;
     this.networkType = networkType;
+    this.cache = new DataCache();
   }
 
   // Query a UTXO from the service.
@@ -102,6 +105,8 @@ export class DataSource {
     allowInsufficient?: boolean;
     onlyNonRgbppUtxos?: boolean;
     onlyConfirmedUtxos?: boolean;
+    noUtxosCache?: boolean;
+    cacheKey?: string;
     excludeUtxos?: {
       txid: string;
       vout: number;
@@ -117,12 +122,20 @@ export class DataSource {
       minUtxoSatoshi,
       onlyConfirmedUtxos,
       onlyNonRgbppUtxos,
+      noUtxosCache,
+      cacheKey,
       allowInsufficient = false,
       excludeUtxos = [],
     } = props;
-    const utxos = await this.getUtxos(address, {
-      only_confirmed: onlyConfirmedUtxos,
-      min_satoshi: minUtxoSatoshi,
+
+    const utxos = await this.cache.optionalCacheUtxos({
+      key: cacheKey,
+      getter: () =>
+        this.getUtxos(address, {
+          only_confirmed: onlyConfirmedUtxos,
+          min_satoshi: minUtxoSatoshi,
+          no_cache: noUtxosCache,
+        }),
     });
 
     const collected = [];
@@ -140,8 +153,14 @@ export class DataSource {
         }
       }
       if (onlyNonRgbppUtxos) {
-        const ckbRgbppAssets = await this.service.getRgbppAssetsByBtcUtxo(utxo.txid, utxo.vout);
-        if (ckbRgbppAssets && ckbRgbppAssets.length > 0) {
+        const hasRgbppAssets = await this.cache.optionalCacheHasRgbppAssets({
+          key: `${utxo.txid}:${utxo.vout}`,
+          getter: async () => {
+            const ckbRgbppAssets = await this.service.getRgbppAssetsByBtcUtxo(utxo.txid, utxo.vout);
+            return Array.isArray(ckbRgbppAssets) && ckbRgbppAssets.length > 0;
+          },
+        });
+        if (hasRgbppAssets) {
           continue;
         }
       }

--- a/packages/btc/src/transaction/build.ts
+++ b/packages/btc/src/transaction/build.ts
@@ -136,13 +136,12 @@ export class TxBuilder {
     publicKey?: string;
     changeAddress?: string;
     deductFromOutputs?: boolean;
-    noUtxosCache?: boolean;
     feeRate?: number;
   }): Promise<{
     fee: number;
     feeRate: number;
   }> {
-    const { address, publicKey, feeRate, changeAddress, deductFromOutputs, noUtxosCache } = props;
+    const { address, publicKey, feeRate, changeAddress, deductFromOutputs } = props;
     const originalInputs = clone(this.inputs);
     const originalOutputs = clone(this.outputs);
 
@@ -182,7 +181,6 @@ export class TxBuilder {
           amount: returnAmount,
           fromAddress: address,
           fromPublicKey: publicKey,
-          noUtxosCache,
           cacheKey,
         });
       } else {
@@ -196,7 +194,6 @@ export class TxBuilder {
           targetAmount,
           changeAddress,
           deductFromOutputs,
-          noUtxosCache,
           cacheKey,
         });
       }
@@ -228,7 +225,6 @@ export class TxBuilder {
     changeAddress?: string;
     injectCollected?: boolean;
     deductFromOutputs?: boolean;
-    noUtxosCache?: boolean;
     cacheKey?: string;
   }) {
     if (!isSupportedFromAddress(props.address)) {
@@ -251,8 +247,8 @@ export class TxBuilder {
         address: props.address,
         targetAmount: _targetAmount,
         allowInsufficient: true,
+        noUtxosCache: true,
         cacheKey: props.cacheKey,
-        noUtxosCache: props.noUtxosCache,
         minUtxoSatoshi: this.minUtxoSatoshi,
         onlyNonRgbppUtxos: this.onlyNonRgbppUtxos,
         onlyConfirmedUtxos: this.onlyConfirmedUtxos,
@@ -377,10 +373,9 @@ export class TxBuilder {
     address: string;
     fromAddress: string;
     fromPublicKey?: string;
-    noUtxosCache?: boolean;
     cacheKey?: string;
   }) {
-    const { address, fromAddress, fromPublicKey, amount, noUtxosCache, cacheKey } = props;
+    const { address, fromAddress, fromPublicKey, amount, cacheKey } = props;
 
     // If any (output.fixed != true) is found in the outputs (search in ASC order),
     // return the change value to the first matched output.
@@ -412,7 +407,6 @@ export class TxBuilder {
         changeAddress: address,
         injectCollected: true,
         deductFromOutputs: false,
-        noUtxosCache,
         cacheKey,
       });
       if (collected < amount) {

--- a/packages/btc/src/transaction/build.ts
+++ b/packages/btc/src/transaction/build.ts
@@ -145,9 +145,9 @@ export class TxBuilder {
     const originalInputs = clone(this.inputs);
     const originalOutputs = clone(this.outputs);
 
-    // Create a cache key to prevent querying the Utxo[] too often
+    // Create a cache key to enable the internal caching, prevent querying the Utxo[] too often
     // TODO: consider provide an option to disable the cache
-    const cacheKey = `${Date.now()}`;
+    const internalCacheKey = `${Date.now()}`;
 
     // Fill a default recommended fee rate if props.feeRate is not provided
     let defaultFeeRate: number | undefined;
@@ -181,7 +181,7 @@ export class TxBuilder {
           amount: returnAmount,
           fromAddress: address,
           fromPublicKey: publicKey,
-          cacheKey,
+          internalCacheKey,
         });
       } else {
         // If the inputs have insufficient satoshi, a satoshi collection is required.
@@ -194,7 +194,7 @@ export class TxBuilder {
           targetAmount,
           changeAddress,
           deductFromOutputs,
-          cacheKey,
+          internalCacheKey,
         });
       }
 
@@ -210,7 +210,7 @@ export class TxBuilder {
     }
 
     // Clear cache for the Utxo[] list
-    this.source.cache.cleanUtxos(cacheKey);
+    this.source.cache.cleanUtxos(internalCacheKey);
 
     return {
       fee: currentFee,
@@ -225,7 +225,7 @@ export class TxBuilder {
     changeAddress?: string;
     injectCollected?: boolean;
     deductFromOutputs?: boolean;
-    cacheKey?: string;
+    internalCacheKey?: string;
   }) {
     if (!isSupportedFromAddress(props.address)) {
       throw TxBuildError.withComment(ErrorCodes.UNSUPPORTED_ADDRESS_TYPE, props.address);
@@ -241,14 +241,18 @@ export class TxBuilder {
     /**
      * Collect from the "from" address via DataSource.
      * Will update the value of inputs/collected/changeAmount.
+     *
+     * The API has two layers of data caching:
+     * - noAssetsApiCache: BtcAssetsApi cache, can be disabled if the set to true
+     * - internalCacheKey: Internal cache, enabled if the key is provided
      */
     const _collect = async (_targetAmount: number) => {
       const { utxos, satoshi } = await this.source.collectSatoshi({
         address: props.address,
         targetAmount: _targetAmount,
         allowInsufficient: true,
-        noUtxosCache: true,
-        cacheKey: props.cacheKey,
+        noAssetsApiCache: true,
+        internalCacheKey: props.internalCacheKey,
         minUtxoSatoshi: this.minUtxoSatoshi,
         onlyNonRgbppUtxos: this.onlyNonRgbppUtxos,
         onlyConfirmedUtxos: this.onlyConfirmedUtxos,
@@ -373,9 +377,9 @@ export class TxBuilder {
     address: string;
     fromAddress: string;
     fromPublicKey?: string;
-    cacheKey?: string;
+    internalCacheKey?: string;
   }) {
-    const { address, fromAddress, fromPublicKey, amount, cacheKey } = props;
+    const { address, fromAddress, fromPublicKey, amount, internalCacheKey } = props;
 
     // If any (output.fixed != true) is found in the outputs (search in ASC order),
     // return the change value to the first matched output.
@@ -407,7 +411,7 @@ export class TxBuilder {
         changeAddress: address,
         injectCollected: true,
         deductFromOutputs: false,
-        cacheKey,
+        internalCacheKey,
       });
       if (collected < amount) {
         throw TxBuildError.withComment(ErrorCodes.INSUFFICIENT_UTXO, `expected: ${amount}, actual: ${collected}`);

--- a/packages/service/README.md
+++ b/packages/service/README.md
@@ -223,6 +223,7 @@ interface BtcApiBlockTransactionIds {
 
 interface BtcApiBalanceParams {
   min_satoshi?: number;
+  no_cache?: boolean;
 }
 
 interface BtcApiBalance {
@@ -236,6 +237,7 @@ interface BtcApiBalance {
 interface BtcApiUtxoParams {
   only_confirmed?: boolean;
   min_satoshi?: number;
+  no_cache?: boolean;
 }
 
 interface BtcApiUtxo {
@@ -329,6 +331,7 @@ interface RgbppApiTransactionState {
 
 interface RgbppApiAssetsByAddressParams {
   type_script?: string;
+  no_cache?: boolean;
 }
 
 interface RgbppApiSpvProof {


### PR DESCRIPTION
## Changes
- Support query data caching internally in TxBuilder/DataSource, preventing query from the service too often
- Add type changes in the #181 to the service readme

## Query data cache

Previously, when collecting inputs for paying fees, the `BtcAssetsApi.getBtcUtxos()` API and the `BtcAssetsApi.getRgbppAssetsByBtcUtxo()` API were queried multiple times. In this PR, a DataCache is added to prevent querying the same API with the same params too often.

Reference: https://github.com/ckb-cell/rgbpp-sdk/issues/173#issuecomment-2112523137

## Test
- [x] @Dawn-githup 