### PR TITLE
chore: update comment style and remove no-git-tag option in the snapshot.yaml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,8 +48,8 @@ jobs:
         run: pnpm i
 
       - name: Create bump PR or release version
-        id: changesets
         uses: changesets/action@v1
+        id: changesets
         with:
           publish: pnpm run release:packages
           title: "bump: assumable rgbpp-sdk version"
@@ -57,3 +57,20 @@ jobs:
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create comment on commit
+        uses: actions/github-script@v7
+        if: steps.changesets.outputs.published
+        env:
+          PACKAGES: ${{ steps.changesets.outputs.publishedPackages }}
+        with:
+          script: |
+            const packages = JSON.parse(process.env.PACKAGES)
+            const packagesTable = packages.map((p) => `| ${p.name} | \`${p.version}\` |`)
+            const body = ['New official version of the rgbpp-sdk packages have been released:', '| Name | Version |', '| --- | --- |', packagesTable].join('\n')
+            github.rest.repos.createCommitComment({
+              commit_sha: context.sha,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: body,
+            });

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -63,22 +63,29 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Publish to npm
-        id: changesets
+      - name: Publish snapshot versions to npm
         uses: changesets/action@v1
+        id: changesets
         with:
-          publish: npx changeset publish --no-git-tag --snapshot --tag snap
+          publish: npx changeset publish --snapshot --tag snap
           createGithubReleases: false
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Create commit comment
-        uses: peter-evans/commit-comment@v3
-        if: ${{ steps.changesets.outputs.published == 'true' }}
+      - name: Create comment on commit
+        uses: actions/github-script@v7
+        if: steps.changesets.outputs.published
+        env:
+          PACKAGES: ${{ steps.changesets.outputs.publishedPackages }}
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          body: |
-            ```json
-            ${{ steps.changesets.outputs.publishedPackages }}
-            ```
+          script: |
+            const packages = JSON.parse(process.env.PACKAGES)
+            const packagesTable = packages.map((p) => `| ${p.name} | \`${p.version}\` |`)
+            const body = ['New snapshot version of the rgbpp-sdk packages have been released:', '| Name | Version |', '| --- | --- |', packagesTable].join('\n')
+            github.rest.repos.createCommitComment({
+              commit_sha: context.sha,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: body,
+            });

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,6 +1,6 @@
 # Test the functionality of the rgbpp-sdk packages.
 
-name: Test
+name: Unit Tests
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
## Changes
- Remove the "--no-git-tag" in the snapshot release workflow, allowing the changesets/action to work as expected
- Update comment style when new package versions have been released (send table to pull/issue comment)