### PR TITLE
refactor(examples): Save ckbVirtualTxResult locally

### DIFF
--- a/examples/rgbpp/shared/utils.ts
+++ b/examples/rgbpp/shared/utils.ts
@@ -1,0 +1,35 @@
+import * as fs from 'fs';
+import * as path from 'path';
+
+/**
+ * Save ckbVirtualTxResult to a log file
+ * @param ckbVirtualTxResult - The ckbVirtualTxResult to save
+ * @param exampleName - Example name used to distinguish different log files
+ */
+export const saveCkbVirtualTxResult = (ckbVirtualTxResult: unknown, exampleName: string) => {
+  try {
+    // Define log file path
+    const logDir = path.resolve(__dirname, '../logs');
+    const logFilePath = path.join(logDir, `${exampleName}-ckbVirtualTxResult.log`);
+
+    // Ensure the log directory exists
+    if (!fs.existsSync(logDir)) {
+      fs.mkdirSync(logDir);
+    }
+
+    // Validate and save ckbVirtualTxResult to log file
+    if (typeof ckbVirtualTxResult === 'object' && ckbVirtualTxResult !== null) {
+      fs.writeFileSync(logFilePath, JSON.stringify(ckbVirtualTxResult, null, 2));
+      console.info(`Saved ckbVirtualTxResult to ${logFilePath}`);
+    } else {
+      console.error('Invalid ckbVirtualTxResult format');
+    }
+
+    // Remind developers to save the transaction result
+    console.info(
+      `Important: It's recommended to save the rgbpp_ckb_tx_virtual locally before the isomorphic transactions are finalized.`,
+    );
+  } catch (error) {
+    console.error('Failed to save ckbVirtualTxResult:', error);
+  }
+};

--- a/examples/rgbpp/shared/utils.ts
+++ b/examples/rgbpp/shared/utils.ts
@@ -1,16 +1,30 @@
 import * as fs from 'fs';
 import * as path from 'path';
+import {
+  BaseCkbVirtualTxResult,
+  SporeVirtualTxResult,
+  SporeCreateVirtualTxResult,
+  SporeTransferVirtualTxResult,
+} from 'rgbpp/ckb';
 
 /**
  * Save ckbVirtualTxResult to a log file
  * @param ckbVirtualTxResult - The ckbVirtualTxResult to save
  * @param exampleName - Example name used to distinguish different log files
  */
