### PR TITLE
feat(service|btc): adapt btc-assets-api#154

### DIFF
--- a/.changeset/tender-hornets-agree.md
+++ b/.changeset/tender-hornets-agree.md
@@ -1,0 +1,11 @@
+---
+"@rgbpp-sdk/service": minor
+"@rgbpp-sdk/btc": minor
+---
+
+Adapt btc-assets-api#154, adding new props and return values to the /balance and /unspent APIs
+
+- Add `available_satoshi` and `total_satoshi` to the BtcAssetsApi.getBtcBalance() API
+- Add `only_non_rgbpp_utxos` to the props of the BtcAssetsApi.getBtcUtxos() API
+- Remove `service.getRgbppAssetsByBtcUtxo()` lines from the DataCollector.collectSatoshi()
+- Remove `hasRgbppAssets` related variables/function from the DataCache

--- a/packages/btc/src/query/cache.ts
+++ b/packages/btc/src/query/cache.ts
@@ -2,11 +2,9 @@ import { Utxo } from '../transaction/utxo';
 
 export class DataCache {
   private utxos: Map<string, Utxo[]>; // Map<Key, Utxo[]>
-  private hasRgbppAssets: Map<string, boolean>; // Map<`{txid}:{vout}`, HasAssets>
 
   constructor() {
     this.utxos = new Map();
-    this.hasRgbppAssets = new Map();
   }
 
   setUtxos(key: string, utxos: Utxo[]) {
@@ -31,32 +29,5 @@ export class DataCache {
     }
 
     return utxos;
-  }
-
-  setHasRgbppAssets(key: string, hasAssets: boolean) {
-    this.hasRgbppAssets.set(key, hasAssets);
-  }
-  getHasRgbppAssets(key: string): boolean | undefined {
-    return this.hasRgbppAssets.get(key);
-  }
-  cleanHasRgbppAssets(key: string) {
-    if (this.hasRgbppAssets.has(key)) {
-      this.hasRgbppAssets.delete(key);
-    }
-  }
-  async optionalCacheHasRgbppAssets(props: {
-    key?: string;
-    getter: () => Promise<boolean> | boolean;
-  }): Promise<boolean> {
-    if (props.key && this.hasRgbppAssets.has(props.key)) {
-      return this.getHasRgbppAssets(props.key) as boolean;
-    }
-
-    const hasRgbppAssets = await props.getter();
-    if (props.key) {
-      this.setHasRgbppAssets(props.key, hasRgbppAssets);
-    }
-
-    return hasRgbppAssets;
   }
 }

--- a/packages/btc/tests/DataSource.test.ts
+++ b/packages/btc/tests/DataSource.test.ts
@@ -19,35 +19,39 @@ describe('DataSource', { retry: 3 }, () => {
       source.getUtxo('70b250e2a3cc7a33b47f7a4e94e41e1ee2501ce73b393d824db1dd4c872c5348', 0),
     ).rejects.toHaveProperty('code', ErrorCodes.UNSPENDABLE_OUTPUT);
   });
-  it('Get UTXO[] via collectSatoshi()', async () => {
-    const address = 'tb1qnxdtut9vpycmpnjpp77rmx33mfxsr86dl3ce6a';
-    const nonRgbppSatoshi = 2546;
-    const totalSatoshi = 3092;
-    const nonRgbppUtxo = 2;
+  describe('collectSatoshi()', () => {
+    const address = 'tb1qn5kgn70tpwsw4nuxrch8l7qa9nqn4fahxgzjg6';
+    const totalSatoshi = 546 + 2000 + 1500;
+    const nonRgbppSatoshi = 1500;
+    const nonRgbppUtxo = 1;
     const totalUtxo = 3;
 
-    const c1 = await source.collectSatoshi({
-      address,
-      targetAmount: totalSatoshi,
-      onlyNonRgbppUtxos: false,
-    });
-    expect(c1.utxos).toHaveLength(totalUtxo);
-    expect(c1.satoshi).toEqual(totalSatoshi);
-
-    const c2 = await source.collectSatoshi({
-      address,
-      targetAmount: nonRgbppSatoshi,
-      onlyNonRgbppUtxos: true,
-    });
-    expect(c2.utxos).toHaveLength(nonRgbppUtxo);
-    expect(c2.satoshi).toEqual(nonRgbppSatoshi);
-
-    await expect(() =>
-      source.collectSatoshi({
+    it('onlyNonRgbppUtxos = false', async () => {
+      const c = await source.collectSatoshi({
         address,
         targetAmount: totalSatoshi,
+        onlyNonRgbppUtxos: false,
+      });
+      expect(c.utxos).toHaveLength(totalUtxo);
+      expect(c.satoshi).toEqual(totalSatoshi);
+    });
+    it('onlyNonRgbppUtxos = true', async () => {
+      const c = await source.collectSatoshi({
+        address,
+        targetAmount: nonRgbppSatoshi,
         onlyNonRgbppUtxos: true,
-      }),
-    ).rejects.toThrowError();
+      });
+      expect(c.utxos).toHaveLength(nonRgbppUtxo);
+      expect(c.satoshi).toEqual(nonRgbppSatoshi);
+    });
+    it('Try onlyNonRgbppUtxos = true and targetAmount = totalSatoshi', async () => {
+      await expect(() =>
+        source.collectSatoshi({
+          address,
+          targetAmount: totalSatoshi,
+          onlyNonRgbppUtxos: true,
+        }),
+      ).rejects.toThrowError();
+    });
   });
 });

