### PR TITLE
chore(CI): Run integration-tests every day

### DIFF
--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -9,8 +9,10 @@ on:
   schedule:
     - cron: '59 0 * * *'
 
+# https://docs.github.com/en/actions/using-jobs/using-concurrency
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
 
 jobs:
   test:

--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -5,6 +5,9 @@ name: Integration Tests
 on:
   workflow_dispatch:
   pull_request:
+  # Run integration-tests every day
+  schedule:
+    - cron: '59 0 * * *'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
## Changes
- [chore(CI): Run integration-tests every day](https://github.com/ckb-cell/rgbpp-sdk/pull/221/commits/fec2b4b4626419a9cdd164672de7591fe5c958dc)
- [chore: only one integration-tests runs at a time](https://github.com/ckb-cell/rgbpp-sdk/pull/221/commits/4cd077b884bc43672a00512006c7960145c65fe6) since only one group of keys is used