-export const saveCkbVirtualTxResult = (ckbVirtualTxResult: unknown, exampleName: string) => {
+
+export type CkbVirtualTxResultType =
+  | BaseCkbVirtualTxResult
+  | SporeVirtualTxResult
+  | SporeCreateVirtualTxResult
+  | SporeTransferVirtualTxResult;
+
+export const saveCkbVirtualTxResult = (ckbVirtualTxResult: CkbVirtualTxResultType, exampleName: string) => {
   try {
     // Define log file path
     const logDir = path.resolve(__dirname, '../logs');
-    const logFilePath = path.join(logDir, `${exampleName}-ckbVirtualTxResult.log`);
+    const timestamp = new Date().toISOString().replace(/:/g, '-'); // Replace colons with hyphens
+    const logFilePath = path.join(logDir, `${exampleName}-${timestamp}-ckbVirtualTxResult.log`);
 
     // Ensure the log directory exists
     if (!fs.existsSync(logDir)) {

--- a/examples/rgbpp/spore/4-transfer-spore.ts
+++ b/examples/rgbpp/spore/4-transfer-spore.ts
@@ -3,6 +3,7 @@ import { genTransferSporeCkbVirtualTx, sendRgbppUtxos } from 'rgbpp';
 import { getSporeTypeScript, Hex } from 'rgbpp/ckb';
 import { serializeScript } from '@nervosnetwork/ckb-sdk-utils';
 import { isMainnet, collector, btcAddress, btcDataSource, btcKeyPair, btcService } from '../env';
+import { saveCkbVirtualTxResult } from '../shared/utils';
 
 interface SporeTransferParams {
   sporeRgbppLockArgs: Hex;
@@ -22,6 +23,9 @@ const transferSpore = async ({ sporeRgbppLockArgs, toBtcAddress, sporeTypeArgs }
     sporeTypeBytes,
     isMainnet,
   });
+
+  // Save ckbVirtualTxResult
+  saveCkbVirtualTxResult(ckbVirtualTxResult, '4-transfer-spore');
 
   const { commitment, ckbRawTx } = ckbVirtualTxResult;
 

--- a/examples/rgbpp/spore/5-leap-spore-to-ckb.ts
+++ b/examples/rgbpp/spore/5-leap-spore-to-ckb.ts
@@ -3,6 +3,7 @@ import { genLeapSporeFromBtcToCkbVirtualTx, sendRgbppUtxos } from 'rgbpp';
 import { getSporeTypeScript, Hex } from 'rgbpp/ckb';
 import { serializeScript } from '@nervosnetwork/ckb-sdk-utils';
 import { isMainnet, collector, btcAddress, btcDataSource, btcKeyPair, btcService } from '../env';
+import { saveCkbVirtualTxResult } from '../shared/utils';
 
 interface SporeLeapParams {
   sporeRgbppLockArgs: Hex;
@@ -23,6 +24,9 @@ const leapSporeFromBtcToCkb = async ({ sporeRgbppLockArgs, toCkbAddress, sporeTy
     toCkbAddress,
     isMainnet,
   });
+
+  // Save ckbVirtualTxResult
+  saveCkbVirtualTxResult(ckbVirtualTxResult, '5-leap-spore-to-ckb');
 
   const { commitment, ckbRawTx } = ckbVirtualTxResult;
 

--- a/examples/rgbpp/spore/launch/2-create-cluster.ts
+++ b/examples/rgbpp/spore/launch/2-create-cluster.ts
@@ -9,6 +9,7 @@ import {
   sendCkbTx,
   updateCkbTxWithRealBtcTxId,
 } from 'rgbpp/ckb';
+import { saveCkbVirtualTxResult } from '../../shared/utils';
 
 const createCluster = async ({ ownerRgbppLockArgs }: { ownerRgbppLockArgs: string }) => {
   const ckbVirtualTxResult = await genCreateClusterCkbVirtualTx({
@@ -18,6 +19,9 @@ const createCluster = async ({ ownerRgbppLockArgs }: { ownerRgbppLockArgs: strin
     isMainnet,
     ckbFeeRate: BigInt(2000),
   });
+
+  // Save ckbVirtualTxResult
+  saveCkbVirtualTxResult(ckbVirtualTxResult, '2-create-cluster');
 
   const { commitment, ckbRawTx, clusterId } = ckbVirtualTxResult;
 

--- a/examples/rgbpp/spore/launch/3-create-spores.ts
+++ b/examples/rgbpp/spore/launch/3-create-spores.ts
@@ -20,6 +20,7 @@ import {
   RawSporeData,
 } from 'rgbpp/ckb';
 import { transactionToHex, utf8ToBuffer } from 'rgbpp/btc';
+import { saveCkbVirtualTxResult } from '../../shared/utils';
 
 interface SporeCreateParams {
   clusterRgbppLockArgs: Hex;
@@ -37,6 +38,9 @@ const createSpores = async ({ clusterRgbppLockArgs, receivers }: SporeCreatePara
     isMainnet,
     ckbFeeRate: BigInt(2000),
   });
+
+  // Save ckbVirtualTxResult
+  saveCkbVirtualTxResult(ckbVirtualTxResult, '3-create-spores');
 
   const { commitment, ckbRawTx, sumInputsCapacity, clusterCell } = ckbVirtualTxResult;
 

--- a/examples/rgbpp/spore/local/4-transfer-spore.ts
+++ b/examples/rgbpp/spore/local/4-transfer-spore.ts
@@ -12,6 +12,7 @@ import { sendRgbppUtxos, transactionToHex } from 'rgbpp/btc';
 import { BtcAssetsApiError } from 'rgbpp';
 import { serializeScript } from '@nervosnetwork/ckb-sdk-utils';
 import { isMainnet, collector, btcAddress, btcDataSource, btcKeyPair, btcService } from '../../env';
+import { saveCkbVirtualTxResult } from '../../shared/utils';
 
 interface SporeTransferParams {
   sporeRgbppLockArgs: Hex;
@@ -34,6 +35,9 @@ const transferSpore = async ({ sporeRgbppLockArgs, toBtcAddress, sporeTypeArgs }
     isMainnet,
     ckbFeeRate: BigInt(5000),
   });
+
+  // Save ckbVirtualTxResult
+  saveCkbVirtualTxResult(ckbVirtualTxResult, '4-transfer-spore');
 
   const { commitment, ckbRawTx, sporeCell } = ckbVirtualTxResult;
 

--- a/examples/rgbpp/spore/local/4-transfer-spore.ts
+++ b/examples/rgbpp/spore/local/4-transfer-spore.ts
@@ -37,7 +37,7 @@ const transferSpore = async ({ sporeRgbppLockArgs, toBtcAddress, sporeTypeArgs }
   });
 
   // Save ckbVirtualTxResult
-  saveCkbVirtualTxResult(ckbVirtualTxResult, '4-transfer-spore');
+  saveCkbVirtualTxResult(ckbVirtualTxResult, '4-transfer-spore-local');
 
   const { commitment, ckbRawTx, sporeCell } = ckbVirtualTxResult;
 

--- a/examples/rgbpp/spore/local/5-leap-spore-to-ckb.ts
+++ b/examples/rgbpp/spore/local/5-leap-spore-to-ckb.ts
@@ -37,7 +37,7 @@ const leapSpore = async ({ sporeRgbppLockArgs, toCkbAddress, sporeTypeArgs }: Sp
   });
 
   // Save ckbVirtualTxResult
-  saveCkbVirtualTxResult(ckbVirtualTxResult, '5-leap-spore-to-ckb');
+  saveCkbVirtualTxResult(ckbVirtualTxResult, '5-leap-spore-to-ckb-local');
 
   const { commitment, ckbRawTx, sporeCell } = ckbVirtualTxResult;
 

--- a/examples/rgbpp/spore/local/5-leap-spore-to-ckb.ts
+++ b/examples/rgbpp/spore/local/5-leap-spore-to-ckb.ts
@@ -12,6 +12,7 @@ import { sendRgbppUtxos, transactionToHex } from 'rgbpp/btc';
 import { serializeScript } from '@nervosnetwork/ckb-sdk-utils';
 import { isMainnet, collector, btcAddress, btcDataSource, btcKeyPair, btcService } from '../../env';
 import { BtcAssetsApiError } from 'rgbpp';
+import { saveCkbVirtualTxResult } from '../../shared/utils';
 
 interface SporeLeapParams {
   sporeRgbppLockArgs: Hex;
@@ -34,6 +35,9 @@ const leapSpore = async ({ sporeRgbppLockArgs, toCkbAddress, sporeTypeArgs }: Sp
     toCkbAddress,
     isMainnet,
   });
+
+  // Save ckbVirtualTxResult
+  saveCkbVirtualTxResult(ckbVirtualTxResult, '5-leap-spore-to-ckb');
 
   const { commitment, ckbRawTx, sporeCell } = ckbVirtualTxResult;
 

--- a/examples/rgbpp/xudt/2-btc-transfer.ts
+++ b/examples/rgbpp/xudt/2-btc-transfer.ts
@@ -2,6 +2,7 @@ import { buildRgbppLockArgs, getXudtTypeScript } from 'rgbpp/ckb';
 import { serializeScript } from '@nervosnetwork/ckb-sdk-utils';
 import { genBtcTransferCkbVirtualTx, sendRgbppUtxos } from 'rgbpp';
 import { isMainnet, collector, btcAddress, btcKeyPair, btcService, btcDataSource } from '../env';
+import { saveCkbVirtualTxResult } from '../shared/utils';
 
 interface RgbppTransferParams {
   rgbppLockArgsList: string[];
@@ -23,6 +24,9 @@ const transfer = async ({ rgbppLockArgsList, toBtcAddress, xudtTypeArgs, transfe
     transferAmount,
     isMainnet,
   });
+
+  // Save ckbVirtualTxResult
+  saveCkbVirtualTxResult(ckbVirtualTxResult, '2-btc-transfer');
 
   const { commitment, ckbRawTx } = ckbVirtualTxResult;
 

--- a/examples/rgbpp/xudt/3-btc-leap-ckb.ts
+++ b/examples/rgbpp/xudt/3-btc-leap-ckb.ts
@@ -2,6 +2,7 @@ import { buildRgbppLockArgs, getXudtTypeScript } from 'rgbpp/ckb';
 import { serializeScript } from '@nervosnetwork/ckb-sdk-utils';
 import { genBtcJumpCkbVirtualTx, sendRgbppUtxos } from 'rgbpp';
 import { isMainnet, collector, btcAddress, btcKeyPair, btcService, btcDataSource } from '../env';
+import { saveCkbVirtualTxResult } from '../shared/utils';
 
 interface LeapToCkbParams {
   rgbppLockArgsList: string[];
@@ -24,6 +25,9 @@ const leapFromBtcToCKB = async ({ rgbppLockArgsList, toCkbAddress, xudtTypeArgs,
     toCkbAddress,
     isMainnet,
   });
+
+  // Save ckbVirtualTxResult
+  saveCkbVirtualTxResult(ckbVirtualTxResult, '3-btc-leap-ckb');
 
   const { commitment, ckbRawTx } = ckbVirtualTxResult;
 

--- a/examples/rgbpp/xudt/launch/2-launch-rgbpp.ts
+++ b/examples/rgbpp/xudt/launch/2-launch-rgbpp.ts
@@ -9,6 +9,7 @@ import {
 import { RGBPP_TOKEN_INFO } from './0-rgbpp-token-info';
 import { btcAddress, btcDataSource, btcKeyPair, btcService, collector, isMainnet } from '../../env';
 import { transactionToHex } from 'rgbpp/btc';
+import { saveCkbVirtualTxResult } from '../../shared/utils';
 
 interface Params {
   ownerRgbppLockArgs: string;
@@ -23,6 +24,9 @@ const launchRgppAsset = async ({ ownerRgbppLockArgs, launchAmount, rgbppTokenInf
     launchAmount,
     isMainnet,
   });
+
+  // Save ckbVirtualTxResult
+  saveCkbVirtualTxResult(ckbVirtualTxResult, '2-launch-rgbpp');
 
   const { commitment, ckbRawTx } = ckbVirtualTxResult;
 

--- a/examples/rgbpp/xudt/launch/3-distribute-rgbpp.ts
+++ b/examples/rgbpp/xudt/launch/3-distribute-rgbpp.ts
@@ -21,6 +21,7 @@ import {
   updateCkbTxWithRealBtcTxId,
 } from 'rgbpp/ckb';
 import { transactionToHex } from 'rgbpp/btc';
+import { saveCkbVirtualTxResult } from '../../shared/utils';
 
 interface Params {
   rgbppLockArgsList: string[];
@@ -42,6 +43,9 @@ const distributeRgbppAssetOnBtc = async ({ rgbppLockArgsList, receivers, xudtTyp
     rgbppReceivers: receivers,
     isMainnet,
   });
+
+  // Save ckbVirtualTxResult
+  saveCkbVirtualTxResult(ckbVirtualTxResult, '3-distribute-rgbpp');
 
   const { commitment, ckbRawTx, sumInputsCapacity, rgbppChangeOutIndex } = ckbVirtualTxResult;
 

--- a/examples/rgbpp/xudt/local/2-btc-transfer.ts
+++ b/examples/rgbpp/xudt/local/2-btc-transfer.ts
@@ -9,6 +9,7 @@ import {
 } from 'rgbpp/ckb';
 import { isMainnet, collector, btcAddress, btcDataSource, btcKeyPair, btcService } from '../../env';
 import { transactionToHex } from 'rgbpp/btc';
+import { saveCkbVirtualTxResult } from '../../shared/utils';
 
 interface RgbppTransferParams {
   rgbppLockArgsList: string[];
@@ -31,6 +32,9 @@ const transfer = async ({ rgbppLockArgsList, toBtcAddress, xudtTypeArgs, transfe
     transferAmount,
     isMainnet,
   });
+
+  // Save ckbVirtualTxResult
+  saveCkbVirtualTxResult(ckbVirtualTxResult, '2-btc-transfer');
 
   const { commitment, ckbRawTx } = ckbVirtualTxResult;
 

--- a/examples/rgbpp/xudt/local/2-btc-transfer.ts
+++ b/examples/rgbpp/xudt/local/2-btc-transfer.ts
@@ -34,7 +34,7 @@ const transfer = async ({ rgbppLockArgsList, toBtcAddress, xudtTypeArgs, transfe
   });
 
   // Save ckbVirtualTxResult
-  saveCkbVirtualTxResult(ckbVirtualTxResult, '2-btc-transfer');
+  saveCkbVirtualTxResult(ckbVirtualTxResult, '2-btc-transfer-local');
 
   const { commitment, ckbRawTx } = ckbVirtualTxResult;
 

--- a/examples/rgbpp/xudt/local/3-btc-leap-ckb.ts
+++ b/examples/rgbpp/xudt/local/3-btc-leap-ckb.ts
@@ -35,7 +35,7 @@ const leapFromBtcToCkb = async ({ rgbppLockArgsList, toCkbAddress, xudtTypeArgs,
   });
 
   // Save ckbVirtualTxResult
-  saveCkbVirtualTxResult(ckbVirtualTxResult, '3-btc-leap-ckb');
+  saveCkbVirtualTxResult(ckbVirtualTxResult, '3-btc-leap-ckb-local');
 
   const { commitment, ckbRawTx } = ckbVirtualTxResult;
 

--- a/examples/rgbpp/xudt/local/3-btc-leap-ckb.ts
+++ b/examples/rgbpp/xudt/local/3-btc-leap-ckb.ts
@@ -9,6 +9,7 @@ import {
 } from 'rgbpp/ckb';
 import { isMainnet, collector, btcAddress, btcDataSource, btcKeyPair, btcService } from '../../env';
 import { transactionToHex } from 'rgbpp/btc';
+import { saveCkbVirtualTxResult } from '../../shared/utils';
 
 interface LeapToCkbParams {
   rgbppLockArgsList: string[];
@@ -32,6 +33,9 @@ const leapFromBtcToCkb = async ({ rgbppLockArgsList, toCkbAddress, xudtTypeArgs,
     toCkbAddress,
     isMainnet,
   });
+
+  // Save ckbVirtualTxResult
+  saveCkbVirtualTxResult(ckbVirtualTxResult, '3-btc-leap-ckb');
 
   const { commitment, ckbRawTx } = ckbVirtualTxResult;
 


### PR DESCRIPTION
## Main Changes:
- Logging Implementation: Added functionality to save ckbVirtualTxResult into a log file in examples/rgbpp/*.
- Comments Addition: Included comments within the codebase to remind developers to adhere to the suggestion of saving ckbVirtualTxResult before finalizing isomorphic transactions.