### PR TITLE
feat(examples): support P2TR in examples/rgbpp

### DIFF
--- a/examples/rgbpp/.env.example
+++ b/examples/rgbpp/.env.example
@@ -20,6 +20,9 @@ CKB_INDEXER_URL=https://testnet.ckb.dev/indexer
 # Read more about P2WPKH in BIP141: https://github.com/bitcoin/bips/blob/master/bip-0141.mediawiki#p2wpkh
 BTC_PRIVATE_KEY=private-key
 
+# The BTC address type to use, available options: P2WPKH or P2TR
+BTC_ADDRESS_TYPE=P2WPKH
+
 # The BTC assets api url which should be matched with IS_MAINNET
 VITE_BTC_SERVICE_URL=https://btc-assets-api.testnet.mibao.pro
 

--- a/examples/rgbpp/README.md
+++ b/examples/rgbpp/README.md
@@ -45,15 +45,18 @@ CKB_INDEXER_URL=https://testnet.ckb.dev/indexer
 # Read more about P2WPKH in BIP141: https://github.com/bitcoin/bips/blob/master/bip-0141.mediawiki#p2wpkh
 BTC_PRIVATE_KEY=private-key
 
+# The BTC address type to use, available options: P2WPKH or P2TR
+BTC_ADDRESS_TYPE=P2WPKH
+
 # The BTC assets api url which should be matched with IS_MAINNET
-VITE_BTC_SERVICE_URL=https://btc-assets-api.testnet.mibao.pro;
+VITE_BTC_SERVICE_URL=https://btc-assets-api.testnet.mibao.pro
 
 # The BTC assets api token which should be matched with IS_MAINNET
 # To get an access token, please refer to https://github.com/ckb-cell/rgbpp-sdk/tree/develop/packages/service#get-an-access-token
-VITE_BTC_SERVICE_TOKEN=;
+VITE_BTC_SERVICE_TOKEN=
 
 # The BTC assets api origin which should be matched with IS_MAINNET