--- a/packages/service/README.md
+++ b/packages/service/README.md
@@ -228,13 +228,18 @@ interface BtcApiBalanceParams {
 
 interface BtcApiBalance {
   address: string;
+  // @deprecated Use available_satoshi instead
   satoshi: number;
+  total_satoshi: number;
+  available_satoshi: number;
   pending_satoshi: number;
+  rgbpp_satoshi: number;
   dust_satoshi: number;
   utxo_count: number;
 }
 
 interface BtcApiUtxoParams {
+  only_non_rgbpp_utxos?: boolean;
   only_confirmed?: boolean;
   min_satoshi?: number;
   no_cache?: boolean;

--- a/packages/service/src/types/btc.ts
+++ b/packages/service/src/types/btc.ts
@@ -62,13 +62,18 @@ export interface BtcApiBalanceParams {
 }
 export interface BtcApiBalance {
   address: string;
+  // @deprecated Use available_satoshi instead
   satoshi: number;
+  total_satoshi: number;
+  available_satoshi: number;
   pending_satoshi: number;
+  rgbpp_satoshi: number;
   dust_satoshi: number;
   utxo_count: number;
 }
 
 export interface BtcApiUtxoParams {
+  only_non_rgbpp_utxos?: boolean;
   only_confirmed?: boolean;
   min_satoshi?: number;
   no_cache?: boolean;

--- a/packages/service/tests/Service.test.ts
+++ b/packages/service/tests/Service.test.ts
@@ -79,6 +79,8 @@ describe(
         const res = await service.getBtcBalance(btcAddress);
         expect(res.address).toEqual(btcAddress);
         expect(res.satoshi).toBeTypeOf('number');
+        expect(res.total_satoshi).toBeTypeOf('number');
+        expect(res.available_satoshi).toBeTypeOf('number');
         expect(res.pending_satoshi).toBeTypeOf('number');
         expect(res.dust_satoshi).toBeTypeOf('number');
         expect(res.utxo_count).toBeTypeOf('number');
@@ -89,8 +91,7 @@ describe(
           min_satoshi: originalBalance.satoshi + 1,
         });
 
-        expect(filteredBalance.satoshi).toEqual(0);
-        // expect(filteredBalance.dust_satoshi).toEqual(originalBalance.satoshi + originalBalance.dust_satoshi);
+        expect(filteredBalance.available_satoshi).toEqual(0);
       });
       it('getBtcBalance() with no_cache', async () => {
         const res = await service.getBtcBalance(btcAddress, {


### PR DESCRIPTION
## Changes
- Adapt [btc-assets-api#154](https://github.com/ckb-cell/btc-assets-api/pull/154), adding new props and return values to the /balance and /unspent APIs
  - Add `available_satoshi` and `total_satoshi` to the BtcAssetsApi.getBtcBalance() API
  - Add `only_non_rgbpp_utxos` to the props of the BtcAssetsApi.getBtcUtxos() API
  - Remove `service.getRgbppAssetsByBtcUtxo()` lines from the DataCollector.collectSatoshi()
  - Remove `hasRgbppAssets` related variables/function from the DataCache

## Related issues

- Resolves #173 
  No need to validate whether each UTXO is an RGBPP asset, the construction time is further optimized. Previously, if an address had 1000+ tiny UTXOs, it would take 40+ minutes to construct a transaction. After the PR, it should only take 10+ seconds. Therefore, the slow construction issue is considered resolved.