### PR TITLE
chore(ci): fix snapshot versioning

### DIFF
--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -49,12 +49,25 @@ jobs:
       - name: Build packages
         run: pnpm run build:packages
 
-      - name: Publish to npm (ignore GitHub)
+      - name: Add snapshot changeset (ensure at least has a changeset)
+        run: |
+          cat << EOF > ".changeset/snap-release-changeset.md"
+            ---
+            "@rgbpp-sdk/btc": patch
+            ---
+            Add temp changeset for snapshot releases
+          EOF
+
+      - name: Version packages to "0.0.0-snap-{timestamp}"
+        run: npx changeset version --snapshot snap
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Publish to npm
         id: changesets
         uses: changesets/action@v1
         with:
-          version: npx changeset version --snapshot snap
-          publish: npx changeset publish --snapshot --tag snap
+          publish: npx changeset publish --no-git-tag --snapshot --tag snap
           createGithubReleases: false
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Changes
- Fix [#163](https://github.com/ckb-cell/rgbpp-sdk/issues/163) by ensuring a temp changeset is always added before the `changeset version` command is executed
- Fix snapshot versioning by reverting code, should not run version command in the changesets/action

## Related issues
- Resolves #163

## Proof

When releasing snapshots, we expect each package to be versioned as `0.0.0-snap-{timestamp}`, and things should work as expected if the `.changeset` folder contains at least one changeset. If the condition has not been met, the `changeset version` command will be skipped, which causes the versions of the packages and the changelog file remain the same as before.

An example of skipping (which causes the [#163](https://github.com/ckb-cell/rgbpp-sdk/issues/163) issue):

```
% changeset version --snapshot snap
🦋  warn No unreleased changesets found, exiting.
```

To address the issue, an extra step has been added to the `snapshot.yml` workflow to always add a temp changest before executing the `changeset version` command. This extra step ensures the versioning command will always updates the versions of the packages, instead of doing nothing. 

Here's an example action where the repo contains no changeset in the `.changeset` folder, even though the versioning command worked and the snapshot was released successfully. Therefore I believe the issue is considered resolved: https://github.com/ShookLyngs/test-changesets/actions/runs/9214982527/job/25352404438#step:9:9

```
Run npx changeset version --snapshot snap
🦋  All files have been updated. Review them and commit at your leisure
```