### PR TITLE
feat(ckb|example): Export `buildRgbppTransferTx` from rgbpp package and update L1 transfer example

### DIFF
--- a/.changeset/great-baboons-smash.md
+++ b/.changeset/great-baboons-smash.md
@@ -1,0 +1,5 @@
+---
+"rgbpp": minor
+---
+
+feat: Export buildRgbppTransferTx from rgbpp package

--- a/examples/rgbpp/xudt/2-btc-transfer.ts
+++ b/examples/rgbpp/xudt/2-btc-transfer.ts
@@ -1,6 +1,6 @@
 import { buildRgbppLockArgs } from 'rgbpp/ckb';
 import { buildRgbppTransferTx } from 'rgbpp';
-import { isMainnet, collector, btcService, btcAccount } from '../env';
+import { isMainnet, collector, btcService, btcAccount, btcDataSource } from '../env';
 import { saveCkbVirtualTxResult } from '../shared/utils';
 import { signAndSendPsbt } from '../shared/btc-account';
 import { bitcoin } from 'rgbpp/btc';
@@ -14,13 +14,17 @@ interface RgbppTransferParams {
 
 const transfer = async ({ rgbppLockArgsList, toBtcAddress, xudtTypeArgs, transferAmount }: RgbppTransferParams) => {
   const { ckbVirtualTxResult, btcPsbtHex } = await buildRgbppTransferTx({
-    collector,
-    xudtTypeArgs,
-    rgbppLockArgsList,
-    transferAmount,
-    fromBtcAddress: btcAccount.from,
-    toBtcAddress,
-    btcDataSource,
+    ckb: {
+      collector,
+      xudtTypeArgs,
+      rgbppLockArgsList,
+      transferAmount,
+    },
+    btc: {
+      fromAddress: btcAccount.from,
+      toAddress: toBtcAddress,
+      dataSource: btcDataSource,
+    },
     isMainnet,
   });
 

--- a/examples/rgbpp/xudt/2-btc-transfer.ts
+++ b/examples/rgbpp/xudt/2-btc-transfer.ts
@@ -1,9 +1,9 @@
-import { buildRgbppLockArgs, getXudtTypeScript } from 'rgbpp/ckb';
-import { serializeScript } from '@nervosnetwork/ckb-sdk-utils';
-import { genBtcTransferCkbVirtualTx, sendRgbppUtxos } from 'rgbpp';
-import { isMainnet, collector, btcService, btcDataSource, btcAccount } from '../env';
+import { buildRgbppLockArgs } from 'rgbpp/ckb';
+import { buildRgbppTransferTx } from 'rgbpp';
+import { isMainnet, collector, btcService, btcAccount } from '../env';
 import { saveCkbVirtualTxResult } from '../shared/utils';
 import { signAndSendPsbt } from '../shared/btc-account';
+import { bitcoin } from 'rgbpp/btc';
 
 interface RgbppTransferParams {
   rgbppLockArgsList: string[];
@@ -13,34 +13,22 @@ interface RgbppTransferParams {
 }
 
 const transfer = async ({ rgbppLockArgsList, toBtcAddress, xudtTypeArgs, transferAmount }: RgbppTransferParams) => {
-  const xudtType: CKBComponents.Script = {
-    ...getXudtTypeScript(isMainnet),
-    args: xudtTypeArgs,
-  };
-
-  const ckbVirtualTxResult = await genBtcTransferCkbVirtualTx({
+  const { ckbVirtualTxResult, btcTxHexToSign } = await buildRgbppTransferTx({
     collector,
+    xudtTypeArgs,
     rgbppLockArgsList,
-    xudtTypeBytes: serializeScript(xudtType),
     transferAmount,
+    fromBtcAddress: btcAccount.from,
+    toBtcAddress,
+    btcDataSource,
     isMainnet,
   });
 
   // Save ckbVirtualTxResult
   saveCkbVirtualTxResult(ckbVirtualTxResult, '2-btc-transfer');
 
-  const { commitment, ckbRawTx } = ckbVirtualTxResult;
-
   // Send BTC tx
-  const psbt = await sendRgbppUtxos({
-    ckbVirtualTx: ckbRawTx,
-    commitment,
-    tos: [toBtcAddress],
-    ckbCollector: collector,
-    from: btcAccount.from,
-    fromPubkey: btcAccount.fromPubkey,
-    source: btcDataSource,
-  });
+  const psbt = bitcoin.Psbt.fromHex(btcTxHexToSign);
 
   const { txId: btcTxId } = await signAndSendPsbt(psbt, btcAccount, btcService);
   console.log('BTC TxId: ', btcTxId);

--- a/examples/rgbpp/xudt/2-btc-transfer.ts
+++ b/examples/rgbpp/xudt/2-btc-transfer.ts
@@ -13,7 +13,7 @@ interface RgbppTransferParams {
 }
 
 const transfer = async ({ rgbppLockArgsList, toBtcAddress, xudtTypeArgs, transferAmount }: RgbppTransferParams) => {
-  const { ckbVirtualTxResult, btcTxHexToSign } = await buildRgbppTransferTx({
+  const { ckbVirtualTxResult, btcPsbtHex } = await buildRgbppTransferTx({
     collector,
     xudtTypeArgs,
     rgbppLockArgsList,
@@ -28,8 +28,7 @@ const transfer = async ({ rgbppLockArgsList, toBtcAddress, xudtTypeArgs, transfe
   saveCkbVirtualTxResult(ckbVirtualTxResult, '2-btc-transfer');
 
   // Send BTC tx
-  const psbt = bitcoin.Psbt.fromHex(btcTxHexToSign);
-
+  const psbt = bitcoin.Psbt.fromHex(btcPsbtHex);
   const { txId: btcTxId } = await signAndSendPsbt(psbt, btcAccount, btcService);
   console.log('BTC TxId: ', btcTxId);
 

--- a/examples/rgbpp/xudt/2-btc-transfer.ts
+++ b/examples/rgbpp/xudt/2-btc-transfer.ts
@@ -23,6 +23,7 @@ const transfer = async ({ rgbppLockArgsList, toBtcAddress, xudtTypeArgs, transfe
     btc: {
       fromAddress: btcAccount.from,
       toAddress: toBtcAddress,
+      fromPubkey: btcAccount.fromPubkey,
       dataSource: btcDataSource,
     },
     isMainnet,

--- a/examples/rgbpp/xudt/local/2-btc-transfer.ts
+++ b/examples/rgbpp/xudt/local/2-btc-transfer.ts
@@ -24,6 +24,7 @@ const transfer = async ({ rgbppLockArgsList, toBtcAddress, xudtTypeArgs, transfe
     btc: {
       fromAddress: btcAccount.from,
       toAddress: toBtcAddress,
+      fromPubkey: btcAccount.fromPubkey,
       dataSource: btcDataSource,
     },
     isMainnet,

--- a/examples/rgbpp/xudt/local/2-btc-transfer.ts
+++ b/examples/rgbpp/xudt/local/2-btc-transfer.ts
@@ -15,13 +15,17 @@ interface RgbppTransferParams {
 // Warning: It is not recommended for developers to use local examples unless you understand the entire process of RGB++ transactions.
 const transfer = async ({ rgbppLockArgsList, toBtcAddress, xudtTypeArgs, transferAmount }: RgbppTransferParams) => {
   const { ckbVirtualTxResult, btcPsbtHex } = await buildRgbppTransferTx({
-    collector,
-    xudtTypeArgs,
-    rgbppLockArgsList,
-    transferAmount,
-    fromBtcAddress: btcAddress!,
-    toBtcAddress,
-    btcDataSource,
+    ckb: {
+      collector,
+      xudtTypeArgs,
+      rgbppLockArgsList,
+      transferAmount,
+    },
+    btc: {
+      fromAddress: btcAccount.from,
+      toAddress: toBtcAddress,
+      dataSource: btcDataSource,
+    },
     isMainnet,
   });
 

--- a/packages/rgbpp/README.md
+++ b/packages/rgbpp/README.md
@@ -13,3 +13,33 @@ $ yarn add rgbpp
 # or
 $ pnpm add rgbpp
 ```
+
+## Transfer RGB++ Assets on BTC
+
+The function `buildRgbppTransferTx` will generate CKB virtual transaction and related BTC transaction with the commitment for the RGB++ assets transfer on BTC. 
+
+The `btcPsbtHex` can be used to construct bitcoin PSBT to sign and send BTC transaction with BTC wallet, and then the BTC transaction id and `ckbVirtualTxResult` will be used to post to RGB++ Queue Service to complete the isomorphic CKB transaction.
+
+```TypeScript
+const { ckbVirtualTxResult, btcPsbtHex } = await buildRgbppTransferTx({
+    collector,
+    xudtTypeArgs,
+    rgbppLockArgsList,
+    transferAmount,
+    fromBtcAddress,
+    toBtcAddress,
+    btcDataSource,
+    isMainnet,
+  });
+
+// Construct SPBT with btcPsbtHex to sign and send BTC transaction with the BTC key pair
+const psbt = bitcoin.Psbt.fromHex(btcPsbtHex);
+psbt.signAllInputs(btcKeyPair);
+psbt.finalizeAllInputs();
+
+const btcTx = psbt.extractTransaction();
+const { txid: btcTxId } = await btcService.sendBtcTransaction(btcTx.toHex());
+
+// Post the BTC txId and ckbVirtualTxResult to the RGB++ Queue Service
+await btcService.sendRgbppCkbTransaction({ btc_txid: btcTxId, ckb_virtual_result: ckbVirtualTxResult });
+```

--- a/packages/rgbpp/README.md
+++ b/packages/rgbpp/README.md
@@ -22,15 +22,22 @@ The `btcPsbtHex` can be used to construct bitcoin PSBT to sign and send BTC tran
 
 ```TypeScript
 const { ckbVirtualTxResult, btcPsbtHex } = await buildRgbppTransferTx({
+  ckb: {
     collector,
     xudtTypeArgs,
     rgbppLockArgsList,
     transferAmount,
+    ckbFeeRate,
+  },
+  btc: {
     fromBtcAddress,
     toBtcAddress,
     btcDataSource,
-    isMainnet,
-  });
+    fromPubkey,
+    feeRate
+  },
+  isMainnet,
+});
 
 // Construct SPBT with btcPsbtHex to sign and send BTC transaction with the BTC key pair
 const psbt = bitcoin.Psbt.fromHex(btcPsbtHex);

--- a/packages/rgbpp/package.json
+++ b/packages/rgbpp/package.json
@@ -36,7 +36,8 @@
   "dependencies": {
     "@rgbpp-sdk/btc": "workspace:*",
     "@rgbpp-sdk/ckb": "workspace:*",
-    "@rgbpp-sdk/service": "workspace:*"
+    "@rgbpp-sdk/service": "workspace:*",
+    "@nervosnetwork/ckb-sdk-utils": "^0.109.1"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/rgbpp/src/index.ts
+++ b/packages/rgbpp/src/index.ts
@@ -54,3 +54,9 @@ export {
   createSendRgbppUtxosBuilder,
 } from '@rgbpp-sdk/btc';
 export type { SendBtcProps, SendUtxosProps, SendRgbppUtxosProps } from '@rgbpp-sdk/btc';
+
+/**
+ * RGB++
+ */
+export { buildRgbppTransferTx } from './rgbpp/xudt';
+export type { RgbppTransferTxParams, RgbppTransferTxResult } from './rgbpp/types';

--- a/packages/rgbpp/src/rgbpp/types.ts
+++ b/packages/rgbpp/src/rgbpp/types.ts
@@ -1,7 +1,7 @@
 import { DataSource } from '@rgbpp-sdk/btc';
 import { BtcTransferVirtualTxResult, Collector, Hex } from '@rgbpp-sdk/ckb';
 
-export interface RgbppTransferCkb {
+export interface RgbppTransferCkbParams {
   // The collector that collects CKB live cells and transactions
   collector: Collector;
   // The transferred RGB++ xUDT type script args
@@ -11,15 +11,15 @@ export interface RgbppTransferCkb {
   // The XUDT amount to be transferred, if the noMergeOutputCells is true, the transferAmount will be ignored
   transferAmount: bigint;
   // The CKB transaction fee rate, default value is 1100
-  ckbFeeRate?: bigint;
+  feeRate?: bigint;
 }
 
-export interface RgbppTransferBtc {
+export interface RgbppTransferBtcParams {
   // The sender BTC address
-  fromBtcAddress: string;
+  fromAddress: string;
   // The receiver BTC address
-  toBtcAddress: string;
-  btcDataSource: DataSource;
+  toAddress: string;
+  dataSource: DataSource;
   // The public key of sender BTC address
   fromPubkey?: Hex;
   // The fee rate of the BTC transaction
@@ -27,8 +27,8 @@ export interface RgbppTransferBtc {
 }
 
 export interface RgbppTransferTxParams {
-  ckb: RgbppTransferCkb;
-  btc: RgbppTransferBtc;
+  ckb: RgbppTransferCkbParams;
+  btc: RgbppTransferBtcParams;
   isMainnet: boolean;
 }
 

--- a/packages/rgbpp/src/rgbpp/types.ts
+++ b/packages/rgbpp/src/rgbpp/types.ts
@@ -1,0 +1,24 @@
+import { DataSource } from '@rgbpp-sdk/btc';
+import { BtcTransferVirtualTxResult, Collector, Hex } from '@rgbpp-sdk/ckb';
+
+export interface RgbppTransferTxParams {
+  // The collector that collects CKB live cells and transactions
+  collector: Collector;
+  // The transferred RGB++ xUDT type script args
+  xudtTypeArgs: Hex;
+  // The rgbpp assets cell lock script args array whose data structure is: out_index | bitcoin_tx_id
+  rgbppLockArgsList: Hex[];
+  // The XUDT amount to be transferred, if the noMergeOutputCells is true, the transferAmount will be ignored
+  transferAmount: bigint;
+  // The sender BTC address
+  fromBtcAddress: string;
+  // The receiver BTC address
+  toBtcAddress: string;
+  btcDataSource: DataSource;
+  isMainnet: boolean;
+}
+
+export interface RgbppTransferTxResult {
+  ckbVirtualTxResult: BtcTransferVirtualTxResult;
+  btcTxHexToSign: Hex;
+}

--- a/packages/rgbpp/src/rgbpp/types.ts
+++ b/packages/rgbpp/src/rgbpp/types.ts
@@ -20,5 +20,6 @@ export interface RgbppTransferTxParams {
 
 export interface RgbppTransferTxResult {
   ckbVirtualTxResult: BtcTransferVirtualTxResult;
-  btcTxHexToSign: Hex;
+  // The BTC transaction hex string which can be used to construct Bitcoin PSBT
+  btcPsbtHex: Hex;
 }

--- a/packages/rgbpp/src/rgbpp/types.ts
+++ b/packages/rgbpp/src/rgbpp/types.ts
@@ -1,7 +1,7 @@
 import { DataSource } from '@rgbpp-sdk/btc';
 import { BtcTransferVirtualTxResult, Collector, Hex } from '@rgbpp-sdk/ckb';
 
-export interface RgbppTransferTxParams {
+export interface RgbppTransferCkb {
   // The collector that collects CKB live cells and transactions
   collector: Collector;
   // The transferred RGB++ xUDT type script args
@@ -10,11 +10,25 @@ export interface RgbppTransferTxParams {
   rgbppLockArgsList: Hex[];
   // The XUDT amount to be transferred, if the noMergeOutputCells is true, the transferAmount will be ignored
   transferAmount: bigint;
+  // The CKB transaction fee rate, default value is 1100
+  ckbFeeRate?: bigint;
+}
+
+export interface RgbppTransferBtc {
   // The sender BTC address
   fromBtcAddress: string;
   // The receiver BTC address
   toBtcAddress: string;
   btcDataSource: DataSource;
+  // The public key of sender BTC address
+  fromPubkey?: Hex;
+  // The fee rate of the BTC transaction
+  feeRate?: number;
+}
+
+export interface RgbppTransferTxParams {
+  ckb: RgbppTransferCkb;
+  btc: RgbppTransferBtc;
   isMainnet: boolean;
 }
 

--- a/packages/rgbpp/src/rgbpp/types.ts
+++ b/packages/rgbpp/src/rgbpp/types.ts
@@ -20,6 +20,6 @@ export interface RgbppTransferTxParams {
 
 export interface RgbppTransferTxResult {
   ckbVirtualTxResult: BtcTransferVirtualTxResult;
-  // The BTC transaction hex string which can be used to construct Bitcoin PSBT
+  // The BTC PSBT hex string which can be used to construct Bitcoin PSBT
   btcPsbtHex: Hex;
 }

--- a/packages/rgbpp/src/rgbpp/xudt.ts
+++ b/packages/rgbpp/src/rgbpp/xudt.ts
@@ -10,19 +10,19 @@ import { RgbppTransferTxParams, RgbppTransferTxResult } from './types';
  * @param xudtTypeArgs The transferred xUDT type script args
  * @param rgbppLockArgsList The RGB++ assets cell lock script args array whose data structure is: out_index | bitcoin_tx_id
  * @param transferAmount The XUDT amount to be transferred, if the noMergeOutputCells is true, the transferAmount will be ignored
- * @param ckbFeeRate The CKB transaction fee rate, default value is 1100
+ * @param feeRate The CKB transaction fee rate, default value is 1100
  *
  * BTC pramaeters
- * @param fromBtcAddress The sender BTC address
+ * @param fromAddress The sender BTC address
  * @param fromPubkey The public key of the sender BTC address
- * @param toBtcAddress The receiver BTC address
- * @param btcDataSource The BTC data source
+ * @param toAddress The receiver BTC address
+ * @param dataSource The BTC data source
  * @param feeRate The fee rate of the BTC transaction
  * @param isMainnet
  */
 export const buildRgbppTransferTx = async ({
-  ckb: { collector, xudtTypeArgs, rgbppLockArgsList, transferAmount, ckbFeeRate },
-  btc: { fromBtcAddress, toBtcAddress, btcDataSource, fromPubkey, feeRate },
+  ckb: { collector, xudtTypeArgs, rgbppLockArgsList, transferAmount, feeRate: ckbFeeRate },
+  btc,
   isMainnet,
 }: RgbppTransferTxParams): Promise<RgbppTransferTxResult> => {
   const xudtType: CKBComponents.Script = {
@@ -45,12 +45,12 @@ export const buildRgbppTransferTx = async ({
   const psbt = await sendRgbppUtxos({
     ckbVirtualTx: ckbRawTx,
     commitment,
-    tos: [toBtcAddress],
+    tos: [btc.toAddress],
     ckbCollector: collector,
-    from: fromBtcAddress!,
-    fromPubkey,
-    source: btcDataSource,
-    feeRate,
+    from: btc.fromAddress!,
+    fromPubkey: btc.fromPubkey,
+    source: btc.dataSource,
+    feeRate: btc.feeRate,
   });
 
   return {

--- a/packages/rgbpp/src/rgbpp/xudt.ts
+++ b/packages/rgbpp/src/rgbpp/xudt.ts
@@ -1,0 +1,56 @@
+import { genBtcTransferCkbVirtualTx, getXudtTypeScript } from '@rgbpp-sdk/ckb';
+import { serializeScript } from '@nervosnetwork/ckb-sdk-utils';
+import { sendRgbppUtxos } from '@rgbpp-sdk/btc';
+import { RgbppTransferTxParams, RgbppTransferTxResult } from './types';
+
+/**
+ * Build the CKB virtual transaction and BTC transaction to be signed for the RGB++ transfer tx
+ * @param collector The collector that collects CKB live cells and transactions
+ * @param xudtTypeArgs The transferred xUDT type script args
+ * @param rgbppLockArgsList The RGB++ assets cell lock script args array whose data structure is: out_index | bitcoin_tx_id
+ * @param transferAmount The XUDT amount to be transferred, if the noMergeOutputCells is true, the transferAmount will be ignored
+ * @param fromBtcAddress The sender BTC address
+ * @param toBtcAddress The receiver BTC address
+ * @param btcDataSource The BTC data source
+ * @param isMainnet
+ */
+export const buildRgbppTransferTx = async ({
+  collector,
+  xudtTypeArgs,
+  rgbppLockArgsList,
+  transferAmount,
+  fromBtcAddress,
+  toBtcAddress,
+  btcDataSource,
+  isMainnet,
+}: RgbppTransferTxParams): Promise<RgbppTransferTxResult> => {
+  const xudtType: CKBComponents.Script = {
+    ...getXudtTypeScript(isMainnet),
+    args: xudtTypeArgs,
+  };
+
+  const ckbVirtualTxResult = await genBtcTransferCkbVirtualTx({
+    collector,
+    rgbppLockArgsList,
+    xudtTypeBytes: serializeScript(xudtType),
+    transferAmount,
+    isMainnet,
+  });
+
+  const { commitment, ckbRawTx } = ckbVirtualTxResult;
+
+  // Send BTC tx
+  const psbt = await sendRgbppUtxos({
+    ckbVirtualTx: ckbRawTx,
+    commitment,
+    tos: [toBtcAddress],
+    ckbCollector: collector,
+    from: fromBtcAddress!,
+    source: btcDataSource,
+  });
+
+  return {
+    ckbVirtualTxResult,
+    btcTxHexToSign: psbt.toHex(),
+  };
+};

--- a/packages/rgbpp/src/rgbpp/xudt.ts
+++ b/packages/rgbpp/src/rgbpp/xudt.ts
@@ -5,23 +5,24 @@ import { RgbppTransferTxParams, RgbppTransferTxResult } from './types';
 
 /**
  * Build the CKB virtual transaction and BTC transaction to be signed for the RGB++ transfer tx
+ * CKB parameters
  * @param collector The collector that collects CKB live cells and transactions
  * @param xudtTypeArgs The transferred xUDT type script args
  * @param rgbppLockArgsList The RGB++ assets cell lock script args array whose data structure is: out_index | bitcoin_tx_id
  * @param transferAmount The XUDT amount to be transferred, if the noMergeOutputCells is true, the transferAmount will be ignored
+ * @param ckbFeeRate The CKB transaction fee rate, default value is 1100
+ *
+ * BTC pramaeters
  * @param fromBtcAddress The sender BTC address
+ * @param fromPubkey The public key of the sender BTC address
  * @param toBtcAddress The receiver BTC address
  * @param btcDataSource The BTC data source
+ * @param feeRate The fee rate of the BTC transaction
  * @param isMainnet
  */
 export const buildRgbppTransferTx = async ({
-  collector,
-  xudtTypeArgs,
-  rgbppLockArgsList,
-  transferAmount,
-  fromBtcAddress,
-  toBtcAddress,
-  btcDataSource,
+  ckb: { collector, xudtTypeArgs, rgbppLockArgsList, transferAmount, ckbFeeRate },
+  btc: { fromBtcAddress, toBtcAddress, btcDataSource, fromPubkey, feeRate },
   isMainnet,
 }: RgbppTransferTxParams): Promise<RgbppTransferTxResult> => {
   const xudtType: CKBComponents.Script = {
@@ -35,6 +36,7 @@ export const buildRgbppTransferTx = async ({
     xudtTypeBytes: serializeScript(xudtType),
     transferAmount,
     isMainnet,
+    ckbFeeRate,
   });
 
   const { commitment, ckbRawTx } = ckbVirtualTxResult;
@@ -46,7 +48,9 @@ export const buildRgbppTransferTx = async ({
     tos: [toBtcAddress],
     ckbCollector: collector,
     from: fromBtcAddress!,
+    fromPubkey,
     source: btcDataSource,
+    feeRate,
   });
 
   return {

--- a/packages/rgbpp/src/rgbpp/xudt.ts
+++ b/packages/rgbpp/src/rgbpp/xudt.ts
@@ -51,6 +51,6 @@ export const buildRgbppTransferTx = async ({
 
   return {
     ckbVirtualTxResult,
-    btcTxHexToSign: psbt.toHex(),
+    btcPsbtHex: psbt.toHex(),
   };
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -263,6 +263,9 @@ importers:
 
   packages/rgbpp:
     dependencies:
+      '@nervosnetwork/ckb-sdk-utils':
+        specifier: ^0.109.1
+        version: 0.109.1
       '@rgbpp-sdk/btc':
         specifier: workspace:*
         version: link:../btc


### PR DESCRIPTION
## Changes

- Export `buildRgbppTransferTx` from rgbpp package to generate CKB virtual TX and BTC tx to be signed
- Update L1 transfer example with the function `buildRgbppTransferTx`

## Function Signature
```TypeScript
const buildRgbppTransferTx = async ({
  ckb: {
    collector,
    xudtTypeArgs,
    rgbppLockArgsList,
    transferAmount,
    ckbFeeRate,
  },
  btc: {
    fromBtcAddress,
    toBtcAddress,
    btcDataSource,
    fromPubkey,
    feeRate
  },
  isMainnet,
}: RgbppTransferTxParams): Promise<RgbppTransferTxResult>
```
The `collector` and `btcDataSource` will be constructed in the `rgbpp-sdk-service` with some necessary variables from the environment.  The necessary request and response for the L1 transfer in the `rgbpp-sdk-service` are as follows: 
```TypeScript
interface RgbppTransferReq {
  // The transferred RGB++ xUDT type script args
  xudtTypeArgs: string;           
  // The rgbpp assets cell lock script args array whose data structure is: out_index | btc_tx_id
  rgbppLockArgsList: string[];   
  // The xUDT amount to be transferred
  transferAmount: Hex;     
  // The sender BTC address       
  fromBtcAddress: string;     
  // The receiver BTC address
  toBtcAddress: string;     
}

interface RgbppTransferResp {
  // The JSON string for the `BtcTransferVirtualTxResult`
  ckbVirtualTxResult: string;    
  // The BTC PSBT hex string which can be used to construct Bitcoin PSBT
  btcPsbtHex: Hex;           
}
``` 

## Related PR
- #218 