### PR TITLE
feat(btc): batch queries to improve transaction build time

### DIFF
--- a/.changeset/smart-pigs-compete.md
+++ b/.changeset/smart-pigs-compete.md
@@ -1,0 +1,5 @@
+---
+"@rgbpp-sdk/btc": minor
+---
+
+Add p-limit and batch queries in the sendRgbppUtxos() and TxBuilder.validateInputs() to improve construction time

--- a/packages/btc/package.json
+++ b/packages/btc/package.json
@@ -24,7 +24,8 @@
     "bip32": "^4.0.0",
     "bitcoinjs-lib": "^6.1.5",
     "ecpair": "^2.1.0",
-    "lodash": "^4.17.21"
+    "lodash": "^4.17.21",
+    "p-limit": "^3.1.0"
   },
   "devDependencies": {
     "@types/lodash": "^4.17.0",

--- a/packages/btc/src/utils.ts
+++ b/packages/btc/src/utils.ts
@@ -1,3 +1,4 @@
+import limitPromiseConcurrency from 'p-limit';
 import { bitcoin, ecc, ECPair } from './bitcoin';
 import { bytes } from '@ckb-lumos/codec';
 
@@ -75,3 +76,15 @@ export function transactionToHex(tx: bitcoin.Transaction, withWitness?: boolean)
   const buffer: Buffer = tx['__toBuffer'](undefined, undefined, withWitness ?? false);
   return buffer.toString('hex');
 }
+
+/**
+ * Limits the batch size of promises when querying with Promise.all().
+ * @example
+ * await Promise.all([
+ *   limitPromiseBatchSize(() => asyncDoSomething()),
+ *   limitPromiseBatchSize(() => asyncDoSomething()),
+ *   limitPromiseBatchSize(() => asyncDoSomething()),
+ *   ...
+ * ]);
+ */
+export const limitPromiseBatchSize = limitPromiseConcurrency(10);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -204,6 +204,9 @@ importers:
       lodash:
         specifier: ^4.17.21
         version: 4.17.21
+      p-limit:
+        specifier: ^3.1.0
+        version: 3.1.0
     devDependencies:
       '@types/lodash':
         specifier: ^4.17.0
@@ -4662,7 +4665,6 @@ packages:
     engines: {node: '>=10'}
     dependencies:
       yocto-queue: 0.1.0
-    dev: true
 
   /p-limit@5.0.0:
     resolution: {integrity: sha512-/Eaoq+QyLSiXQ4lyYV23f14mZRQcXnxfHrN0vCai+ak9G0pp9iEQukIIZq5NccEvwRB8PUnZT0KsOoDCINS1qQ==}
@@ -6288,7 +6290,6 @@ packages:
   /yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
-    dev: true
 
   /yocto-queue@1.0.0:
     resolution: {integrity: sha512-9bnSc/HEW2uRy67wc+T8UwauLuPJVn28jb+GtJY16iiKWyvmYJRXVT4UamsAEGQfPohgr2q4Tq0sQbQlxTfi1g==}


### PR DESCRIPTION
## Changes
- Add `p-limit` and batch queries in the sendRgbppUtxos() and TxBuilder.validateInputs() to improve transaction construction time, when querying a group of individual requests, batch up to `10` requests each time

## Test
- [x] Speed test @Dawn-githup 