### PR TITLE
fix(ckb): load the first 16 bytes of the XUDT cell data

### DIFF
--- a/.changeset/serious-actors-explode.md
+++ b/.changeset/serious-actors-explode.md
@@ -1,0 +1,5 @@
+---
+"@rgbpp-sdk/ckb": patch
+---
+
+Fix the XUDT cell data unpacking logic to load only the first 16 bytes

--- a/packages/ckb/src/collector/index.ts
+++ b/packages/ckb/src/collector/index.ts
@@ -4,7 +4,7 @@ import { toCamelcase } from '../utils/case-parser';
 import { CollectConfig, CollectResult, CollectUdtResult, IndexerCell } from '../types/collector';
 import { MIN_CAPACITY } from '../constants';
 import { CapacityNotEnoughError, IndexerError, UdtAmountNotEnoughError } from '../error';
-import { isRgbppLockCellIgnoreChain, leToU128 } from '../utils';
+import { isRgbppLockCellIgnoreChain, leToU128, remove0x } from '../utils';
 import { Hex } from '../types';
 
 interface IndexerScript {
@@ -148,7 +148,9 @@ export class Collector {
         since: '0x0',
       });
       sumInputsCapacity = sumInputsCapacity + BigInt(cell.output.capacity);
-      sumAmount += leToU128(cell.outputData);
+      // XUDT cell.data = <amount: uint128> <xudt data (optional)>
+      // Ref: https://blog.cryptape.com/enhance-sudts-programmability-with-xudt#heading-xudt-cell
+      sumAmount += leToU128(remove0x(cell.outputData).slice(0, 32));
       if (sumAmount >= needAmount && !isRgbppLock) {
         break;
       }


### PR DESCRIPTION
## Changes
- Resolves https://github.com/ckb-cell/rgbpp-sdk/issues/211

## Reference

ref: https://blog.cryptape.com/enhance-sudts-programmability-with-xudt#heading-xudt-cell

```yml
XUDT cell
On top of sUDT, xUDT extends a cell as follows:

data:
    <amount: uint128> <xudt data>
```