### PR TITLE
feat(service): support BtcAssetsApi.getRgbppApiBalanceByAddress()

### DIFF
--- a/.changeset/silly-rules-collect.md
+++ b/.changeset/silly-rules-collect.md
@@ -1,0 +1,5 @@
+---
+"@rgbpp-sdk/service": minor
+---
+
+Add BtcAssetsApi.getRgbppApiBalanceByAddress() API for querying RGBPP XUDT balances by a BTC address

--- a/packages/service/src/service/service.ts
+++ b/packages/service/src/service/service.ts
@@ -24,6 +24,8 @@ import {
   RgbppApiSendCkbTransactionPayload,
   RgbppApiCkbTransactionHash,
   RgbppApiAssetsByAddressParams,
+  RgbppApiBalanceByAddressParams,
+  RgbppApiBalance,
   RgbppApiRetryCkbTransactionPayload,
   RgbppApiTransactionStateParams,
   RgbppApiTransactionRetry,
@@ -124,6 +126,12 @@ export class BtcAssetsApi extends BtcAssetsApiBase implements BtcApis, RgbppApis
 
   getRgbppAssetsByBtcAddress(btcAddress: string, params?: RgbppApiAssetsByAddressParams) {
     return this.request<Cell[]>(`/rgbpp/v1/address/${btcAddress}/assets`, {
+      params,
+    });
+  }
+
+  getRgbppBalanceByBtcAddress(btcAddress: string, params?: RgbppApiBalanceByAddressParams) {
+    return this.request<RgbppApiBalance>(`/rgbpp/v1/address/${btcAddress}/balance`, {
       params,
     });
   }

--- a/packages/service/src/types/rgbpp.ts
+++ b/packages/service/src/types/rgbpp.ts
@@ -7,6 +7,7 @@ export interface RgbppApis {
   getRgbppAssetsByBtcTxId(btcTxId: string): Promise<Cell[]>;
   getRgbppAssetsByBtcUtxo(btcTxId: string, vout: number): Promise<Cell[]>;
   getRgbppAssetsByBtcAddress(btcAddress: string, params?: RgbppApiAssetsByAddressParams): Promise<Cell[]>;
+  getRgbppBalanceByBtcAddress(btcAddress: string, params?: RgbppApiBalanceByAddressParams): Promise<RgbppApiBalance>;
   getRgbppSpvProof(btcTxId: string, confirmations: number): Promise<RgbppApiSpvProof>;
   sendRgbppCkbTransaction(payload: RgbppApiSendCkbTransactionPayload): Promise<RgbppApiTransactionState>;
   retryRgbppCkbTransaction(payload: RgbppApiRetryCkbTransactionPayload): Promise<RgbppApiTransactionRetry>;
@@ -45,6 +46,24 @@ export interface RgbppApiTransactionState {
 export interface RgbppApiAssetsByAddressParams {
   type_script?: string;
   no_cache?: boolean;
+}
+
+export interface RgbppApiBalanceByAddressParams {
+  type_script?: string;
+  no_cache?: boolean;
+}
+export interface RgbppApiBalance {
+  address: string;
+  xudt: RgbppApiXudtBalance[];
+}
+export interface RgbppApiXudtBalance {
+  name: string;
+  decimal: number;
+  symbol: string;
+  total_amount: string;
+  available_amount: string;
+  pending_amount: string;
+  type_hash: string;
 }
 
 export interface RgbppApiSpvProof {

--- a/packages/service/tests/Service.test.ts
+++ b/packages/service/tests/Service.test.ts
@@ -261,12 +261,20 @@ describe(
           expectCell(cell);
         }
       });
-      it('getRgbppAssetsByBtcAddress() with no_cache', async () => {
-        const res = await service.getRgbppAssetsByBtcAddress(rgbppBtcAddress, {
-          no_cache: true,
-        });
+      it('getRgbppBalanceByBtcAddress()', async () => {
+        const res = await service.getRgbppBalanceByBtcAddress(rgbppBtcAddress);
         expect(res).toBeDefined();
-        expect(res.length).toBeGreaterThan(0);
+        expect(res.address).toBeTypeOf('string');
+        expect(res.xudt.length).toBeGreaterThan(0);
+        for (const xudt of res.xudt) {
+          expect(xudt.name).toBeTypeOf('string');
+          expect(xudt.decimal).toBeTypeOf('number');
+          expect(xudt.symbol).toBeTypeOf('string');
+          expect(xudt.total_amount).toBeTypeOf('string');
+          expect(xudt.available_amount).toBeTypeOf('string');
+          expect(xudt.pending_amount).toBeTypeOf('string');
+          expect(xudt.type_hash).toBeTypeOf('string');
+        }
       });
       it('getRgbppSpvProof()', async () => {
         const res = await service.getRgbppSpvProof(rgbppBtcTxId, 6);


### PR DESCRIPTION
## Changes
- Add BtcAssetsApi.getRgbppApiBalanceByAddress() API for querying RGBPP XUDT balances by a BTC address (this PR introduces the `/rgbpp/v1/address/:address/balance` API, which is supported by [btc-assets-api#146](https://github.com/ckb-cell/btc-assets-api/pull/146), [btc-assets-api#155](https://github.com/ckb-cell/btc-assets-api/pull/155) and other related PRs)