### PR TITLE
feat(ckb|example): Dynamic fetching cell deps deployed by TypeID

### DIFF
--- a/examples/xudt-on-ckb/1-issue-xudt.ts
+++ b/examples/xudt-on-ckb/1-issue-xudt.ts
@@ -11,12 +11,11 @@ import {
   getUniqueTypeScript,
   u128ToLe,
   encodeRgbppTokenInfo,
-  getXudtDep,
-  getUniqueTypeDep,
   SECP256K1_WITNESS_LOCK_SIZE,
   calculateTransactionFee,
   generateUniqueTypeArgs,
   calculateXudtTokenInfoCellCapacity,
+  fetchTypeIdCellDeps,
 } from 'rgbpp/ckb';
 import { CKB_PRIVATE_KEY, ckbAddress, collector, isMainnet } from './env';
 
@@ -77,7 +76,10 @@ const issueXudt = async ({ xudtTotalAmount, tokenInfo }: { xudtTotalAmount: bigi
   const emptyWitness = { lock: '', inputType: '', outputType: '' };
   const witnesses = inputs.map((_, index) => (index === 0 ? emptyWitness : '0x'));
 
-  const cellDeps = [getSecp256k1CellDep(isMainnet), getUniqueTypeDep(isMainnet), getXudtDep(isMainnet)];
+  const cellDeps = [
+    getSecp256k1CellDep(isMainnet),
+    ...(await fetchTypeIdCellDeps(isMainnet, { xudt: true, unique: true })),
+  ];
 
   const unsignedTx = {
     version: '0x0',

--- a/examples/xudt-on-ckb/2-transfer-xudt.ts
+++ b/examples/xudt-on-ckb/2-transfer-xudt.ts
@@ -8,11 +8,10 @@ import {
   MIN_CAPACITY,
   append0x,
   u128ToLe,
-  getXudtDep,
-  getUniqueTypeDep,
   SECP256K1_WITNESS_LOCK_SIZE,
   calculateTransactionFee,
   NoXudtLiveCellError,
+  fetchTypeIdCellDeps,
 } from 'rgbpp/ckb';
 import { CKB_PRIVATE_KEY, ckbAddress, collector, isMainnet } from './env';
 
@@ -104,7 +103,7 @@ const transferXudt = async ({ xudtType, receivers }: XudtTransferParams) => {
   const emptyWitness = { lock: '', inputType: '', outputType: '' };
   const witnesses = inputs.map((_, index) => (index === 0 ? emptyWitness : '0x'));
 
-  const cellDeps = [getSecp256k1CellDep(isMainnet), getUniqueTypeDep(isMainnet), getXudtDep(isMainnet)];
+  const cellDeps = [getSecp256k1CellDep(isMainnet), ...(await fetchTypeIdCellDeps(isMainnet, { xudt: true }))];
 
   const unsignedTx = {
     version: '0x0',

--- a/packages/ckb/src/collector/index.ts
+++ b/packages/ckb/src/collector/index.ts
@@ -159,9 +159,9 @@ export class Collector {
     return { inputs, sumInputsCapacity, sumAmount };
   }
 
-  async getLiveCell(outPoint: CKBComponents.OutPoint): Promise<CKBComponents.LiveCell> {
+  async getLiveCell(outPoint: CKBComponents.OutPoint, withData = true): Promise<CKBComponents.LiveCell> {
     const ckb = new CKB(this.ckbNodeUrl);
-    const { cell } = await ckb.rpc.getLiveCell(outPoint, true);
+    const { cell } = await ckb.rpc.getLiveCell(outPoint, withData);
     return cell;
   }
 }

--- a/packages/ckb/src/rgbpp/btc-jump-ckb.ts
+++ b/packages/ckb/src/rgbpp/btc-jump-ckb.ts
@@ -6,6 +6,8 @@ import {
   calculateRgbppCellCapacity,
   calculateTransactionFee,
   deduplicateList,
+  fetchRgbppAndConfigCellDeps,
+  fetchXudtCellDep,
   isLockArgsSizeExceeded,
   isScriptEqual,
   isUDTTypeSupported,
@@ -23,13 +25,7 @@ import {
   isRgbppCapacitySufficientForChange,
 } from '../utils/rgbpp';
 import { Hex, IndexerCell } from '../types';
-import {
-  RGBPP_WITNESS_PLACEHOLDER,
-  getRgbppLockConfigDep,
-  getRgbppLockDep,
-  getSecp256k1CellDep,
-  getXudtDep,
-} from '../constants';
+import { RGBPP_WITNESS_PLACEHOLDER, getSecp256k1CellDep } from '../constants';
 import { addressToScript, getTransactionSize } from '@nervosnetwork/ckb-sdk-utils';
 
 /**
@@ -139,7 +135,10 @@ export const genBtcJumpCkbVirtualTx = async ({
     outputsData.push(otherRgbppCell.outputData);
   }
 
-  const cellDeps = [getRgbppLockDep(isMainnet), getXudtDep(isMainnet), getRgbppLockConfigDep(isMainnet)];
+  const cellDeps = [
+    ...(await fetchRgbppAndConfigCellDeps(isMainnet)),
+    await fetchXudtCellDep(isMainnet),
+  ];
   if (needPaymasterCell) {
     cellDeps.push(getSecp256k1CellDep(isMainnet));
   }

--- a/packages/ckb/src/rgbpp/btc-jump-ckb.ts
+++ b/packages/ckb/src/rgbpp/btc-jump-ckb.ts
@@ -6,8 +6,7 @@ import {
   calculateRgbppCellCapacity,
   calculateTransactionFee,
   deduplicateList,
-  fetchRgbppAndConfigCellDeps,
-  fetchXudtCellDep,
+  fetchTypeIdCellDeps,
   isLockArgsSizeExceeded,
   isScriptEqual,
   isUDTTypeSupported,
@@ -135,10 +134,7 @@ export const genBtcJumpCkbVirtualTx = async ({
     outputsData.push(otherRgbppCell.outputData);
   }
 
-  const cellDeps = [
-    ...(await fetchRgbppAndConfigCellDeps(isMainnet)),
-    await fetchXudtCellDep(isMainnet),
-  ];
+  const cellDeps = await fetchTypeIdCellDeps(isMainnet, { rgbpp: true, xudt: true });
   if (needPaymasterCell) {
     cellDeps.push(getSecp256k1CellDep(isMainnet));
   }

--- a/packages/ckb/src/rgbpp/btc-time.ts
+++ b/packages/ckb/src/rgbpp/btc-time.ts
@@ -10,11 +10,8 @@ import {
 import {
   BTC_JUMP_CONFIRMATION_BLOCKS,
   SECP256K1_WITNESS_LOCK_SIZE,
-  getBtcTimeLockConfigDep,
-  getBtcTimeLockDep,
   getBtcTimeLockScript,
   getSecp256k1CellDep,
-  getXudtDep,
 } from '../constants';
 import { BTCTimeUnlock } from '../schemas/generated/rgbpp';
 import { BtcTimeCellStatusParams, BtcTimeCellsParams, Hex, SignBtcTimeCellsTxParams } from '../types';
@@ -23,6 +20,7 @@ import {
   btcTxIdFromBtcTimeLockArgs,
   calculateTransactionFee,
   compareInputs,
+  fetchTypeIdCellDeps,
   genBtcTimeLockArgs,
   lockScriptFromBtcTimeLockArgs,
   transformSpvProof,
@@ -62,11 +60,7 @@ export const buildBtcTimeCellsSpentTx = async ({
 
   const outputsData = sortedBtcTimeCells.map((cell) => cell.outputData);
 
-  const cellDeps: CKBComponents.CellDep[] = [
-    getBtcTimeLockDep(isMainnet),
-    getXudtDep(isMainnet),
-    getBtcTimeLockConfigDep(isMainnet),
-  ];
+  const cellDeps: CKBComponents.CellDep[] = await fetchTypeIdCellDeps(isMainnet, { btcTime: true, xudt: true });
 
   const witnesses: Hex[] = [];
 

--- a/packages/ckb/src/rgbpp/btc-transfer.ts
+++ b/packages/ckb/src/rgbpp/btc-transfer.ts
@@ -13,6 +13,7 @@ import {
   calculateRgbppCellCapacity,
   calculateTransactionFee,
   deduplicateList,
+  fetchRgbppXudtCellDeps,
   isScriptEqual,
   isUDTTypeSupported,
   u128ToLe,
@@ -33,11 +34,8 @@ import {
   MIN_CAPACITY,
   RGBPP_WITNESS_PLACEHOLDER,
   SECP256K1_WITNESS_LOCK_SIZE,
-  getRgbppLockConfigDep,
-  getRgbppLockDep,
   getRgbppLockScript,
   getSecp256k1CellDep,
-  getXudtDep,
 } from '../constants';
 import {
   addressToScript,
@@ -172,7 +170,7 @@ export const genBtcTransferCkbVirtualTx = async ({
     handleNonTargetRgbppCells(outputs.length);
   }
 
-  const cellDeps = [getRgbppLockDep(isMainnet), getXudtDep(isMainnet), getRgbppLockConfigDep(isMainnet)];
+  const cellDeps = await fetchRgbppXudtCellDeps(isMainnet);
   if (needPaymasterCell) {
     cellDeps.push(getSecp256k1CellDep(isMainnet));
   }
@@ -286,13 +284,7 @@ export const genBtcBatchTransferCkbVirtualTx = async ({
     outputsData.push(append0x(u128ToLe(sumAmount - sumTransferAmount)));
   }
 
-  const cellDeps = [
-    getRgbppLockDep(isMainnet),
-    getXudtDep(isMainnet),
-    getRgbppLockConfigDep(isMainnet),
-    getSecp256k1CellDep(isMainnet),
-  ];
-
+  const cellDeps = [...(await fetchRgbppXudtCellDeps(isMainnet)), getSecp256k1CellDep(isMainnet)];
   const witnesses: Hex[] = [];
   const lockArgsSet: Set<string> = new Set();
   for (const cell of rgbppCells) {

--- a/packages/ckb/src/rgbpp/btc-transfer.ts
+++ b/packages/ckb/src/rgbpp/btc-transfer.ts
@@ -13,7 +13,7 @@ import {
   calculateRgbppCellCapacity,
   calculateTransactionFee,
   deduplicateList,
-  fetchRgbppXudtCellDeps,
+  fetchTypeIdCellDeps,
   isScriptEqual,
   isUDTTypeSupported,
   u128ToLe,
@@ -170,7 +170,7 @@ export const genBtcTransferCkbVirtualTx = async ({
     handleNonTargetRgbppCells(outputs.length);
   }
 
-  const cellDeps = await fetchRgbppXudtCellDeps(isMainnet);
+  const cellDeps = await fetchTypeIdCellDeps(isMainnet, { rgbpp: true, xudt: true });
   if (needPaymasterCell) {
     cellDeps.push(getSecp256k1CellDep(isMainnet));
   }
@@ -284,7 +284,10 @@ export const genBtcBatchTransferCkbVirtualTx = async ({
     outputsData.push(append0x(u128ToLe(sumAmount - sumTransferAmount)));
   }
 
-  const cellDeps = [...(await fetchRgbppXudtCellDeps(isMainnet)), getSecp256k1CellDep(isMainnet)];
+  const cellDeps = [
+    ...(await fetchTypeIdCellDeps(isMainnet, { rgbpp: true, xudt: true })),
+    getSecp256k1CellDep(isMainnet),
+  ];
   const witnesses: Hex[] = [];
   const lockArgsSet: Set<string> = new Set();
   for (const cell of rgbppCells) {

--- a/packages/ckb/src/rgbpp/ckb-jump-btc.ts
+++ b/packages/ckb/src/rgbpp/ckb-jump-btc.ts
@@ -6,11 +6,12 @@ import {
   calculateRgbppCellCapacity,
   calculateTransactionFee,
   calculateUdtCellCapacity,
+  fetchTypeIdCellDeps,
   isTypeAssetSupported,
   u128ToLe,
 } from '../utils';
 import { genRgbppLockScript } from '../utils/rgbpp';
-import { MAX_FEE, MIN_CAPACITY, RGBPP_TX_WITNESS_MAX_SIZE, getXudtDep } from '../constants';
+import { MAX_FEE, MIN_CAPACITY, RGBPP_TX_WITNESS_MAX_SIZE } from '../constants';
 import { addressToScript, getTransactionSize } from '@nervosnetwork/ckb-sdk-utils';
 
 /**
@@ -98,7 +99,7 @@ export const genCkbJumpBtcVirtualTx = async ({
   });
   outputsData.push('0x');
 
-  const cellDeps = [getXudtDep(isMainnet)];
+  const cellDeps = await fetchTypeIdCellDeps(isMainnet, { xudt: true });
   const witnesses = inputs.map(() => '0x');
 
   const ckbRawTx: CKBComponents.RawTransaction = {
@@ -206,7 +207,7 @@ export const genCkbBatchJumpBtcVirtualTx = async ({
   });
   outputsData.push('0x');
 
-  const cellDeps = [getXudtDep(isMainnet)];
+  const cellDeps = await fetchTypeIdCellDeps(isMainnet, { xudt: true });
   const witnesses = inputs.map(() => '0x');
 
   const ckbRawTx: CKBComponents.RawTransaction = {

--- a/packages/ckb/src/rgbpp/launch.ts
+++ b/packages/ckb/src/rgbpp/launch.ts
@@ -4,6 +4,7 @@ import {
   append0x,
   calculateRgbppTokenInfoCellCapacity,
   calculateTransactionFee,
+  fetchRgbppXudtCellDeps,
   generateUniqueTypeArgs,
   u128ToLe,
 } from '../utils';
@@ -19,13 +20,10 @@ import {
   MAX_FEE,
   RGBPP_TX_WITNESS_MAX_SIZE,
   RGBPP_WITNESS_PLACEHOLDER,
-  getRgbppLockDep,
-  getXudtDep,
   getXudtTypeScript,
   getUniqueTypeScript,
   getUniqueTypeDep,
   UNLOCKABLE_LOCK_SCRIPT,
-  getRgbppLockConfigDep,
 } from '../constants';
 import { getTransactionSize, scriptToHash } from '@nervosnetwork/ckb-sdk-utils';
 
@@ -80,12 +78,7 @@ export const genRgbppLaunchCkbVirtualTx = async ({
   ];
 
   const outputsData = [append0x(u128ToLe(launchAmount)), encodeRgbppTokenInfo(rgbppTokenInfo)];
-  const cellDeps = [
-    getRgbppLockDep(isMainnet),
-    getRgbppLockConfigDep(isMainnet),
-    getXudtDep(isMainnet),
-    getUniqueTypeDep(isMainnet),
-  ];
+  const cellDeps = [...(await fetchRgbppXudtCellDeps(isMainnet)), getUniqueTypeDep(isMainnet)];
 
   const witnesses: Hex[] = inputs.map((_, index) => (index === 0 ? RGBPP_WITNESS_PLACEHOLDER : '0x'));
 

--- a/packages/ckb/src/rgbpp/launch.ts
+++ b/packages/ckb/src/rgbpp/launch.ts
@@ -4,7 +4,7 @@ import {
   append0x,
   calculateRgbppTokenInfoCellCapacity,
   calculateTransactionFee,
-  fetchRgbppXudtCellDeps,
+  fetchTypeIdCellDeps,
   generateUniqueTypeArgs,
   u128ToLe,
 } from '../utils';
@@ -22,7 +22,6 @@ import {
   RGBPP_WITNESS_PLACEHOLDER,
   getXudtTypeScript,
   getUniqueTypeScript,
-  getUniqueTypeDep,
   UNLOCKABLE_LOCK_SCRIPT,
 } from '../constants';
 import { getTransactionSize, scriptToHash } from '@nervosnetwork/ckb-sdk-utils';
@@ -78,7 +77,7 @@ export const genRgbppLaunchCkbVirtualTx = async ({
   ];
 
   const outputsData = [append0x(u128ToLe(launchAmount)), encodeRgbppTokenInfo(rgbppTokenInfo)];
-  const cellDeps = [...(await fetchRgbppXudtCellDeps(isMainnet)), getUniqueTypeDep(isMainnet)];
+  const cellDeps = await fetchTypeIdCellDeps(isMainnet, { rgbpp: true, xudt: true, unique: true });
 
   const witnesses: Hex[] = inputs.map((_, index) => (index === 0 ? RGBPP_WITNESS_PLACEHOLDER : '0x'));
 

--- a/packages/ckb/src/spore/cluster.ts
+++ b/packages/ckb/src/spore/cluster.ts
@@ -1,6 +1,6 @@
 import { RgbppCkbVirtualTx } from '../types/rgbpp';
 import { packRawClusterData } from '@spore-sdk/core';
-import { append0x, calculateTransactionFee, fetchRgbppAndConfigCellDeps } from '../utils';
+import { append0x, calculateTransactionFee, fetchTypeIdCellDeps } from '../utils';
 import { buildPreLockArgs, calculateCommitment, genRgbppLockScript } from '../utils/rgbpp';
 import { CreateClusterCkbVirtualTxParams, Hex, SporeVirtualTxResult } from '../types';
 import {
@@ -60,7 +60,7 @@ export const genCreateClusterCkbVirtualTx = async ({
     },
   ];
   const outputsData: Hex[] = [bytesToHex(packRawClusterData(clusterData))];
-  const cellDeps = [...(await fetchRgbppAndConfigCellDeps(isMainnet)), getClusterTypeDep(isMainnet)];
+  const cellDeps = [...(await fetchTypeIdCellDeps(isMainnet, {rgbpp: true})), getClusterTypeDep(isMainnet)];
   const sporeCoBuild = generateClusterCreateCoBuild(outputs[0], outputsData[0]);
   const witnesses = [RGBPP_WITNESS_PLACEHOLDER, sporeCoBuild];
 

--- a/packages/ckb/src/spore/cluster.ts
+++ b/packages/ckb/src/spore/cluster.ts
@@ -1,6 +1,6 @@
 import { RgbppCkbVirtualTx } from '../types/rgbpp';
 import { packRawClusterData } from '@spore-sdk/core';
-import { append0x, calculateTransactionFee } from '../utils';
+import { append0x, calculateTransactionFee, fetchRgbppAndConfigCellDeps } from '../utils';
 import { buildPreLockArgs, calculateCommitment, genRgbppLockScript } from '../utils/rgbpp';
 import { CreateClusterCkbVirtualTxParams, Hex, SporeVirtualTxResult } from '../types';
 import {
@@ -8,8 +8,6 @@ import {
   RGBPP_WITNESS_PLACEHOLDER,
   getClusterTypeDep,
   getClusterTypeScript,
-  getRgbppLockConfigDep,
-  getRgbppLockDep,
   getRgbppLockScript,
 } from '../constants';
 import { generateClusterCreateCoBuild, generateClusterId } from '../utils/spore';
@@ -62,7 +60,7 @@ export const genCreateClusterCkbVirtualTx = async ({
     },
   ];
   const outputsData: Hex[] = [bytesToHex(packRawClusterData(clusterData))];
-  const cellDeps = [getRgbppLockDep(isMainnet), getRgbppLockConfigDep(isMainnet), getClusterTypeDep(isMainnet)];
+  const cellDeps = [...(await fetchRgbppAndConfigCellDeps(isMainnet)), getClusterTypeDep(isMainnet)];
   const sporeCoBuild = generateClusterCreateCoBuild(outputs[0], outputsData[0]);
   const witnesses = [RGBPP_WITNESS_PLACEHOLDER, sporeCoBuild];
 

--- a/packages/ckb/src/spore/cluster.ts
+++ b/packages/ckb/src/spore/cluster.ts
@@ -60,7 +60,7 @@ export const genCreateClusterCkbVirtualTx = async ({
     },
   ];
   const outputsData: Hex[] = [bytesToHex(packRawClusterData(clusterData))];
-  const cellDeps = [...(await fetchTypeIdCellDeps(isMainnet, {rgbpp: true})), getClusterTypeDep(isMainnet)];
+  const cellDeps = [...(await fetchTypeIdCellDeps(isMainnet, { rgbpp: true })), getClusterTypeDep(isMainnet)];
   const sporeCoBuild = generateClusterCreateCoBuild(outputs[0], outputsData[0]);
   const witnesses = [RGBPP_WITNESS_PLACEHOLDER, sporeCoBuild];
 

--- a/packages/ckb/src/spore/leap.ts
+++ b/packages/ckb/src/spore/leap.ts
@@ -1,5 +1,5 @@
 import { BtcTimeCellsParams, RgbppCkbVirtualTx } from '../types/rgbpp';
-import { append0x, calculateTransactionFee } from '../utils';
+import { append0x, calculateTransactionFee, fetchRgbppAndConfigCellDeps } from '../utils';
 import {
   btcTxIdFromBtcTimeLockArgs,
   buildSpvClientCellDep,
@@ -21,8 +21,6 @@ import {
   RGBPP_WITNESS_PLACEHOLDER,
   getBtcTimeLockConfigDep,
   getBtcTimeLockDep,
-  getRgbppLockConfigDep,
-  getRgbppLockDep,
   getRgbppLockScript,
   getSporeTypeDep,
 } from '../constants';
@@ -80,7 +78,7 @@ export const genLeapSporeFromBtcToCkbVirtualTx = async ({
     },
   ];
   const outputsData: Hex[] = [sporeCell.outputData];
-  const cellDeps = [getRgbppLockDep(isMainnet), getRgbppLockConfigDep(isMainnet), getSporeTypeDep(isMainnet)];
+  const cellDeps = [...(await fetchRgbppAndConfigCellDeps(isMainnet)), getSporeTypeDep(isMainnet)];
   const sporeCoBuild = generateSporeTransferCoBuild([sporeCell], outputs);
   const witnesses = [RGBPP_WITNESS_PLACEHOLDER, sporeCoBuild];
 
@@ -233,7 +231,7 @@ export const genLeapSporeFromCkbToBtcRawTx = async ({
     },
   ];
   const outputsData: Hex[] = [sporeCell.outputData];
-  const cellDeps = [getRgbppLockDep(isMainnet), getRgbppLockConfigDep(isMainnet), getSporeTypeDep(isMainnet)];
+  const cellDeps = [...(await fetchRgbppAndConfigCellDeps(isMainnet)), getSporeTypeDep(isMainnet)];
   const sporeCoBuild = generateSporeTransferCoBuild([sporeCell], outputs);
   const witnesses = [RGBPP_WITNESS_PLACEHOLDER, sporeCoBuild];
 

--- a/packages/ckb/src/spore/leap.ts
+++ b/packages/ckb/src/spore/leap.ts
@@ -1,5 +1,5 @@
 import { BtcTimeCellsParams, RgbppCkbVirtualTx } from '../types/rgbpp';
-import { append0x, calculateTransactionFee, fetchRgbppAndConfigCellDeps } from '../utils';
+import { append0x, calculateTransactionFee } from '../utils';
 import {
   btcTxIdFromBtcTimeLockArgs,
   buildSpvClientCellDep,

--- a/packages/ckb/src/spore/leap.ts
+++ b/packages/ckb/src/spore/leap.ts
@@ -1,5 +1,5 @@
 import { BtcTimeCellsParams, RgbppCkbVirtualTx } from '../types/rgbpp';
-import { append0x, calculateTransactionFee } from '../utils';
+import { append0x, calculateTransactionFee, fetchTypeIdCellDeps } from '../utils';
 import {
   btcTxIdFromBtcTimeLockArgs,
   buildSpvClientCellDep,
@@ -19,8 +19,6 @@ import {
   BTC_JUMP_CONFIRMATION_BLOCKS,
   RGBPP_TX_WITNESS_MAX_SIZE,
   RGBPP_WITNESS_PLACEHOLDER,
-  getBtcTimeLockConfigDep,
-  getBtcTimeLockDep,
   getRgbppLockScript,
   getSporeTypeDep,
 } from '../constants';
@@ -78,7 +76,7 @@ export const genLeapSporeFromBtcToCkbVirtualTx = async ({
     },
   ];
   const outputsData: Hex[] = [sporeCell.outputData];
-  const cellDeps = [...(await fetchRgbppAndConfigCellDeps(isMainnet)), getSporeTypeDep(isMainnet)];
+  const cellDeps = [...(await fetchTypeIdCellDeps(isMainnet, { rgbpp: true })), getSporeTypeDep(isMainnet)];
   const sporeCoBuild = generateSporeTransferCoBuild([sporeCell], outputs);
   const witnesses = [RGBPP_WITNESS_PLACEHOLDER, sporeCoBuild];
 
@@ -140,9 +138,8 @@ export const buildSporeBtcTimeCellsSpentTx = async ({
   const outputsData = sortedBtcTimeCells.map((cell) => cell.outputData);
 
   const cellDeps: CKBComponents.CellDep[] = [
-    getBtcTimeLockDep(isMainnet),
+    ...(await fetchTypeIdCellDeps(isMainnet, { btcTime: true })),
     getSporeTypeDep(isMainnet),
-    getBtcTimeLockConfigDep(isMainnet),
   ];
 
   const witnesses: Hex[] = [];
@@ -231,7 +228,7 @@ export const genLeapSporeFromCkbToBtcRawTx = async ({
     },
   ];
   const outputsData: Hex[] = [sporeCell.outputData];
-  const cellDeps = [...(await fetchRgbppAndConfigCellDeps(isMainnet)), getSporeTypeDep(isMainnet)];
+  const cellDeps = [...(await fetchTypeIdCellDeps(isMainnet, { rgbpp: true })), getSporeTypeDep(isMainnet)];
   const sporeCoBuild = generateSporeTransferCoBuild([sporeCell], outputs);
   const witnesses = [RGBPP_WITNESS_PLACEHOLDER, sporeCoBuild];
 

--- a/packages/ckb/src/spore/spore.ts
+++ b/packages/ckb/src/spore/spore.ts
@@ -4,6 +4,7 @@ import {
   append0x,
   calculateRgbppSporeCellCapacity,
   calculateTransactionFee,
+  fetchRgbppAndConfigCellDeps,
   isClusterSporeTypeSupported,
 } from '../utils';
 import { buildPreLockArgs, calculateCommitment, genRgbppLockScript } from '../utils/rgbpp';
@@ -23,8 +24,6 @@ import {
   RGBPP_WITNESS_PLACEHOLDER,
   SECP256K1_WITNESS_LOCK_SIZE,
   getClusterTypeDep,
-  getRgbppLockConfigDep,
-  getRgbppLockDep,
   getRgbppLockScript,
   getSecp256k1CellDep,
   getSporeTypeDep,
@@ -117,8 +116,7 @@ export const genCreateSporeCkbVirtualTx = async ({
   ];
   const outputsData: Hex[] = [clusterCell.outputData, ...sporeOutputsData];
   const cellDeps = [
-    getRgbppLockDep(isMainnet),
-    getRgbppLockConfigDep(isMainnet),
+    ...(await fetchRgbppAndConfigCellDeps(isMainnet)),
     getClusterTypeDep(isMainnet),
     getSporeTypeDep(isMainnet),
     clusterCellDep,
@@ -322,7 +320,7 @@ export const genTransferSporeCkbVirtualTx = async ({
     },
   ];
   const outputsData: Hex[] = [sporeCell.outputData];
-  const cellDeps = [getRgbppLockDep(isMainnet), getRgbppLockConfigDep(isMainnet), getSporeTypeDep(isMainnet)];
+  const cellDeps = [...(await fetchRgbppAndConfigCellDeps(isMainnet)), getSporeTypeDep(isMainnet)];
   const sporeCoBuild = generateSporeTransferCoBuild([sporeCell], outputs);
   const witnesses = [RGBPP_WITNESS_PLACEHOLDER, sporeCoBuild];
 

--- a/packages/ckb/src/spore/spore.ts
+++ b/packages/ckb/src/spore/spore.ts
@@ -4,7 +4,7 @@ import {
   append0x,
   calculateRgbppSporeCellCapacity,
   calculateTransactionFee,
-  fetchRgbppAndConfigCellDeps,
+  fetchTypeIdCellDeps,
   isClusterSporeTypeSupported,
 } from '../utils';
 import { buildPreLockArgs, calculateCommitment, genRgbppLockScript } from '../utils/rgbpp';
@@ -116,7 +116,7 @@ export const genCreateSporeCkbVirtualTx = async ({
   ];
   const outputsData: Hex[] = [clusterCell.outputData, ...sporeOutputsData];
   const cellDeps = [
-    ...(await fetchRgbppAndConfigCellDeps(isMainnet)),
+    ...(await fetchTypeIdCellDeps(isMainnet, { rgbpp: true })),
     getClusterTypeDep(isMainnet),
     getSporeTypeDep(isMainnet),
     clusterCellDep,
@@ -320,7 +320,7 @@ export const genTransferSporeCkbVirtualTx = async ({
     },
   ];
   const outputsData: Hex[] = [sporeCell.outputData];
-  const cellDeps = [...(await fetchRgbppAndConfigCellDeps(isMainnet)), getSporeTypeDep(isMainnet)];
+  const cellDeps = [...(await fetchTypeIdCellDeps(isMainnet, { rgbpp: true })), getSporeTypeDep(isMainnet)];
   const sporeCoBuild = generateSporeTransferCoBuild([sporeCell], outputs);
   const witnesses = [RGBPP_WITNESS_PLACEHOLDER, sporeCoBuild];
 

--- a/packages/ckb/src/utils/cell-dep.spec.ts
+++ b/packages/ckb/src/utils/cell-dep.spec.ts
@@ -1,47 +1,62 @@
 import { describe, it, expect } from 'vitest';
-import {
-  fetchBtcTimeAndConfigCellDeps,
-  fetchBtcTimeXudtCellDeps,
-  fetchRgbppAndConfigCellDeps,
-  fetchRgbppXudtCellDeps,
-  fetchUniqueCellDep,
-} from './cell-dep';
+import { fetchTypeIdCellDeps } from './cell-dep';
 import { getBtcTimeLockDep, getRgbppLockDep, getUniqueTypeDep, getXudtDep } from '../constants';
 
 describe('dynamic fetch cell dep', () => {
-  it('fetchUniqueTypeCellDep', async () => {
+  it('fetchTypeIdCellDeps with xudt and unique', async () => {
     const isMainnet = false;
-    const cellDep = await fetchUniqueCellDep(isMainnet);
-    expect(cellDep.outPoint?.txHash).toBe(getUniqueTypeDep(isMainnet).outPoint?.txHash);
+    const [xudtDep, uniqueDep] = await fetchTypeIdCellDeps(isMainnet, { xudt: true, unique: true });
+    expect(xudtDep.outPoint?.txHash).toBe(getXudtDep(isMainnet).outPoint?.txHash);
+    expect(uniqueDep.outPoint?.txHash).toBe(getUniqueTypeDep(isMainnet).outPoint?.txHash);
   });
 
-  it('fetchRgbppLockAndConfigCellDeps', async () => {
+  it('fetchTypeIdCellDeps with rgbpp and config', async () => {
     const isMainnet = false;
-    const [rgbppDep, configDep] = await fetchRgbppAndConfigCellDeps(isMainnet);
+    const [rgbppDep, configDep] = await fetchTypeIdCellDeps(isMainnet, { rgbpp: true });
     expect(rgbppDep.outPoint?.txHash).toBe(getRgbppLockDep(isMainnet).outPoint?.txHash);
     expect(configDep.outPoint?.index).toBe('0x1');
   });
 
-  it('fetchRgbppXudtCellDeps', async () => {
+  it('fetchTypeIdCellDeps with rgbpp, config and xudt', async () => {
     const isMainnet = false;
-    const [rgbppDep, configDep, xudtDep] = await fetchRgbppXudtCellDeps(isMainnet);
+    const [rgbppDep, configDep, xudtDep] = await fetchTypeIdCellDeps(isMainnet, { rgbpp: true, xudt: true });
     expect(rgbppDep.outPoint?.txHash).toBe(getRgbppLockDep(isMainnet).outPoint?.txHash);
     expect(configDep.outPoint?.index).toBe('0x1');
     expect(xudtDep.outPoint?.txHash).toBe(getXudtDep(isMainnet).outPoint?.txHash);
   });
 
-  it('fetchBtcTimeAndConfigCellDeps', async () => {
+  it('fetchTypeIdCellDeps with btcTime and config', async () => {
     const isMainnet = true;
-    const [btcTimeDep, configDep] = await fetchBtcTimeAndConfigCellDeps(isMainnet);
+    const [btcTimeDep, configDep] = await fetchTypeIdCellDeps(isMainnet, { btcTime: true });
     expect(btcTimeDep.outPoint?.txHash).toBe(getBtcTimeLockDep(isMainnet).outPoint?.txHash);
     expect(configDep.outPoint?.index).toBe('0x1');
   });
 
-  it('fetchBtcTimeXudtCellDeps', async () => {
+  it('fetchTypeIdCellDeps with btcTime, config and xudt', async () => {
     const isMainnet = true;
-    const [btcTimeDep, configDep, xudtDep] = await fetchBtcTimeXudtCellDeps(isMainnet);
+    const [btcTimeDep, configDep, xudtDep] = await fetchTypeIdCellDeps(isMainnet, { btcTime: true, xudt: true });
     expect(btcTimeDep.outPoint?.txHash).toBe(getBtcTimeLockDep(isMainnet).outPoint?.txHash);
     expect(configDep.outPoint?.index).toBe('0x1');
     expect(xudtDep.outPoint?.txHash).toBe(getXudtDep(isMainnet).outPoint?.txHash);
+  });
+
+  it('fetchTypeIdCellDeps with rgbpp, btcTime, xudt and unique', async () => {
+    const isMainnet = false;
+    const cellDeps = await fetchTypeIdCellDeps(isMainnet, { rgbpp: true, btcTime: true, xudt: true, unique: true });
+    expect(cellDeps[0].outPoint?.txHash).toBe(getRgbppLockDep(isMainnet).outPoint?.txHash);
+    expect(cellDeps[1].outPoint?.index).toBe('0x1');
+
+    expect(cellDeps[2].outPoint?.txHash).toBe(getBtcTimeLockDep(isMainnet).outPoint?.txHash);
+    expect(cellDeps[3].outPoint?.index).toBe('0x1');
+
+    expect(cellDeps[4].outPoint?.txHash).toBe(getXudtDep(isMainnet).outPoint?.txHash);
+
+    expect(cellDeps[5].outPoint?.txHash).toBe(getUniqueTypeDep(isMainnet).outPoint?.txHash);
+  });
+
+  it('fetchTypeIdCellDeps without cell deps', async () => {
+    const isMainnet = false;
+    const cellDeps = await fetchTypeIdCellDeps(isMainnet, {});
+    expect(cellDeps.length).toBe(0);
   });
 });

--- a/packages/ckb/src/utils/cell-dep.spec.ts
+++ b/packages/ckb/src/utils/cell-dep.spec.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest';
+import {
+  fetchBtcTimeAndConfigCellDeps,
+  fetchBtcTimeXudtCellDeps,
+  fetchRgbppAndConfigCellDeps,
+  fetchRgbppXudtCellDeps,
+  fetchUniqueCellDep,
+} from './cell-dep';
+import { getBtcTimeLockDep, getRgbppLockDep, getUniqueTypeDep, getXudtDep } from '../constants';
+
+describe('dynamic fetch cell dep', () => {
+  it('fetchUniqueTypeCellDep', async () => {
+    const isMainnet = false;
+    const cellDep = await fetchUniqueCellDep(isMainnet);
+    expect(cellDep.outPoint?.txHash).toBe(getUniqueTypeDep(isMainnet).outPoint?.txHash);
+  });
+
+  it('fetchRgbppLockAndConfigCellDeps', async () => {
+    const isMainnet = false;
+    const [rgbppDep, configDep] = await fetchRgbppAndConfigCellDeps(isMainnet);
+    expect(rgbppDep.outPoint?.txHash).toBe(getRgbppLockDep(isMainnet).outPoint?.txHash);
+    expect(configDep.outPoint?.index).toBe('0x1');
+  });
+
+  it('fetchRgbppXudtCellDeps', async () => {
+    const isMainnet = false;
+    const [rgbppDep, configDep, xudtDep] = await fetchRgbppXudtCellDeps(isMainnet);
+    expect(rgbppDep.outPoint?.txHash).toBe(getRgbppLockDep(isMainnet).outPoint?.txHash);
+    expect(configDep.outPoint?.index).toBe('0x1');
+    expect(xudtDep.outPoint?.txHash).toBe(getXudtDep(isMainnet).outPoint?.txHash);
+  });
+
+  it('fetchBtcTimeAndConfigCellDeps', async () => {
+    const isMainnet = true;
+    const [btcTimeDep, configDep] = await fetchBtcTimeAndConfigCellDeps(isMainnet);
+    expect(btcTimeDep.outPoint?.txHash).toBe(getBtcTimeLockDep(isMainnet).outPoint?.txHash);
+    expect(configDep.outPoint?.index).toBe('0x1');
+  });
+
+  it('fetchBtcTimeXudtCellDeps', async () => {
+    const isMainnet = true;
+    const [btcTimeDep, configDep, xudtDep] = await fetchBtcTimeXudtCellDeps(isMainnet);
+    expect(btcTimeDep.outPoint?.txHash).toBe(getBtcTimeLockDep(isMainnet).outPoint?.txHash);
+    expect(configDep.outPoint?.index).toBe('0x1');
+    expect(xudtDep.outPoint?.txHash).toBe(getXudtDep(isMainnet).outPoint?.txHash);
+  });
+});

--- a/packages/ckb/src/utils/cell-dep.ts
+++ b/packages/ckb/src/utils/cell-dep.ts
@@ -25,7 +25,7 @@ const fetchCellDepsJson = async () => {
     const response = await axios.get(GITHUB_CELL_DEPS_JSON_URL);
     return response.data as CellDepsObject;
   } catch (error) {
-    console.error('Error fetching cell deps:', error);
+    // console.error('Error fetching cell deps:', error);
   }
 };
 

--- a/packages/ckb/src/utils/cell-dep.ts
+++ b/packages/ckb/src/utils/cell-dep.ts
@@ -56,6 +56,12 @@ export const fetchTypeIdCellDeps = async (
   }
   let cellDeps: CKBComponents.CellDep[] = [];
   if (selected.rgbpp) {
+    // RGB++ config cell is deployed together with the RGB++ lock contract
+    //
+    // contract_deployment_transaction:
+    //   - output(index=0, data=rgbpp_code)
+    //   - output(index=1, data=rgbpp_config)
+    //
     cellDeps = [
       ...cellDeps,
       rgbppLockDep,
@@ -70,6 +76,12 @@ export const fetchTypeIdCellDeps = async (
   }
 
   if (selected.btcTime) {
+    // BTC Time config cell is deployed together with the BTC Time lock contract
+    //
+    // contract_deployment_transaction:
+    //   - output(index=0, data=rgbpp_code)
+    //   - output(index=1, data=rgbpp_config)
+    //
     cellDeps = [
       ...cellDeps,
       btcTimeDep,

--- a/packages/ckb/src/utils/cell-dep.ts
+++ b/packages/ckb/src/utils/cell-dep.ts
@@ -20,9 +20,14 @@ interface CellDepsObject {
 const GITHUB_CELL_DEPS_JSON_URL =
   'https://raw.githubusercontent.com/ckb-cell/typeid-contract-cell-deps/main/deployment/cell-deps.json';
 
+const CDN_GITHUB_CELL_DEPS_JSON_URL =
+  'https://cdn.jsdelivr.net/gh/ckb-cell/typeid-contract-cell-deps@main/deployment/cell-deps.json';
+
+const request = (url: string) => axios.get(url, { timeout: 2000 });
+
 const fetchCellDepsJson = async () => {
   try {
-    const response = await axios.get(GITHUB_CELL_DEPS_JSON_URL);
+    const response = await Promise.any([request(GITHUB_CELL_DEPS_JSON_URL), request(CDN_GITHUB_CELL_DEPS_JSON_URL)]);
     return response.data as CellDepsObject;
   } catch (error) {
     // console.error('Error fetching cell deps:', error);

--- a/packages/ckb/src/utils/cell-dep.ts
+++ b/packages/ckb/src/utils/cell-dep.ts
@@ -29,110 +29,67 @@ const fetchCellDepsJson = async () => {
   }
 };
 
-export const fetchRgbppAndConfigCellDeps = async (isMainnet: boolean): Promise<CKBComponents.CellDep[]> => {
+export interface CellDepsSelected {
+  rgbpp?: boolean;
+  btcTime?: boolean;
+  xudt?: boolean;
+  unique?: boolean;
+}
+
+export const fetchTypeIdCellDeps = async (
+  isMainnet: boolean,
+  selected: CellDepsSelected,
+): Promise<CKBComponents.CellDep[]> => {
   let rgbppLockDep = getRgbppLockDep(isMainnet);
-  const cellDepsObj = await fetchCellDepsJson();
-  if (cellDepsObj) {
-    rgbppLockDep = isMainnet ? cellDepsObj.rgbpp.mainnet : cellDepsObj.rgbpp.testnet;
-  }
-  return [
-    rgbppLockDep,
-    {
-      ...rgbppLockDep,
-      outPoint: {
-        ...rgbppLockDep.outPoint,
-        index: '0x1',
-      },
-    },
-  ] as CKBComponents.CellDep[];
-};
-
-export const fetchBtcTimeAndConfigCellDeps = async (isMainnet: boolean): Promise<CKBComponents.CellDep[]> => {
-  let btcTimeCellDep = getBtcTimeLockDep(isMainnet);
-  const cellDepsObj = await fetchCellDepsJson();
-  if (cellDepsObj) {
-    btcTimeCellDep = isMainnet ? cellDepsObj.btcTime.mainnet : cellDepsObj.btcTime.testnet;
-  }
-  return [
-    btcTimeCellDep,
-    {
-      ...btcTimeCellDep,
-      outPoint: {
-        ...btcTimeCellDep.outPoint,
-        index: '0x1',
-      },
-    },
-  ] as CKBComponents.CellDep[];
-};
-
-export const fetchUniqueCellDep = async (isMainnet: boolean): Promise<CKBComponents.CellDep> => {
+  let btcTimeDep = getBtcTimeLockDep(isMainnet);
+  let xudtDep = getXudtDep(isMainnet);
   let uniqueDep = getUniqueTypeDep(isMainnet);
-  if (isMainnet) {
-    // The mainnet deployment type of unique type script is data hash
-    return uniqueDep;
-  }
-  const cellDepsObj = await fetchCellDepsJson();
-  if (cellDepsObj) {
-    uniqueDep = cellDepsObj.unique.testnet;
-  }
-  return uniqueDep;
-};
 
-export const fetchXudtCellDep = async (isMainnet: boolean): Promise<CKBComponents.CellDep> => {
-  let xudtDep = getXudtDep(isMainnet);
-  if (isMainnet) {
-    // The mainnet deployment type of xudt type script is data hash
-    return xudtDep;
-  }
-  const cellDepsObj = await fetchCellDepsJson();
-  if (cellDepsObj) {
-    xudtDep = cellDepsObj.xudt.testnet;
-  }
-  return xudtDep;
-};
-
-export const fetchRgbppXudtCellDeps = async (isMainnet: boolean): Promise<CKBComponents.CellDep[]> => {
-  let rgbppLockDep = getRgbppLockDep(isMainnet);
-  let xudtDep = getXudtDep(isMainnet);
   const cellDepsObj = await fetchCellDepsJson();
   if (cellDepsObj) {
     rgbppLockDep = isMainnet ? cellDepsObj.rgbpp.mainnet : cellDepsObj.rgbpp.testnet;
+    btcTimeDep = isMainnet ? cellDepsObj.btcTime.mainnet : cellDepsObj.btcTime.testnet;
     if (!isMainnet) {
       xudtDep = cellDepsObj.xudt.testnet;
+      uniqueDep = cellDepsObj.unique.testnet;
     }
   }
-  return [
-    rgbppLockDep,
-    {
-      ...rgbppLockDep,
-      outPoint: {
-        ...rgbppLockDep.outPoint,
-        index: '0x1',
+  let cellDeps: CKBComponents.CellDep[] = [];
+  if (selected.rgbpp) {
+    cellDeps = [
+      ...cellDeps,
+      rgbppLockDep,
+      {
+        ...rgbppLockDep,
+        outPoint: {
+          ...rgbppLockDep.outPoint,
+          index: '0x1',
+        },
       },
-    },
-    xudtDep,
-  ] as CKBComponents.CellDep[];
-};
+    ] as CKBComponents.CellDep[];
+  }
 
-export const fetchBtcTimeXudtCellDeps = async (isMainnet: boolean): Promise<CKBComponents.CellDep[]> => {
-  let btcTimeCellDep = getBtcTimeLockDep(isMainnet);
-  let xudtDep = getXudtDep(isMainnet);
-  const cellDepsObj = await fetchCellDepsJson();
-  if (cellDepsObj) {
-    btcTimeCellDep = isMainnet ? cellDepsObj.btcTime.mainnet : cellDepsObj.btcTime.testnet;
-    if (!isMainnet) {
-      xudtDep = cellDepsObj.xudt.testnet;
-    }
-  }
-  return [
-    btcTimeCellDep,
-    {
-      ...btcTimeCellDep,
-      outPoint: {
-        ...btcTimeCellDep.outPoint,
-        index: '0x1',
+  if (selected.btcTime) {
+    cellDeps = [
+      ...cellDeps,
+      btcTimeDep,
+      {
+        ...btcTimeDep,
+        outPoint: {
+          ...btcTimeDep.outPoint,
+          index: '0x1',
+        },
       },
-    },
-    xudtDep,
-  ] as CKBComponents.CellDep[];
+    ] as CKBComponents.CellDep[];
+  }
+
+  if (selected.xudt) {
+    cellDeps = [...cellDeps, xudtDep] as CKBComponents.CellDep[];
+  }
+
+  if (selected.unique) {
+    cellDeps = [...cellDeps, uniqueDep] as CKBComponents.CellDep[];
+  }
+
+  return cellDeps;
 };

--- a/packages/ckb/src/utils/cell-dep.ts
+++ b/packages/ckb/src/utils/cell-dep.ts
@@ -1,0 +1,138 @@
+import axios from 'axios';
+import { getBtcTimeLockDep, getRgbppLockDep, getUniqueTypeDep, getXudtDep } from '../constants';
+
+interface CellDepsObject {
+  rgbpp: {
+    mainnet: CKBComponents.CellDep;
+    testnet: CKBComponents.CellDep;
+  };
+  btcTime: {
+    mainnet: CKBComponents.CellDep;
+    testnet: CKBComponents.CellDep;
+  };
+  xudt: {
+    testnet: CKBComponents.CellDep;
+  };
+  unique: {
+    testnet: CKBComponents.CellDep;
+  };
+}
+const GITHUB_CELL_DEPS_JSON_URL =
+  'https://raw.githubusercontent.com/ckb-cell/typeid-contract-cell-deps/main/deployment/cell-deps.json';
+
+const fetchCellDepsJson = async () => {
+  try {
+    const response = await axios.get(GITHUB_CELL_DEPS_JSON_URL);
+    return response.data as CellDepsObject;
+  } catch (error) {
+    console.error('Error fetching cell deps:', error);
+  }
+};
+
+export const fetchRgbppAndConfigCellDeps = async (isMainnet: boolean): Promise<CKBComponents.CellDep[]> => {
+  let rgbppLockDep = getRgbppLockDep(isMainnet);
+  const cellDepsObj = await fetchCellDepsJson();
+  if (cellDepsObj) {
+    rgbppLockDep = isMainnet ? cellDepsObj.rgbpp.mainnet : cellDepsObj.rgbpp.testnet;
+  }
+  return [
+    rgbppLockDep,
+    {
+      ...rgbppLockDep,
+      outPoint: {
+        ...rgbppLockDep.outPoint,
+        index: '0x1',
+      },
+    },
+  ] as CKBComponents.CellDep[];
+};
+
+export const fetchBtcTimeAndConfigCellDeps = async (isMainnet: boolean): Promise<CKBComponents.CellDep[]> => {
+  let btcTimeCellDep = getBtcTimeLockDep(isMainnet);
+  const cellDepsObj = await fetchCellDepsJson();
+  if (cellDepsObj) {
+    btcTimeCellDep = isMainnet ? cellDepsObj.btcTime.mainnet : cellDepsObj.btcTime.testnet;
+  }
+  return [
+    btcTimeCellDep,
+    {
+      ...btcTimeCellDep,
+      outPoint: {
+        ...btcTimeCellDep.outPoint,
+        index: '0x1',
+      },
+    },
+  ] as CKBComponents.CellDep[];
+};
+
+export const fetchUniqueCellDep = async (isMainnet: boolean): Promise<CKBComponents.CellDep> => {
+  let uniqueDep = getUniqueTypeDep(isMainnet);
+  if (isMainnet) {
+    // The mainnet deployment type of unique type script is data hash
+    return uniqueDep;
+  }
+  const cellDepsObj = await fetchCellDepsJson();
+  if (cellDepsObj) {
+    uniqueDep = cellDepsObj.unique.testnet;
+  }
+  return uniqueDep;
+};
+
+export const fetchXudtCellDep = async (isMainnet: boolean): Promise<CKBComponents.CellDep> => {
+  let xudtDep = getXudtDep(isMainnet);
+  if (isMainnet) {
+    // The mainnet deployment type of xudt type script is data hash
+    return xudtDep;
+  }
+  const cellDepsObj = await fetchCellDepsJson();
+  if (cellDepsObj) {
+    xudtDep = cellDepsObj.xudt.testnet;
+  }
+  return xudtDep;
+};
+
+export const fetchRgbppXudtCellDeps = async (isMainnet: boolean): Promise<CKBComponents.CellDep[]> => {
+  let rgbppLockDep = getRgbppLockDep(isMainnet);
+  let xudtDep = getXudtDep(isMainnet);
+  const cellDepsObj = await fetchCellDepsJson();
+  if (cellDepsObj) {
+    rgbppLockDep = isMainnet ? cellDepsObj.rgbpp.mainnet : cellDepsObj.rgbpp.testnet;
+    if (!isMainnet) {
+      xudtDep = cellDepsObj.xudt.testnet;
+    }
+  }
+  return [
+    rgbppLockDep,
+    {
+      ...rgbppLockDep,
+      outPoint: {
+        ...rgbppLockDep.outPoint,
+        index: '0x1',
+      },
+    },
+    xudtDep,
+  ] as CKBComponents.CellDep[];
+};
+
+export const fetchBtcTimeXudtCellDeps = async (isMainnet: boolean): Promise<CKBComponents.CellDep[]> => {
+  let btcTimeCellDep = getBtcTimeLockDep(isMainnet);
+  let xudtDep = getXudtDep(isMainnet);
+  const cellDepsObj = await fetchCellDepsJson();
+  if (cellDepsObj) {
+    btcTimeCellDep = isMainnet ? cellDepsObj.btcTime.mainnet : cellDepsObj.btcTime.testnet;
+    if (!isMainnet) {
+      xudtDep = cellDepsObj.xudt.testnet;
+    }
+  }
+  return [
+    btcTimeCellDep,
+    {
+      ...btcTimeCellDep,
+      outPoint: {
+        ...btcTimeCellDep.outPoint,
+        index: '0x1',
+      },
+    },
+    xudtDep,
+  ] as CKBComponents.CellDep[];
+};

--- a/packages/ckb/src/utils/index.ts
+++ b/packages/ckb/src/utils/index.ts
@@ -3,3 +3,4 @@ export * from './hex';
 export * from './ckb-tx';
 export * from './rgbpp';
 export * from './spore';
+export * from './cell-dep';


### PR DESCRIPTION
## Problem
Although [Lumos](https://github.com/ckb-js/lumos/pull/687) provides a function `refreshTypeIdCellDeps` to refresh the cell deps of a upgraded TypeID script, it requires the dApp developers themselves to handle it manually.

**But usually a dApp developer doesn't know when a TypeID script is updated.**

This PR introduces a mechanism to automatically get the TypeID scripts' latest cell deps, trying to make things easier.

## Design Goal and Main Changes

- Add `fetchTypeIdCellDeps` function to fetch `cellDeps` from the GitHub JSON file
- Use `cellDepsSelected` parameter to select the `cellDeps` which are needed
- Use dynamic fetching `cellDeps` for all the RGB++ transactions
- If `fetchCellDepsJson` fails due to a network error, the [constants](https://github.com/ckb-cell/rgbpp-sdk/blob/develop/packages/ckb/src/constants/index.ts) are used as a fallback mechanism.
- [x] Setup CDN for https://raw.githubusercontent.com/ckb-cell/typeid-contract-cell-deps/main/deployment/cell-deps.json
  The speed of fetching `cell-deps.json` should be faster than fetching TypeID script cell deps through ckb-indexer directly.
  Example: https://cdn.jsdelivr.net/gh/ckb-cell/typeid-contract-cell-deps@main/deployment/cell-deps.json
  test: https://github.com/ckb-cell/rgbpp-sdk/pull/191#issuecomment-2134720392
- Update https://github.com/ckb-cell/typeid-contract-cell-deps automatically through a GitHub action workflow (maybe every 5 mins)
  https://github.com/ckb-cell/typeid-contract-cell-deps/actions/workflows/update.yml

## Those that need to be optimized

Fetching the GitHub JSON file is not stable or slow for some users, we should do something to optimize it.

The GitHub JSON file path is https://github.com/ckb-cell/rgbpp-sdk/pull/191/files#diff-3039d7f71cfd89a5a23296b2cccdb966bc9132c2bf938a39a08bf0aeceed5d58R21

## The tests that need to be run

I have tested the examples of `xudt-on-ckb` and using the integration tests of https://github.com/ckb-cell/rgbpp-sdk/pull/169 to test more examples is needed. cc @Dawn-githup 