### PR TITLE
test(service): skip dust_satoshi check in tests

### DIFF
--- a/packages/service/tests/Service.test.ts
+++ b/packages/service/tests/Service.test.ts
@@ -90,7 +90,7 @@ describe(
         });
 
         expect(filteredBalance.satoshi).toEqual(0);
-        expect(filteredBalance.dust_satoshi).toEqual(originalBalance.satoshi + originalBalance.dust_satoshi);
+        // expect(filteredBalance.dust_satoshi).toEqual(originalBalance.satoshi + originalBalance.dust_satoshi);
       });
       it('getBtcBalance() with no_cache', async () => {
         const res = await service.getBtcBalance(btcAddress, {


### PR DESCRIPTION
## Changes
- Skip dust_satoshi check in service tests temporary due to the /balance API changes in https://github.com/ckb-cell/btc-assets-api/pull/154

  > The change is tiny, no changeset needed

## Mocking

One suggestion is that the requests in the unit tests should be mocked, so the changes to the btc-assets-api won't affect the tests of the rgbpp-sdk, nor will the rgbpp-sdk be affected by the networking conditions or otherwise. However, when developers wish to check the status of the service via the tests, an on-off switch option may also be required.