-VITE_BTC_SERVICE_ORIGIN=https://btc-test.app;
+VITE_BTC_SERVICE_ORIGIN=https://btc-test.app
 ```
 
 ## RGB++ xUDT Examples

--- a/examples/rgbpp/env.ts
+++ b/examples/rgbpp/env.ts
@@ -46,7 +46,7 @@ export const BTC_SERVICE_ORIGIN = process.env.VITE_BTC_SERVICE_ORIGIN!;
 // Read more about the available address types:
 // - P2WPKH: https://github.com/bitcoin/bips/blob/master/bip-0141.mediawiki#p2wpkh
 // - P2TR: https://github.com/bitcoin/bips/blob/master/bip-0341.mediawiki
-const addressType = process.env.BTC_ADDRESS_TYPE === 'P2TR' ? AddressType.P2WPKH : AddressType.P2TR;
+const addressType = process.env.BTC_ADDRESS_TYPE === 'P2TR' ? AddressType.P2TR : AddressType.P2WPKH;
 const networkType = isMainnet ? NetworkType.MAINNET : NetworkType.TESTNET;
 export const btcAccount = createBtcAccount(BTC_PRIVATE_KEY, addressType, networkType);
 

--- a/examples/rgbpp/env.ts
+++ b/examples/rgbpp/env.ts
@@ -1,3 +1,4 @@
+import dotenv from 'dotenv';
 import {
   blake160,
   bytesToHex,
@@ -5,14 +6,22 @@ import {
   scriptToAddress,
   systemScripts,
 } from '@nervosnetwork/ckb-sdk-utils';
-import { DataSource, BtcAssetsApi } from 'rgbpp';
-import { ECPair, ECPairInterface, bitcoin, NetworkType } from 'rgbpp/btc';
-import dotenv from 'dotenv';
+import { NetworkType, AddressType, DataSource } from 'rgbpp/btc';
+import { BtcAssetsApi } from 'rgbpp/service';
 import { Collector } from 'rgbpp/ckb';
+import { createBtcAccount } from './shared/btc-account';
 
 dotenv.config({ path: __dirname + '/.env' });
 
-export const isMainnet = process.env.IS_MAINNET === 'true' ? true : false;
+/**
+ * Network
+ */
+
+export const isMainnet = process.env.IS_MAINNET === 'true';
+
+/**
+ * CKB
+ */
 
 export const collector = new Collector({
   ckbNodeUrl: process.env.CKB_NODE_URL!,
@@ -25,20 +34,21 @@ const secp256k1Lock: CKBComponents.Script = {
 };
 export const ckbAddress = scriptToAddress(secp256k1Lock, isMainnet);
 
+/**
+ * BTC
+ */
+
 export const BTC_PRIVATE_KEY = process.env.BTC_PRIVATE_KEY!;
 export const BTC_SERVICE_URL = process.env.VITE_BTC_SERVICE_URL!;
 export const BTC_SERVICE_TOKEN = process.env.VITE_BTC_SERVICE_TOKEN!;
 export const BTC_SERVICE_ORIGIN = process.env.VITE_BTC_SERVICE_ORIGIN!;
 
-const network = isMainnet ? bitcoin.networks.bitcoin : bitcoin.networks.testnet;
-export const btcKeyPair: ECPairInterface = ECPair.fromPrivateKey(Buffer.from(BTC_PRIVATE_KEY, 'hex'), { network });
-// The Native Segwit P2WPKH address will be generated with the BTC private key
-// Read more about P2WPKH in BIP141: https://github.com/bitcoin/bips/blob/master/bip-0141.mediawiki#p2wpkh
-export const { address: btcAddress } = bitcoin.payments.p2wpkh({
-  pubkey: btcKeyPair.publicKey,
-  network,
-});
-
+// Read more about the available address types:
+// - P2WPKH: https://github.com/bitcoin/bips/blob/master/bip-0141.mediawiki#p2wpkh
+// - P2TR: https://github.com/bitcoin/bips/blob/master/bip-0341.mediawiki
+const addressType = process.env.BTC_ADDRESS_TYPE === 'P2TR' ? AddressType.P2WPKH : AddressType.P2TR;
 const networkType = isMainnet ? NetworkType.MAINNET : NetworkType.TESTNET;
+export const btcAccount = createBtcAccount(BTC_PRIVATE_KEY, addressType, networkType);
+
 export const btcService = BtcAssetsApi.fromToken(BTC_SERVICE_URL, BTC_SERVICE_TOKEN, BTC_SERVICE_ORIGIN);
 export const btcDataSource = new DataSource(btcService, networkType);

--- a/examples/rgbpp/shared/btc-account.ts
+++ b/examples/rgbpp/shared/btc-account.ts
@@ -1,0 +1,100 @@
+import {
+  addressToScriptPublicKeyHex,
+  networkTypeToNetwork,
+  remove0x,
+  toXOnly,
+  transactionToHex,
+  tweakSigner,
+} from 'rgbpp/btc';
+import { AddressType, NetworkType, bitcoin, ECPair } from 'rgbpp/btc';
+import { BtcAssetsApi } from 'rgbpp/service';
+
+export interface BtcAccount {
+  from: string;
+  fromPubkey?: string;
+  keyPair: bitcoin.Signer;
+  payment: bitcoin.Payment;
+  addressType: AddressType;
+  networkType: NetworkType;
+}
+
+export function createBtcAccount(privateKey: string, addressType: AddressType, networkType: NetworkType): BtcAccount {
+  const network = networkTypeToNetwork(networkType);
+
+  const key = Buffer.from(remove0x(privateKey), 'hex');
+  const keyPair = ECPair.fromPrivateKey(key, { network });
+
+  if (addressType === AddressType.P2WPKH) {
+    const p2wpkh = bitcoin.payments.p2wpkh({
+      pubkey: keyPair.publicKey,
+      network,
+    });
+    return {
+      from: p2wpkh.address!,
+      payment: p2wpkh,
+      keyPair,
+      addressType,
+      networkType,
+    };
+  } else if (addressType === AddressType.P2TR) {
+    const p2tr = bitcoin.payments.p2tr({
+      internalPubkey: toXOnly(keyPair.publicKey),
+      network,
+    });
+    return {
+      from: p2tr.address!,
+      fromPubkey: keyPair.publicKey.toString('hex'),
+      payment: p2tr,
+      keyPair,
+      addressType,
+      networkType,
+    };
+  } else {
+    throw new Error('Unsupported address type, only support P2WPKH and P2TR');
+  }
+}
+
+export function signPsbt(psbt: bitcoin.Psbt, account: BtcAccount): bitcoin.Psbt {
+  const accountScript = addressToScriptPublicKeyHex(account.from, account.networkType);
+  const tweakedSigner = tweakSigner(account.keyPair, {
+    network: account.payment.network,
+  });
+
+  psbt.data.inputs.forEach((input, index) => {
+    if (input.witnessUtxo) {
+      const script = input.witnessUtxo.script.toString('hex');
+      if (script === accountScript && account.addressType === AddressType.P2WPKH) {
+        psbt.signInput(index, account.keyPair);
+      }
+      if (script === accountScript && account.addressType === AddressType.P2TR) {
+        psbt.signInput(index, tweakedSigner);
+      }
+    }
+  });
+
+  return psbt;
+}
+
+export async function signAndSendPsbt(
+  psbt: bitcoin.Psbt,
+  account: BtcAccount,
+  service: BtcAssetsApi,
+): Promise<{
+  txId: string;
+  txHex: string;
+  txHexRaw: string;
+}> {
+  signPsbt(psbt, account);
+  psbt.finalizeAllInputs();
+
+  const tx = psbt.extractTransaction();
+  const txHex = tx.toHex();
+
+  const { txid } = await service.sendBtcTransaction(txHex);
+
+  return {
+    txHex,
+    txId: txid,
+    txHexRaw: transactionToHex(tx, false),
+  };
+}

--- a/examples/rgbpp/shared/btc-account.ts
+++ b/examples/rgbpp/shared/btc-account.ts
@@ -82,7 +82,7 @@ export async function signAndSendPsbt(
 ): Promise<{
   txId: string;
   txHex: string;
-  txHexRaw: string;
+  rawTxHex: string;
 }> {
   signPsbt(psbt, account);
   psbt.finalizeAllInputs();
@@ -95,6 +95,7 @@ export async function signAndSendPsbt(
   return {
     txHex,
     txId: txid,
-    txHexRaw: transactionToHex(tx, false),
+    // Exclude witness from the BTC_TX for unlocking RGBPP assets
+    rawTxHex: transactionToHex(tx, false),
   };
 }

--- a/examples/rgbpp/spore/4-transfer-spore.ts
+++ b/examples/rgbpp/spore/4-transfer-spore.ts
@@ -2,8 +2,9 @@ import { buildRgbppLockArgs } from 'rgbpp/ckb';
 import { genTransferSporeCkbVirtualTx, sendRgbppUtxos } from 'rgbpp';
 import { getSporeTypeScript, Hex } from 'rgbpp/ckb';
 import { serializeScript } from '@nervosnetwork/ckb-sdk-utils';
-import { isMainnet, collector, btcAddress, btcDataSource, btcKeyPair, btcService } from '../env';
+import { isMainnet, collector, btcDataSource, btcService, btcAccount } from '../env';
 import { saveCkbVirtualTxResult } from '../shared/utils';
+import { signAndSendPsbt } from '../shared/btc-account';
 
 interface SporeTransferParams {
   sporeRgbppLockArgs: Hex;
@@ -36,16 +37,13 @@ const transferSpore = async ({ sporeRgbppLockArgs, toBtcAddress, sporeTypeArgs }
     tos: [toBtcAddress],
     needPaymaster: needPaymasterCell,
     ckbCollector: collector,
-    from: btcAddress!,
+    from: btcAccount.from,
+    fromPubkey: btcAccount.fromPubkey,
     source: btcDataSource,
     feeRate: 30,
   });
-  psbt.signAllInputs(btcKeyPair);
-  psbt.finalizeAllInputs();
 
-  const btcTx = psbt.extractTransaction();
-  const { txid: btcTxId } = await btcService.sendBtcTransaction(btcTx.toHex());
-
+  const { txId: btcTxId } = await signAndSendPsbt(psbt, btcAccount, btcService);
   console.log('BTC TxId: ', btcTxId);
 
   await btcService.sendRgbppCkbTransaction({ btc_txid: btcTxId, ckb_virtual_result: ckbVirtualTxResult });

--- a/examples/rgbpp/spore/5-leap-spore-to-ckb.ts
+++ b/examples/rgbpp/spore/5-leap-spore-to-ckb.ts
@@ -2,8 +2,9 @@ import { buildRgbppLockArgs } from 'rgbpp/ckb';
 import { genLeapSporeFromBtcToCkbVirtualTx, sendRgbppUtxos } from 'rgbpp';
 import { getSporeTypeScript, Hex } from 'rgbpp/ckb';
 import { serializeScript } from '@nervosnetwork/ckb-sdk-utils';
-import { isMainnet, collector, btcAddress, btcDataSource, btcKeyPair, btcService } from '../env';
+import { isMainnet, collector, btcDataSource, btcService, btcAccount } from '../env';
 import { saveCkbVirtualTxResult } from '../shared/utils';
+import { signAndSendPsbt } from '../shared/btc-account';
 
 interface SporeLeapParams {
   sporeRgbppLockArgs: Hex;
@@ -34,19 +35,16 @@ const leapSporeFromBtcToCkb = async ({ sporeRgbppLockArgs, toCkbAddress, sporeTy
   const psbt = await sendRgbppUtxos({
     ckbVirtualTx: ckbRawTx,
     commitment,
-    tos: [btcAddress!],
+    tos: [btcAccount.from],
     needPaymaster: needPaymasterCell,
     ckbCollector: collector,
-    from: btcAddress!,
+    from: btcAccount.from,
+    fromPubkey: btcAccount.fromPubkey,
     source: btcDataSource,
     feeRate: 30,
   });
-  psbt.signAllInputs(btcKeyPair);
-  psbt.finalizeAllInputs();
 
-  const btcTx = psbt.extractTransaction();
-  const { txid: btcTxId } = await btcService.sendBtcTransaction(btcTx.toHex());
-
+  const { txId: btcTxId } = await signAndSendPsbt(psbt, btcAccount, btcService);
   console.log('BTC TxId: ', btcTxId);
 
   await btcService.sendRgbppCkbTransaction({ btc_txid: btcTxId, ckb_virtual_result: ckbVirtualTxResult });

--- a/examples/rgbpp/spore/launch/2-create-cluster.ts
+++ b/examples/rgbpp/spore/launch/2-create-cluster.ts
@@ -41,7 +41,7 @@ const createCluster = async ({ ownerRgbppLockArgs }: { ownerRgbppLockArgs: strin
     feeRate: 30,
   });
 
-  const { txId: btcTxId, txHexRaw: btcTxBytes } = await signAndSendPsbt(psbt, btcAccount, btcService);
+  const { txId: btcTxId, rawTxHex: btcTxBytes } = await signAndSendPsbt(psbt, btcAccount, btcService);
   console.log('BTC TxId: ', btcTxId);
 
   const interval = setInterval(async () => {

--- a/examples/rgbpp/spore/launch/3-create-spores.ts
+++ b/examples/rgbpp/spore/launch/3-create-spores.ts
@@ -52,7 +52,7 @@ const createSpores = async ({ clusterRgbppLockArgs, receivers }: SporeCreatePara
     feeRate: 120,
   });
 
-  const { txId: btcTxId, txHexRaw: btcTxBytes } = await signAndSendPsbt(psbt, btcAccount, btcService);
+  const { txId: btcTxId, rawTxHex: btcTxBytes } = await signAndSendPsbt(psbt, btcAccount, btcService);
   console.log('BTC TxId: ', btcTxId);
 
   const interval = setInterval(async () => {

--- a/examples/rgbpp/spore/local/4-transfer-spore.ts
+++ b/examples/rgbpp/spore/local/4-transfer-spore.ts
@@ -57,7 +57,7 @@ const transferSpore = async ({ sporeRgbppLockArgs, toBtcAddress, sporeTypeArgs }
     feeRate: 30,
   });
 
-  const { txId: btcTxId, txHexRaw: btcTxBytes } = await signAndSendPsbt(psbt, btcAccount, btcService);
+  const { txId: btcTxId, rawTxHex: btcTxBytes } = await signAndSendPsbt(psbt, btcAccount, btcService);
   console.log('BTC TxId: ', btcTxId);
 
   const interval = setInterval(async () => {

--- a/examples/rgbpp/spore/local/4-transfer-spore.ts
+++ b/examples/rgbpp/spore/local/4-transfer-spore.ts
@@ -8,11 +8,12 @@ import {
   generateSporeTransferCoBuild,
   genTransferSporeCkbVirtualTx,
 } from 'rgbpp/ckb';
-import { sendRgbppUtxos, transactionToHex } from 'rgbpp/btc';
+import { sendRgbppUtxos } from 'rgbpp/btc';
 import { BtcAssetsApiError } from 'rgbpp';
 import { serializeScript } from '@nervosnetwork/ckb-sdk-utils';
-import { isMainnet, collector, btcAddress, btcDataSource, btcKeyPair, btcService } from '../../env';
+import { isMainnet, collector, btcDataSource, btcService, btcAccount } from '../../env';
 import { saveCkbVirtualTxResult } from '../../shared/utils';
+import { signAndSendPsbt } from '../../shared/btc-account';
 
 interface SporeTransferParams {
   sporeRgbppLockArgs: Hex;
@@ -50,17 +51,13 @@ const transferSpore = async ({ sporeRgbppLockArgs, toBtcAddress, sporeTypeArgs }
     tos: [toBtcAddress],
     needPaymaster: needPaymasterCell,
     ckbCollector: collector,
-    from: btcAddress!,
+    from: btcAccount.from,
+    fromPubkey: btcAccount.fromPubkey,
     source: btcDataSource,
     feeRate: 30,
   });
-  psbt.signAllInputs(btcKeyPair);
-  psbt.finalizeAllInputs();
 
-  const btcTx = psbt.extractTransaction();
-  const btcTxBytes = transactionToHex(btcTx, false);
-  const { txid: btcTxId } = await btcService.sendBtcTransaction(btcTx.toHex());
-
+  const { txId: btcTxId, txHexRaw: btcTxBytes } = await signAndSendPsbt(psbt, btcAccount, btcService);
   console.log('BTC TxId: ', btcTxId);
 
   const interval = setInterval(async () => {

--- a/examples/rgbpp/spore/local/5-leap-spore-to-ckb.ts
+++ b/examples/rgbpp/spore/local/5-leap-spore-to-ckb.ts
@@ -57,7 +57,7 @@ const leapSpore = async ({ sporeRgbppLockArgs, toCkbAddress, sporeTypeArgs }: Sp
     feeRate: 120,
   });
 
-  const { txId: btcTxId, txHexRaw: btcTxBytes } = await signAndSendPsbt(psbt, btcAccount, btcService);
+  const { txId: btcTxId, rawTxHex: btcTxBytes } = await signAndSendPsbt(psbt, btcAccount, btcService);
   console.log('BTC TxId: ', btcTxId);
 
   const interval = setInterval(async () => {

--- a/examples/rgbpp/xudt/2-btc-transfer.ts
+++ b/examples/rgbpp/xudt/2-btc-transfer.ts
@@ -1,8 +1,9 @@
 import { buildRgbppLockArgs, getXudtTypeScript } from 'rgbpp/ckb';
 import { serializeScript } from '@nervosnetwork/ckb-sdk-utils';
 import { genBtcTransferCkbVirtualTx, sendRgbppUtxos } from 'rgbpp';
-import { isMainnet, collector, btcAddress, btcKeyPair, btcService, btcDataSource } from '../env';
+import { isMainnet, collector, btcService, btcDataSource, btcAccount } from '../env';
 import { saveCkbVirtualTxResult } from '../shared/utils';
+import { signAndSendPsbt } from '../shared/btc-account';
 
 interface RgbppTransferParams {
   rgbppLockArgsList: string[];
@@ -36,15 +37,12 @@ const transfer = async ({ rgbppLockArgsList, toBtcAddress, xudtTypeArgs, transfe
     commitment,
     tos: [toBtcAddress],
     ckbCollector: collector,
-    from: btcAddress!,
+    from: btcAccount.from,
+    fromPubkey: btcAccount.fromPubkey,
     source: btcDataSource,
   });
-  psbt.signAllInputs(btcKeyPair);
-  psbt.finalizeAllInputs();
 
-  const btcTx = psbt.extractTransaction();
-  const { txid: btcTxId } = await btcService.sendBtcTransaction(btcTx.toHex());
-
+  const { txId: btcTxId } = await signAndSendPsbt(psbt, btcAccount, btcService);
   console.log('BTC TxId: ', btcTxId);
 
   await btcService.sendRgbppCkbTransaction({ btc_txid: btcTxId, ckb_virtual_result: ckbVirtualTxResult });

--- a/examples/rgbpp/xudt/launch/2-launch-rgbpp.ts
+++ b/examples/rgbpp/xudt/launch/2-launch-rgbpp.ts
@@ -46,7 +46,7 @@ const launchRgppAsset = async ({ ownerRgbppLockArgs, launchAmount, rgbppTokenInf
     source: btcDataSource,
   });
 
-  const { txId: btcTxId, txHexRaw: btcTxBytes } = await signAndSendPsbt(psbt, btcAccount, btcService);
+  const { txId: btcTxId, rawTxHex: btcTxBytes } = await signAndSendPsbt(psbt, btcAccount, btcService);
   console.log('BTC TxId: ', btcTxId);
 
   const interval = setInterval(async () => {

--- a/examples/rgbpp/xudt/launch/3-distribute-rgbpp.ts
+++ b/examples/rgbpp/xudt/launch/3-distribute-rgbpp.ts
@@ -58,7 +58,7 @@ const distributeRgbppAssetOnBtc = async ({ rgbppLockArgsList, receivers, xudtTyp
     source: btcDataSource,
   });
 
-  const { txId: btcTxId, txHexRaw: btcTxBytes } = await signAndSendPsbt(psbt, btcAccount, btcService);
+  const { txId: btcTxId, rawTxHex: btcTxBytes } = await signAndSendPsbt(psbt, btcAccount, btcService);
   console.log('BTC TxId: ', btcTxId);
 
   const interval = setInterval(async () => {

--- a/examples/rgbpp/xudt/local/2-btc-transfer.ts
+++ b/examples/rgbpp/xudt/local/2-btc-transfer.ts
@@ -49,7 +49,7 @@ const transfer = async ({ rgbppLockArgsList, toBtcAddress, xudtTypeArgs, transfe
     source: btcDataSource,
   });
 
-  const { txId: btcTxId, txHexRaw: btcTxBytes } = await signAndSendPsbt(psbt, btcAccount, btcService);
+  const { txId: btcTxId, rawTxHex: btcTxBytes } = await signAndSendPsbt(psbt, btcAccount, btcService);
   console.log('BTC TxId: ', btcTxId);
 
   // Wait for BTC tx and proof to be ready, and then send isomorphic CKB transactions

--- a/examples/rgbpp/xudt/local/2-btc-transfer.ts
+++ b/examples/rgbpp/xudt/local/2-btc-transfer.ts
@@ -7,9 +7,9 @@ import {
   getXudtTypeScript,
   updateCkbTxWithRealBtcTxId,
 } from 'rgbpp/ckb';
-import { isMainnet, collector, btcAddress, btcDataSource, btcKeyPair, btcService } from '../../env';
-import { transactionToHex } from 'rgbpp/btc';
+import { isMainnet, collector, btcDataSource, btcService, btcAccount } from '../../env';
 import { saveCkbVirtualTxResult } from '../../shared/utils';
+import { signAndSendPsbt } from '../../shared/btc-account';
 
 interface RgbppTransferParams {
   rgbppLockArgsList: string[];
@@ -44,17 +44,12 @@ const transfer = async ({ rgbppLockArgsList, toBtcAddress, xudtTypeArgs, transfe
     commitment,
     tos: [toBtcAddress],
     ckbCollector: collector,
-    from: btcAddress!,
+    from: btcAccount.from,
+    fromPubkey: btcAccount.fromPubkey,
     source: btcDataSource,
   });
-  psbt.signAllInputs(btcKeyPair);
-  psbt.finalizeAllInputs();
 
-  const btcTx = psbt.extractTransaction();
-  // Remove the witness from BTC tx for RGBPP unlock
-  const btcTxBytes = transactionToHex(btcTx, false);
-  const { txid: btcTxId } = await btcService.sendBtcTransaction(btcTx.toHex());
-
+  const { txId: btcTxId, txHexRaw: btcTxBytes } = await signAndSendPsbt(psbt, btcAccount, btcService);
   console.log('BTC TxId: ', btcTxId);
 
   // Wait for BTC tx and proof to be ready, and then send isomorphic CKB transactions

--- a/examples/rgbpp/xudt/local/3-btc-leap-ckb.ts
+++ b/examples/rgbpp/xudt/local/3-btc-leap-ckb.ts
@@ -50,7 +50,7 @@ const leapFromBtcToCkb = async ({ rgbppLockArgsList, toCkbAddress, xudtTypeArgs,
     source: btcDataSource,
   });
 
-  const { txId: btcTxId, txHexRaw: btcTxBytes } = await signAndSendPsbt(psbt, btcAccount, btcService);
+  const { txId: btcTxId, rawTxHex: btcTxBytes } = await signAndSendPsbt(psbt, btcAccount, btcService);
   console.log('BTC Tx bytes: ', btcTxBytes);
   console.log('BTC TxId: ', btcTxId);
   console.log('ckbRawTx', JSON.stringify(ckbRawTx));

--- a/examples/rgbpp/xudt/local/3-btc-leap-ckb.ts
+++ b/examples/rgbpp/xudt/local/3-btc-leap-ckb.ts
@@ -7,9 +7,9 @@ import {
   getXudtTypeScript,
   updateCkbTxWithRealBtcTxId,
 } from 'rgbpp/ckb';
-import { isMainnet, collector, btcAddress, btcDataSource, btcKeyPair, btcService } from '../../env';
-import { transactionToHex } from 'rgbpp/btc';
+import { isMainnet, collector, btcDataSource, btcService, btcAccount } from '../../env';
 import { saveCkbVirtualTxResult } from '../../shared/utils';
+import { signAndSendPsbt } from '../../shared/btc-account';
 
 interface LeapToCkbParams {
   rgbppLockArgsList: string[];
@@ -43,19 +43,14 @@ const leapFromBtcToCkb = async ({ rgbppLockArgsList, toCkbAddress, xudtTypeArgs,
   const psbt = await sendRgbppUtxos({
     ckbVirtualTx: ckbRawTx,
     commitment,
-    tos: [btcAddress!],
+    tos: [btcAccount.from],
     ckbCollector: collector,
-    from: btcAddress!,
+    from: btcAccount.from,
+    fromPubkey: btcAccount.fromPubkey,
     source: btcDataSource,
   });
-  psbt.signAllInputs(btcKeyPair);
-  psbt.finalizeAllInputs();
 
-  const btcTx = psbt.extractTransaction();
-  // Remove the witness from BTC tx for RGBPP unlock
-  const btcTxBytes = transactionToHex(btcTx, false);
-  const { txid: btcTxId } = await btcService.sendBtcTransaction(btcTx.toHex());
-
+  const { txId: btcTxId, txHexRaw: btcTxBytes } = await signAndSendPsbt(psbt, btcAccount, btcService);
   console.log('BTC Tx bytes: ', btcTxBytes);
   console.log('BTC TxId: ', btcTxId);
   console.log('ckbRawTx', JSON.stringify(ckbRawTx));


### PR DESCRIPTION
## Changes
- Add `BtcAccount` in the examplex/rgbpp to support both P2WPKH and P2TR
  - Fill `BtcAccount.from` and `BtcAccount.fromPubkey` when constructing transactions
  - Remove `btcAddress` and `btcKeyPair` relevant usage in the examples
  - Sign PSBT with BtcAccount via the `signPsbt()` API

## Related issues
- Resovles #207

## Test
- [ ] @Dawn-githup 