### PR TITLE
fix(examples): Update inputs capacity for the xUDT transfer example

### DIFF
--- a/examples/xudt-on-ckb/2-transfer-xudt.ts
+++ b/examples/xudt-on-ckb/2-transfer-xudt.ts
@@ -42,6 +42,10 @@ const transferXudt = async ({ xudtType, receivers }: XudtTransferParams) => {
     .map((receiver) => receiver.transferAmount)
     .reduce((prev, current) => prev + current, BigInt(0));
 
+  let sumXudtOutputCapacity = receivers
+    .map(({ toAddress }) => calculateUdtCellCapacity(addressToScript(toAddress)))
+    .reduce((prev, current) => prev + current, BigInt(0));
+
   const {
     inputs: udtInputs,
     sumInputsCapacity: sumXudtInputsCapacity,
@@ -53,28 +57,26 @@ const transferXudt = async ({ xudtType, receivers }: XudtTransferParams) => {
   let actualInputsCapacity = sumXudtInputsCapacity;
   let inputs = udtInputs;
 
-  const xudtCapacity = calculateUdtCellCapacity(fromLock);
-  let sumXudtoutputCapacity = xudtCapacity * BigInt(receivers.length);
-
-  const outputs: CKBComponents.CellOutput[] = receivers.map((receiver) => ({
-    lock: addressToScript(receiver.toAddress),
+  const outputs: CKBComponents.CellOutput[] = receivers.map(({ toAddress }) => ({
+    lock: addressToScript(toAddress),
     type: xudtType,
-    capacity: append0x(xudtCapacity.toString(16)),
+    capacity: append0x(calculateUdtCellCapacity(addressToScript(toAddress)).toString(16)),
   }));
-  const outputsData = receivers.map((receiver) => append0x(u128ToLe(receiver.transferAmount)));
+  const outputsData = receivers.map(({ transferAmount }) => append0x(u128ToLe(transferAmount)));
 
   if (sumAmount > sumTransferAmount) {
+    const xudtChangeCapacity = calculateUdtCellCapacity(fromLock);
     outputs.push({
       lock: fromLock,
       type: xudtType,
-      capacity: append0x(xudtCapacity.toString(16)),
+      capacity: append0x(xudtChangeCapacity.toString(16)),
     });
     outputsData.push(append0x(u128ToLe(sumAmount - sumTransferAmount)));
-    sumXudtoutputCapacity += xudtCapacity;
+    sumXudtOutputCapacity += xudtChangeCapacity;
   }
 
   const txFee = MAX_FEE;
-  if (sumXudtInputsCapacity <= sumXudtoutputCapacity) {
+  if (sumXudtInputsCapacity <= sumXudtOutputCapacity) {
     let emptyCells = await collector.getCells({
       lock: fromLock,
     });
@@ -82,7 +84,7 @@ const transferXudt = async ({ xudtType, receivers }: XudtTransferParams) => {
       throw new NoLiveCellError('The address has no empty cells');
     }
     emptyCells = emptyCells.filter((cell) => !cell.output.type);
-    const needCapacity = sumXudtoutputCapacity - sumXudtInputsCapacity;
+    const needCapacity = sumXudtOutputCapacity - sumXudtInputsCapacity;
     const { inputs: emptyInputs, sumInputsCapacity: sumEmptyCapacity } = collector.collectInputs(
       emptyCells,
       needCapacity,
@@ -93,7 +95,7 @@ const transferXudt = async ({ xudtType, receivers }: XudtTransferParams) => {
     actualInputsCapacity += sumEmptyCapacity;
   }
 
-  let changeCapacity = actualInputsCapacity - sumXudtoutputCapacity;
+  let changeCapacity = actualInputsCapacity - sumXudtOutputCapacity;
   outputs.push({
     lock: fromLock,
     capacity: append0x(changeCapacity.toString(16)),
@@ -143,7 +145,7 @@ transferXudt({
   },
   receivers: [
     {
-      toAddress: 'ckt1qyqpyw8j7tlu3v44am8d54066zrzk4vz5lvqat8fpf',
+      toAddress: 'ckt1qrfrwcdnvssswdwpn3s9v8fp87emat306ctjwsm3nmlkjg8qyza2cqgqq92pncevj8c3nwz7f3mlx2fwqn6l44y73yr5swl5',
       transferAmount: BigInt(1000) * BigInt(10 ** XUDT_TOKEN_INFO.decimal),
     },
     {


### PR DESCRIPTION
## Changes

- Fix the inputs capacity collecting error which causes the outputs capacity is larger than the inputs capacity
- Calculate the capacity for each output by using `calculateUdtCellCapacity` function instead of a fixed value to make sure the output capacity is correct