### PR TITLE
fix(examples): ckb-leap-btc not reading env variables

### DIFF
--- a/examples/rgbpp/xudt/1-ckb-leap-btc.ts
+++ b/examples/rgbpp/xudt/1-ckb-leap-btc.ts
@@ -30,7 +30,7 @@ const leapFromCkbToBtc = async ({ outIndex, btcTxId, xudtTypeArgs, transferAmoun
   const emptyWitness = { lock: '', inputType: '', outputType: '' };
   const unsignedTx: CKBComponents.RawTransactionToSign = {
     ...ckbRawTx,
-    cellDeps: [...ckbRawTx.cellDeps, getSecp256k1CellDep(false)],
+    cellDeps: [...ckbRawTx.cellDeps, getSecp256k1CellDep(isMainnet)],
     witnesses: [emptyWitness, ...ckbRawTx.witnesses.slice(1)],
   };
 


### PR DESCRIPTION
## Changes
- Fixed issue where ckb-leap-btc did not read environment variables correctly.
