### PR TITLE
chore(examples): update rgbpp-sdk to v0.3.0

### DIFF
--- a/examples/rgbpp/package.json
+++ b/examples/rgbpp/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "@nervosnetwork/ckb-sdk-utils": "^0.109.1",
-    "rgbpp": "workspace:*"
+    "rgbpp": "^0.3.0"
   },
   "devDependencies": {
     "@types/node": "^20.11.28",

--- a/examples/xudt-on-ckb/package.json
+++ b/examples/xudt-on-ckb/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "@nervosnetwork/ckb-sdk-utils": "^0.109.1",
-    "rgbpp": "workspace:*"
+    "rgbpp": "^0.3.0"
   },
   "devDependencies": {
     "dotenv": "^16.4.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -143,7 +143,7 @@ importers:
         specifier: ^0.109.1
         version: 0.109.1
       rgbpp:
-        specifier: workspace:*
+        specifier: ^0.3.0
         version: link:../../packages/rgbpp
     devDependencies:
       '@types/dotenv':
@@ -165,7 +165,7 @@ importers:
         specifier: ^0.109.1
         version: 0.109.1
       rgbpp:
-        specifier: workspace:*
+        specifier: ^0.3.0
         version: link:../../packages/rgbpp
     devDependencies:
       '@types/dotenv':


### PR DESCRIPTION
## Changes
- Update the rgbpp-sdk version in the examples to v0.3.0.