### PR TITLE
feat(ckb|examples): Support BTC Signet and update examples

### DIFF
--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -7,6 +7,7 @@ on:
   push:
     branches:
       - develop
+      - feat/btc-signet
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -7,7 +7,6 @@ on:
   push:
     branches:
       - develop
-      - feat/btc-signet
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 

--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,5 @@ devbox.json
 devbox.lock
 .envrc
 
+# examples logs
+examples/rgbpp/logs

--- a/apps/service/.env.example
+++ b/apps/service/.env.example
@@ -1,20 +1,20 @@
 # testnet for CKB and BTC Testnet and mainnet for CKB and BTC Mainnet, the default value is testnet
 NETWORK=testnet
 
+# The Bitcoin Testnet type including Testnet3 and Signet, default value is Testnet3
+# Testnet3: https://mempool.space/testnet
+# Signet: https://mempool.space/signet
+BTC_TESTNET_TYPE=Testnet3
+
 # CKB node url which should be matched with NETWORK
 CKB_RPC_URL=https://testnet.ckb.dev
 
 # The BTC assets api url which should be matched with NETWORK
 BTC_SERVICE_URL=https://btc-assets-api.testnet.mibao.pro
 
-# The BTC assets api token which should be matched with IS_MAINNET
+# The BTC assets api token which should be matched with NETWORK and BTC_TESTNET_TYPE
 # To get an access token, please refer to https://github.com/ckb-cell/rgbpp-sdk/tree/develop/packages/service#get-an-access-token
 BTC_SERVICE_TOKEN=
 
-# The BTC assets api origin which should be matched with IS_MAINNET
+# The BTC assets api origin which should be matched with NETWORK and BTC_TESTNET_TYPE
 BTC_SERVICE_ORIGIN=https://btc-assets-api.testnet.mibao.pro
-
-# The Bitcoin Testnet type including Testnet3 and Signet, default value is Testnet3
-# Testnet3: https://mempool.space/testnet
-# Signet: https://mempool.space/signet
-BTC_TESTNET_TYPE=Testnet3

--- a/apps/service/.env.example
+++ b/apps/service/.env.example
@@ -13,3 +13,8 @@ BTC_SERVICE_TOKEN=
 
 # The BTC assets api origin which should be matched with IS_MAINNET
 BTC_SERVICE_ORIGIN=https://btc-assets-api.testnet.mibao.pro
+
+# The Bitcoin Testnet type including Testnet3 and Signet, default value is Testnet3
+# Testnet3: https://mempool.space/testnet
+# Signet: https://mempool.space/signet
+BTC_TESTNET_TYPE=Testnet3

--- a/apps/service/README.md
+++ b/apps/service/README.md
@@ -38,6 +38,11 @@ BTC_SERVICE_TOKEN=
 
 # The BTC assets api origin which should be matched with IS_MAINNET
 BTC_SERVICE_ORIGIN=https://btc-assets-api.testnet.mibao.pro
+
+# The Bitcoin Testnet type including Testnet3 and Signet, default value is Testnet3
+# Testnet3: https://mempool.space/testnet
+# Signet: https://mempool.space/signet
+BTC_TESTNET_TYPE=Testnet3
 ```
 
 ### Run RGB++ SDK Service

--- a/apps/service/README.md
+++ b/apps/service/README.md
@@ -26,23 +26,23 @@ Update the configuration values:
 # testnet for CKB and BTC Testnet and mainnet for CKB and BTC Mainnet, the default value is testnet
 NETWORK=testnet
 
+# The Bitcoin Testnet type including Testnet3 and Signet, default value is Testnet3
+# Testnet3: https://mempool.space/testnet
+# Signet: https://mempool.space/signet
+BTC_TESTNET_TYPE=Testnet3
+
 # CKB node url which should be matched with NETWORK
 CKB_RPC_URL=https://testnet.ckb.dev
 
 # The BTC assets api url which should be matched with NETWORK
 BTC_SERVICE_URL=https://btc-assets-api.testnet.mibao.pro
 
-# The BTC assets api token which should be matched with IS_MAINNET
+# The BTC assets api token which should be matched with NETWORK and BTC_TESTNET_TYPE
 # To get an access token, please refer to https://github.com/ckb-cell/rgbpp-sdk/tree/develop/packages/service#get-an-access-token
 BTC_SERVICE_TOKEN=
 
-# The BTC assets api origin which should be matched with IS_MAINNET
+# The BTC assets api origin which should be matched with NETWORK and BTC_TESTNET_TYPE
 BTC_SERVICE_ORIGIN=https://btc-assets-api.testnet.mibao.pro
-
-# The Bitcoin Testnet type including Testnet3 and Signet, default value is Testnet3
-# Testnet3: https://mempool.space/testnet
-# Signet: https://mempool.space/signet
-BTC_TESTNET_TYPE=Testnet3
 ```
 
 ### Run RGB++ SDK Service

--- a/apps/service/src/app.module.ts
+++ b/apps/service/src/app.module.ts
@@ -4,7 +4,7 @@ import JsonRpcModule from './json-rpc/json-rpc.module';
 import { RgbppModule } from './rgbpp/rgbpp.module';
 import { AppService } from './app.service';
 import { envSchema } from './env';
-import { Collector } from 'rgbpp/ckb';
+import { BTCTestnetType, Collector } from 'rgbpp/ckb';
 import { BtcAssetsApi } from 'rgbpp';
 
 @Global()
@@ -23,6 +23,11 @@ import { BtcAssetsApi } from 'rgbpp';
     {
       provide: 'IS_MAINNET',
       useFactory: (configService: ConfigService): boolean => configService.get('NETWORK') === 'mainnet',
+      inject: [ConfigService],
+    },
+    {
+      provide: 'BTC_TESTNET_TYPE',
+      useFactory: (configService: ConfigService): BTCTestnetType => configService.get('BTC_TESTNET_TYPE'),
       inject: [ConfigService],
     },
     {
@@ -47,6 +52,6 @@ import { BtcAssetsApi } from 'rgbpp';
       inject: [ConfigService],
     },
   ],
-  exports: ['IS_MAINNET', 'COLLECTOR', 'BTC_ASSETS_API'],
+  exports: ['IS_MAINNET', 'COLLECTOR', 'BTC_ASSETS_API', 'BTC_TESTNET_TYPE'],
 })
 export class AppModule {}

--- a/apps/service/src/env.ts
+++ b/apps/service/src/env.ts
@@ -7,4 +7,5 @@ export const envSchema = z.object({
   BTC_SERVICE_URL: z.string(),
   BTC_SERVICE_TOKEN: z.string(),
   BTC_SERVICE_ORIGIN: z.string(),
+  BTC_TESTNET_TYPE: z.string().default('Testnet3'),
 });

--- a/apps/service/src/rgbpp/rgbpp.service.ts
+++ b/apps/service/src/rgbpp/rgbpp.service.ts
@@ -1,7 +1,7 @@
 import { Inject } from '@nestjs/common';
 import { RpcHandler, RpcMethodHandler } from 'src/json-rpc/json-rpc.decorators';
 import { DataSource, NetworkType } from 'rgbpp/btc';
-import { Collector, Hex, toCamelcase } from 'rgbpp/ckb';
+import { BTCTestnetType, Collector, Hex, toCamelcase } from 'rgbpp/ckb';
 import { RgbppTransferReq, RgbppCkbBtcTransaction, RgbppCkbTxBtcTxId, RgbppStateReq, RgbppCkbTxHashReq } from './types';
 import { toSnakeCase } from 'src/utils/snake';
 import { buildRgbppTransferTx } from 'rgbpp';
@@ -11,6 +11,7 @@ import { BtcAssetsApi } from 'rgbpp/service';
 export class RgbppService {
   constructor(
     @Inject('IS_MAINNET') private isMainnet: boolean,
+    @Inject('BTC_TESTNET_TYPE') private btcTestnetType: BTCTestnetType,
     @Inject('COLLECTOR') private collector: Collector,
     @Inject('BTC_ASSETS_API') private btcAssetsApi: BtcAssetsApi,
   ) {}
@@ -32,6 +33,7 @@ export class RgbppService {
         fromAddress: fromBtcAddress,
         toAddress: toBtcAddress,
         dataSource: btcDataSource,
+        testnetType: this.btcTestnetType,
       },
       isMainnet: this.isMainnet,
     });

--- a/examples/rgbpp/.env.example
+++ b/examples/rgbpp/.env.example
@@ -15,6 +15,11 @@ CKB_INDEXER_URL=https://testnet.ckb.dev/indexer
 
 # BTC Variables
 
+# The Bitcoin Testnet type including Testnet3 and Signet, default value is Testnet3
+# Testnet3: https://mempool.space/testnet
+# Signet: https://mempool.space/signet
+BTC_TESTNET_TYPE=Testnet3
+
 # The BTC private key whose format is 32bytes hex string without 0x prefix
 BTC_PRIVATE_KEY=private-key
 
@@ -23,17 +28,13 @@ BTC_PRIVATE_KEY=private-key
 # Read more about P2WPKH in BIP141: https://github.com/bitcoin/bips/blob/master/bip-0141.mediawiki#p2wpkh
 BTC_ADDRESS_TYPE=P2WPKH
 
-# The BTC assets api url which should be matched with IS_MAINNET
+# The BTC assets api url which should be matched with IS_MAINNET and BTC_TESTNET_TYPE
 VITE_BTC_SERVICE_URL=https://btc-assets-api.testnet.mibao.pro
 
-# The BTC assets api token which should be matched with IS_MAINNET
+# The BTC assets api token which should be matched with IS_MAINNET and BTC_TESTNET_TYPE
 # To get an access token, please refer to https://github.com/ckb-cell/rgbpp-sdk/tree/develop/packages/service#get-an-access-token
 VITE_BTC_SERVICE_TOKEN=
 
-# The BTC assets api origin which should be matched with IS_MAINNET
+# The BTC assets api origin which should be matched with IS_MAINNET and BTC_TESTNET_TYPE
 VITE_BTC_SERVICE_ORIGIN=https://btc-test.app
 
-# The Bitcoin Testnet type including Testnet3 and Signet, default value is Testnet3
-# Testnet3: https://mempool.space/testnet
-# Signet: https://mempool.space/signet
-VITE_BTC_TESTNET_TYPE=Testnet3

--- a/examples/rgbpp/.env.example
+++ b/examples/rgbpp/.env.example
@@ -16,11 +16,11 @@ CKB_INDEXER_URL=https://testnet.ckb.dev/indexer
 # BTC Variables
 
 # The BTC private key whose format is 32bytes hex string without 0x prefix
-# The Native Segwit P2WPKH address will be generated with the BTC private key
-# Read more about P2WPKH in BIP141: https://github.com/bitcoin/bips/blob/master/bip-0141.mediawiki#p2wpkh
 BTC_PRIVATE_KEY=private-key
 
 # The BTC address type to use, available options: P2WPKH or P2TR
+# The Native Segwit P2WPKH address will be generated with the BTC private key as default
+# Read more about P2WPKH in BIP141: https://github.com/bitcoin/bips/blob/master/bip-0141.mediawiki#p2wpkh
 BTC_ADDRESS_TYPE=P2WPKH
 
 # The BTC assets api url which should be matched with IS_MAINNET

--- a/examples/rgbpp/.env.example
+++ b/examples/rgbpp/.env.example
@@ -32,3 +32,8 @@ VITE_BTC_SERVICE_TOKEN=
 
 # The BTC assets api origin which should be matched with IS_MAINNET
 VITE_BTC_SERVICE_ORIGIN=https://btc-test.app
+
+# The Bitcoin Testnet type including Testnet3 and Signet, default value is Testnet3
+# Testnet3: https://mempool.space/testnet
+# Signet: https://mempool.space/signet
+VITE_BTC_TESTNET_TYPE=Testnet3

--- a/examples/rgbpp/README.md
+++ b/examples/rgbpp/README.md
@@ -4,7 +4,9 @@
 - Spore directory: The examples for RGB++ Spore creation, transfer and leap
 
 > [!TIP]
-> All the parameters of the examples should be repalced with your own, including BTC private key, CKB private key, BTC Service origin, BTC Service token, BTC UTXO, xUDT type args, Spore type args, etc. Please confirm whether the parameters are correct according to the code comments
+> All the parameters of the examples should be repalced with your own, including BTC private key, CKB private key, BTC Service origin, BTC Service token, BTC UTXO, xUDT type args, Spore type args, etc. 
+
+> Please confirm whether the parameters are correct according to the code comments
 
 ## How to Start
 
@@ -41,11 +43,11 @@ CKB_INDEXER_URL=https://testnet.ckb.dev/indexer
 # BTC Variables
 
 # The BTC private key whose format is 32bytes hex string without 0x prefix
-# The Native Segwit P2WPKH address will be generated with the BTC private key
-# Read more about P2WPKH in BIP141: https://github.com/bitcoin/bips/blob/master/bip-0141.mediawiki#p2wpkh
 BTC_PRIVATE_KEY=private-key
 
 # The BTC address type to use, available options: P2WPKH or P2TR
+# The Native Segwit P2WPKH address will be generated with the BTC private key as default
+# Read more about P2WPKH in BIP141: https://github.com/bitcoin/bips/blob/master/bip-0141.mediawiki#p2wpkh
 BTC_ADDRESS_TYPE=P2WPKH
 
 # The BTC assets api url which should be matched with IS_MAINNET
@@ -57,6 +59,11 @@ VITE_BTC_SERVICE_TOKEN=
 
 # The BTC assets api origin which should be matched with IS_MAINNET
 VITE_BTC_SERVICE_ORIGIN=https://btc-test.app
+
+# The Bitcoin Testnet type including Testnet3 and Signet, default value is Testnet3
+# Testnet3: https://mempool.space/testnet
+# Signet: https://mempool.space/signet
+VITE_BTC_TESTNET_TYPE=Testnet3
 ```
 
 ## RGB++ xUDT Examples
@@ -66,7 +73,7 @@ VITE_BTC_SERVICE_ORIGIN=https://btc-test.app
 #### 1. Prepare Launch
 
 > [!TIP]
-> Please make sure the CKB private key in the .env is correct
+> Please make sure the CKB private key in the .env is correct.
 
 ```shell
 # Create a CKB empty rgbpp lock cell to launch RGB++ xUDT assets later
@@ -75,7 +82,7 @@ npx ts-node xudt/launch/1-prepare-launch.ts
 #### 2. Launch RGB++ xUDT on BTC
 
 > [!TIP]
-> Please make sure the `1-prepare-launch.ts` has been run and the corresponding CKB transaction has been committed
+> Please make sure the `1-prepare-launch.ts` has been run and the corresponding CKB transaction has been committed.
 
 ```shell
 npx ts-node xudt/launch/2-launch-rgbpp.ts
@@ -86,8 +93,8 @@ When the command is executed successfully, the **RGB++ Asset type script args** 
 #### 3. Distribute RGB++ xUDT on BTC
 
 > [!TIP]
-> Please make sure the `2-launch-rgbpp.ts` has been run and the corresponding BTC and CKB transactions have been committed
-> The **RGB++ Asset type script args** in the above should be set to the `xudtTypeArgs`
+> Please make sure the `2-launch-rgbpp.ts` has been run and the corresponding BTC and CKB transactions have been committed.
+> The **RGB++ Asset type script args** in the above should be set to the `xudtTypeArgs`.
 
 ```shell
 npx ts-node xudt/launch/3-distribute-rgbpp.ts
@@ -132,8 +139,8 @@ npx ts-node xudt/4-unlock-btc-time.ts
 #### 1. Create RGB++ Cluster Cell
 
 > [!TIP]
-> Please make sure all the variables in the .env are correct
-> The BTC UTXO of `1-prepare-cluster.ts` and `2-create-cluster.ts` should be same
+> Please make sure all the variables in the .env are correct.
+> The BTC UTXO of `1-prepare-cluster.ts` and `2-create-cluster.ts` should be same.
 
 ```shell
 # Create a CKB empty rgbpp lock cell to create cluster later
@@ -148,8 +155,8 @@ When the commands are executed successfully, the **clusterId** and **cluster rgb
 #### 2. Create RGB++ Spores with Cluster on BTC
 
 > [!TIP]
-> Please make sure the `2-create-cluster.ts` has been run and the corresponding BTC and CKB transactions have been committed
-> The **clusterId** in the above should be set to the `clusterId` and the **cluster rgbpp lock args** should be set to the `clusterRgbppLockArgs`
+> Please make sure the `2-create-cluster.ts` has been run and the corresponding BTC and CKB transactions have been committed.
+> The **clusterId** in the above should be set to the `clusterId` and the **cluster rgbpp lock args** should be set to the `clusterRgbppLockArgs`.
 
 ```shell
 npx ts-node spore/launch/3-create-spores.ts

--- a/examples/rgbpp/README.md
+++ b/examples/rgbpp/README.md
@@ -42,6 +42,11 @@ CKB_INDEXER_URL=https://testnet.ckb.dev/indexer
 
 # BTC Variables
 
+# The Bitcoin Testnet type including Testnet3 and Signet, default value is Testnet3
+# Testnet3: https://mempool.space/testnet
+# Signet: https://mempool.space/signet
+BTC_TESTNET_TYPE=Testnet3
+
 # The BTC private key whose format is 32bytes hex string without 0x prefix
 BTC_PRIVATE_KEY=private-key
 
@@ -59,11 +64,6 @@ VITE_BTC_SERVICE_TOKEN=
 
 # The BTC assets api origin which should be matched with IS_MAINNET
 VITE_BTC_SERVICE_ORIGIN=https://btc-test.app
-
-# The Bitcoin Testnet type including Testnet3 and Signet, default value is Testnet3
-# Testnet3: https://mempool.space/testnet
-# Signet: https://mempool.space/signet
-VITE_BTC_TESTNET_TYPE=Testnet3
 ```
 
 ## RGB++ xUDT Examples

--- a/examples/rgbpp/env.ts
+++ b/examples/rgbpp/env.ts
@@ -39,10 +39,10 @@ export const ckbAddress = scriptToAddress(secp256k1Lock, isMainnet);
  */
 
 export const BTC_PRIVATE_KEY = process.env.BTC_PRIVATE_KEY!;
+export const BTC_TESTNET_TYPE = process.env.BTC_TESTNET_TYPE! as BTCTestnetType;
 export const BTC_SERVICE_URL = process.env.VITE_BTC_SERVICE_URL!;
 export const BTC_SERVICE_TOKEN = process.env.VITE_BTC_SERVICE_TOKEN!;
 export const BTC_SERVICE_ORIGIN = process.env.VITE_BTC_SERVICE_ORIGIN!;
-export const BTC_TESTNET_TYPE = process.env.VITE_BTC_TESTNET_TYPE! as BTCTestnetType;
 
 // Read more about the available address types:
 // - P2WPKH: https://github.com/bitcoin/bips/blob/master/bip-0141.mediawiki#p2wpkh

--- a/examples/rgbpp/env.ts
+++ b/examples/rgbpp/env.ts
@@ -8,7 +8,7 @@ import {
 } from '@nervosnetwork/ckb-sdk-utils';
 import { NetworkType, AddressType, DataSource } from 'rgbpp/btc';
 import { BtcAssetsApi } from 'rgbpp/service';
-import { Collector } from 'rgbpp/ckb';
+import { BTCTestnetType, Collector } from 'rgbpp/ckb';
 import { createBtcAccount } from './shared/btc-account';
 
 dotenv.config({ path: __dirname + '/.env' });
@@ -42,6 +42,7 @@ export const BTC_PRIVATE_KEY = process.env.BTC_PRIVATE_KEY!;
 export const BTC_SERVICE_URL = process.env.VITE_BTC_SERVICE_URL!;
 export const BTC_SERVICE_TOKEN = process.env.VITE_BTC_SERVICE_TOKEN!;
 export const BTC_SERVICE_ORIGIN = process.env.VITE_BTC_SERVICE_ORIGIN!;
+export const BTC_TESTNET_TYPE = process.env.VITE_BTC_TESTNET_TYPE! as BTCTestnetType;
 
 // Read more about the available address types:
 // - P2WPKH: https://github.com/bitcoin/bips/blob/master/bip-0141.mediawiki#p2wpkh

--- a/examples/rgbpp/package.json
+++ b/examples/rgbpp/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "@nervosnetwork/ckb-sdk-utils": "^0.109.1",
-    "rgbpp": "^0.3.0"
+    "rgbpp": "workspace:*"
   },
   "devDependencies": {
     "@types/node": "^20.11.28",

--- a/examples/rgbpp/spore/4-transfer-spore.ts
+++ b/examples/rgbpp/spore/4-transfer-spore.ts
@@ -2,7 +2,7 @@ import { buildRgbppLockArgs } from 'rgbpp/ckb';
 import { genTransferSporeCkbVirtualTx, sendRgbppUtxos } from 'rgbpp';
 import { getSporeTypeScript, Hex } from 'rgbpp/ckb';
 import { serializeScript } from '@nervosnetwork/ckb-sdk-utils';
-import { isMainnet, collector, btcDataSource, btcService, btcAccount } from '../env';
+import { isMainnet, collector, btcDataSource, btcService, btcAccount, BTC_TESTNET_TYPE } from '../env';
 import { saveCkbVirtualTxResult } from '../shared/utils';
 import { signAndSendPsbt } from '../shared/btc-account';
 
@@ -23,6 +23,7 @@ const transferSpore = async ({ sporeRgbppLockArgs, toBtcAddress, sporeTypeArgs }
     sporeRgbppLockArgs,
     sporeTypeBytes,
     isMainnet,
+    btcTestnetType: BTC_TESTNET_TYPE,
   });
 
   // Save ckbVirtualTxResult
@@ -68,6 +69,9 @@ const transferSpore = async ({ sporeRgbppLockArgs, toBtcAddress, sporeTypeArgs }
 };
 
 // Please use your real BTC UTXO information on the BTC Testnet
+// BTC Testnet3: https://mempool.space/testnet
+// BTC Signet: https://mempool.space/signet
+
 // rgbppLockArgs: outIndexU32 + btcTxId
 transferSpore({
   sporeRgbppLockArgs: buildRgbppLockArgs(2, 'd5868dbde4be5e49876b496449df10150c356843afb6f94b08f8d81f394bb350'),

--- a/examples/rgbpp/spore/5-leap-spore-to-ckb.ts
+++ b/examples/rgbpp/spore/5-leap-spore-to-ckb.ts
@@ -2,7 +2,7 @@ import { buildRgbppLockArgs } from 'rgbpp/ckb';
 import { genLeapSporeFromBtcToCkbVirtualTx, sendRgbppUtxos } from 'rgbpp';
 import { getSporeTypeScript, Hex } from 'rgbpp/ckb';
 import { serializeScript } from '@nervosnetwork/ckb-sdk-utils';
-import { isMainnet, collector, btcDataSource, btcService, btcAccount } from '../env';
+import { isMainnet, collector, btcDataSource, btcService, btcAccount, BTC_TESTNET_TYPE } from '../env';
 import { saveCkbVirtualTxResult } from '../shared/utils';
 import { signAndSendPsbt } from '../shared/btc-account';
 
@@ -24,6 +24,7 @@ const leapSporeFromBtcToCkb = async ({ sporeRgbppLockArgs, toCkbAddress, sporeTy
     sporeTypeBytes,
     toCkbAddress,
     isMainnet,
+    btcTestnetType: BTC_TESTNET_TYPE,
   });
 
   // Save ckbVirtualTxResult
@@ -69,6 +70,9 @@ const leapSporeFromBtcToCkb = async ({ sporeRgbppLockArgs, toCkbAddress, sporeTy
 };
 
 // Please use your real BTC UTXO information on the BTC Testnet
+// BTC Testnet3: https://mempool.space/testnet
+// BTC Signet: https://mempool.space/signet
+
 // rgbppLockArgs: outIndexU32 + btcTxId
 leapSporeFromBtcToCkb({
   sporeRgbppLockArgs: buildRgbppLockArgs(3, 'd8a31796fbd42c546f6b22014b9b82b16586ce1df81b0e7ca9a552cdc492a0af'),

--- a/examples/rgbpp/spore/6-unlock-btc-time-cell.ts
+++ b/examples/rgbpp/spore/6-unlock-btc-time-cell.ts
@@ -1,12 +1,12 @@
 import { buildSporeBtcTimeCellsSpentTx, signBtcTimeCellSpentTx } from 'rgbpp';
-import { CKB_PRIVATE_KEY, btcService, ckbAddress, collector, isMainnet } from '../env';
+import { BTC_TESTNET_TYPE, CKB_PRIVATE_KEY, btcService, ckbAddress, collector, isMainnet } from '../env';
 import { sendCkbTx, getBtcTimeLockScript } from 'rgbpp/ckb';
 
 // Warning: Wait at least 6 BTC confirmation blocks to spend the BTC time cells after 5-leap-spore-to-ckb.ts
 const unlockSporeBtcTimeCell = async ({ btcTimeCellArgs }: { btcTimeCellArgs: string }) => {
   const btcTimeCells = await collector.getCells({
     lock: {
-      ...getBtcTimeLockScript(false),
+      ...getBtcTimeLockScript(isMainnet, BTC_TESTNET_TYPE),
       args: btcTimeCellArgs,
     },
     isDataMustBeEmpty: false,
@@ -20,6 +20,7 @@ const unlockSporeBtcTimeCell = async ({ btcTimeCellArgs }: { btcTimeCellArgs: st
     btcTimeCells,
     btcAssetsApi: btcService,
     isMainnet,
+    btcTestnetType: BTC_TESTNET_TYPE,
   });
 
   const signedTx = await signBtcTimeCellSpentTx({

--- a/examples/rgbpp/spore/7-leap-spore-to-btc.ts
+++ b/examples/rgbpp/spore/7-leap-spore-to-btc.ts
@@ -1,6 +1,6 @@
 import { serializeScript } from '@nervosnetwork/ckb-sdk-utils';
 import { genLeapSporeFromCkbToBtcRawTx } from 'rgbpp';
-import { isMainnet, collector, ckbAddress, CKB_PRIVATE_KEY } from '../env';
+import { isMainnet, collector, ckbAddress, CKB_PRIVATE_KEY, BTC_TESTNET_TYPE } from '../env';
 import { buildRgbppLockArgs, getSecp256k1CellDep, getSporeTypeScript } from 'rgbpp/ckb';
 
 const leapSporeFromCkbToBtc = async ({
@@ -25,6 +25,7 @@ const leapSporeFromCkbToBtc = async ({
     toRgbppLockArgs,
     sporeTypeBytes: serializeScript(sporeType),
     isMainnet,
+    btcTestnetType: BTC_TESTNET_TYPE,
   });
 
   const emptyWitness = { lock: '', inputType: '', outputType: '' };
@@ -41,6 +42,8 @@ const leapSporeFromCkbToBtc = async ({
 };
 
 // Please use your real BTC UTXO information on the BTC Testnet
+// BTC Testnet3: https://mempool.space/testnet
+// BTC Signet: https://mempool.space/signet
 leapSporeFromCkbToBtc({
   outIndex: 1,
   btcTxId: '448897515cf07b4ca0cd38af9806399ede55775b4c760b274ed2322121ed185f',

--- a/examples/rgbpp/spore/launch/1-prepare-cluster.ts
+++ b/examples/rgbpp/spore/launch/1-prepare-cluster.ts
@@ -10,7 +10,7 @@ import {
   genRgbppLockScript,
   getSecp256k1CellDep,
 } from 'rgbpp/ckb';
-import { ckbAddress, isMainnet, collector, CKB_PRIVATE_KEY } from '../../env';
+import { ckbAddress, isMainnet, collector, CKB_PRIVATE_KEY, BTC_TESTNET_TYPE } from '../../env';
 import { CLUSTER_DATA } from './0-cluster-info';
 
 const prepareClusterCell = async ({ outIndex, btcTxId }: { outIndex: number; btcTxId: string }) => {
@@ -33,7 +33,7 @@ const prepareClusterCell = async ({ outIndex, btcTxId }: { outIndex: number; btc
 
   const outputs: CKBComponents.CellOutput[] = [
     {
-      lock: genRgbppLockScript(buildRgbppLockArgs(outIndex, btcTxId), isMainnet),
+      lock: genRgbppLockScript(buildRgbppLockArgs(outIndex, btcTxId), isMainnet, BTC_TESTNET_TYPE),
       capacity: append0x(clusterCellCapacity.toString(16)),
     },
   ];

--- a/examples/rgbpp/spore/launch/2-create-cluster.ts
+++ b/examples/rgbpp/spore/launch/2-create-cluster.ts
@@ -1,5 +1,5 @@
 import { BtcAssetsApiError, genCreateClusterCkbVirtualTx, sendRgbppUtxos } from 'rgbpp';
-import { isMainnet, collector, btcAccount, btcDataSource, btcService } from '../../env';
+import { isMainnet, collector, btcAccount, btcDataSource, btcService, BTC_TESTNET_TYPE } from '../../env';
 import { CLUSTER_DATA } from './0-cluster-info';
 import {
   appendCkbTxWitnesses,
@@ -19,6 +19,7 @@ const createCluster = async ({ ownerRgbppLockArgs }: { ownerRgbppLockArgs: strin
     clusterData: CLUSTER_DATA,
     isMainnet,
     ckbFeeRate: BigInt(2000),
+    btcTestnetType: BTC_TESTNET_TYPE,
   });
 
   // Save ckbVirtualTxResult
@@ -78,6 +79,9 @@ const createCluster = async ({ ownerRgbppLockArgs }: { ownerRgbppLockArgs: strin
 };
 
 // Please use your real BTC UTXO information on the BTC Testnet which should be same as the 1-prepare-cluster.ts
+// BTC Testnet3: https://mempool.space/testnet
+// BTC Signet: https://mempool.space/signet
+
 // rgbppLockArgs: outIndexU32 + btcTxId
 createCluster({
   ownerRgbppLockArgs: buildRgbppLockArgs(3, 'aee4e8e3aa95e9e9ab1f0520714031d92d3263262099dcc7f7d64e62fa2fcb44'),

--- a/examples/rgbpp/spore/launch/3-create-spores.ts
+++ b/examples/rgbpp/spore/launch/3-create-spores.ts
@@ -1,5 +1,14 @@
 import { BtcAssetsApiError, genCreateSporeCkbVirtualTx, sendRgbppUtxos } from 'rgbpp';
-import { isMainnet, collector, btcDataSource, btcService, CKB_PRIVATE_KEY, ckbAddress, btcAccount } from '../../env';
+import {
+  isMainnet,
+  collector,
+  btcDataSource,
+  btcService,
+  CKB_PRIVATE_KEY,
+  ckbAddress,
+  btcAccount,
+  BTC_TESTNET_TYPE,
+} from '../../env';
 import {
   Hex,
   appendCkbTxWitnesses,
@@ -30,6 +39,7 @@ const createSpores = async ({ clusterRgbppLockArgs, receivers }: SporeCreatePara
     clusterRgbppLockArgs,
     isMainnet,
     ckbFeeRate: BigInt(2000),
+    btcTestnetType: BTC_TESTNET_TYPE,
   });
 
   // Save ckbVirtualTxResult
@@ -105,6 +115,9 @@ const createSpores = async ({ clusterRgbppLockArgs, receivers }: SporeCreatePara
 };
 
 // Please use your real BTC UTXO information on the BTC Testnet
+// BTC Testnet3: https://mempool.space/testnet
+// BTC Signet: https://mempool.space/signet
+
 // rgbppLockArgs: outIndexU32 + btcTxId
 createSpores({
   // The cluster cell will be spent and the new cluster cell will be created in each spore creation tx,

--- a/examples/rgbpp/spore/local/4-transfer-spore.ts
+++ b/examples/rgbpp/spore/local/4-transfer-spore.ts
@@ -11,7 +11,7 @@ import {
 import { sendRgbppUtxos } from 'rgbpp/btc';
 import { BtcAssetsApiError } from 'rgbpp';
 import { serializeScript } from '@nervosnetwork/ckb-sdk-utils';
-import { isMainnet, collector, btcDataSource, btcService, btcAccount } from '../../env';
+import { isMainnet, collector, btcDataSource, btcService, btcAccount, BTC_TESTNET_TYPE } from '../../env';
 import { saveCkbVirtualTxResult } from '../../shared/utils';
 import { signAndSendPsbt } from '../../shared/btc-account';
 
@@ -35,6 +35,7 @@ const transferSpore = async ({ sporeRgbppLockArgs, toBtcAddress, sporeTypeArgs }
     sporeTypeBytes,
     isMainnet,
     ckbFeeRate: BigInt(5000),
+    btcTestnetType: BTC_TESTNET_TYPE,
   });
 
   // Save ckbVirtualTxResult
@@ -90,6 +91,9 @@ const transferSpore = async ({ sporeRgbppLockArgs, toBtcAddress, sporeTypeArgs }
 };
 
 // Please use your real BTC UTXO information on the BTC Testnet
+// BTC Testnet3: https://mempool.space/testnet
+// BTC Signet: https://mempool.space/signet
+
 // rgbppLockArgs: outIndexU32 + btcTxId
 transferSpore({
   // The spore rgbpp lock args is from 3-create-spore.ts

--- a/examples/rgbpp/spore/local/5-leap-spore-to-ckb.ts
+++ b/examples/rgbpp/spore/local/5-leap-spore-to-ckb.ts
@@ -10,7 +10,7 @@ import {
 } from 'rgbpp/ckb';
 import { sendRgbppUtxos } from 'rgbpp/btc';
 import { serializeScript } from '@nervosnetwork/ckb-sdk-utils';
-import { isMainnet, collector, btcDataSource, btcService, btcAccount } from '../../env';
+import { isMainnet, collector, btcDataSource, btcService, btcAccount, BTC_TESTNET_TYPE } from '../../env';
 import { BtcAssetsApiError } from 'rgbpp';
 import { saveCkbVirtualTxResult } from '../../shared/utils';
 import { signAndSendPsbt } from '../../shared/btc-account';
@@ -35,6 +35,7 @@ const leapSpore = async ({ sporeRgbppLockArgs, toCkbAddress, sporeTypeArgs }: Sp
     sporeTypeBytes,
     toCkbAddress,
     isMainnet,
+    btcTestnetType: BTC_TESTNET_TYPE,
   });
 
   // Save ckbVirtualTxResult
@@ -90,6 +91,9 @@ const leapSpore = async ({ sporeRgbppLockArgs, toCkbAddress, sporeTypeArgs }: Sp
 };
 
 // Please use your real BTC UTXO information on the BTC Testnet
+// BTC Testnet3: https://mempool.space/testnet
+// BTC Signet: https://mempool.space/signet
+
 // rgbppLockArgs: outIndexU32 + btcTxId
 leapSpore({
   // The spore rgbpp lock args is from 3-create-spore.ts

--- a/examples/rgbpp/xudt/1-ckb-leap-btc.ts
+++ b/examples/rgbpp/xudt/1-ckb-leap-btc.ts
@@ -1,7 +1,7 @@
 import { serializeScript } from '@nervosnetwork/ckb-sdk-utils';
 import { genCkbJumpBtcVirtualTx } from 'rgbpp';
 import { getSecp256k1CellDep, buildRgbppLockArgs, getXudtTypeScript } from 'rgbpp/ckb';
-import { CKB_PRIVATE_KEY, isMainnet, collector, ckbAddress } from '../env';
+import { CKB_PRIVATE_KEY, isMainnet, collector, ckbAddress, BTC_TESTNET_TYPE } from '../env';
 
 interface LeapToBtcParams {
   outIndex: number;
@@ -25,6 +25,7 @@ const leapFromCkbToBtc = async ({ outIndex, btcTxId, xudtTypeArgs, transferAmoun
     toRgbppLockArgs,
     xudtTypeBytes: serializeScript(xudtType),
     transferAmount,
+    btcTestnetType: BTC_TESTNET_TYPE,
   });
 
   const emptyWitness = { lock: '', inputType: '', outputType: '' };
@@ -41,10 +42,12 @@ const leapFromCkbToBtc = async ({ outIndex, btcTxId, xudtTypeArgs, transferAmoun
 };
 
 // Please use your real BTC UTXO information on the BTC Testnet
+// BTC Testnet3: https://mempool.space/testnet
+// BTC Signet: https://mempool.space/signet
 leapFromCkbToBtc({
   outIndex: 1,
-  btcTxId: '4ff1855b64b309afa19a8b9be3d4da99dcb18b083b65d2d851662995c7d99e7a',
+  btcTxId: '3f6db9a387587006cb2fa8c6352bc728984bf39cb010789dffe574f27775a6ac',
   // Please use your own RGB++ xudt asset's xudtTypeArgs
-  xudtTypeArgs: '0x1ba116c119d1cfd98a53e9d1a615cf2af2bb87d95515c9d217d367054cfc696b',
+  xudtTypeArgs: '0x562e4e8a2f64a3e9c24beb4b7dd002d0ad3b842d0cc77924328e36ad114e3ebe',
   transferAmount: BigInt(800_0000_0000),
 });

--- a/examples/rgbpp/xudt/1-ckb-leap-btc.ts
+++ b/examples/rgbpp/xudt/1-ckb-leap-btc.ts
@@ -38,7 +38,7 @@ const leapFromCkbToBtc = async ({ outIndex, btcTxId, xudtTypeArgs, transferAmoun
   const signedTx = collector.getCkb().signTransaction(CKB_PRIVATE_KEY)(unsignedTx);
 
   const txHash = await collector.getCkb().rpc.sendTransaction(signedTx, 'passthrough');
-  console.info(`Rgbpp asset has been jumped from CKB to BTC and tx hash is ${txHash}`);
+  console.info(`Rgbpp asset has been jumped from CKB to BTC and CKB tx hash is ${txHash}`);
 };
 
 // Please use your real BTC UTXO information on the BTC Testnet

--- a/examples/rgbpp/xudt/2-btc-transfer.ts
+++ b/examples/rgbpp/xudt/2-btc-transfer.ts
@@ -1,6 +1,6 @@
 import { buildRgbppLockArgs } from 'rgbpp/ckb';
 import { buildRgbppTransferTx } from 'rgbpp';
-import { isMainnet, collector, btcService, btcAccount, btcDataSource } from '../env';
+import { isMainnet, collector, btcService, btcAccount, btcDataSource, BTC_TESTNET_TYPE } from '../env';
 import { saveCkbVirtualTxResult } from '../shared/utils';
 import { signAndSendPsbt } from '../shared/btc-account';
 import { bitcoin } from 'rgbpp/btc';
@@ -25,6 +25,7 @@ const transfer = async ({ rgbppLockArgsList, toBtcAddress, xudtTypeArgs, transfe
       toAddress: toBtcAddress,
       fromPubkey: btcAccount.fromPubkey,
       dataSource: btcDataSource,
+      testnetType: BTC_TESTNET_TYPE,
     },
     isMainnet,
   });
@@ -35,7 +36,7 @@ const transfer = async ({ rgbppLockArgsList, toBtcAddress, xudtTypeArgs, transfe
   // Send BTC tx
   const psbt = bitcoin.Psbt.fromHex(btcPsbtHex);
   const { txId: btcTxId } = await signAndSendPsbt(psbt, btcAccount, btcService);
-  console.log('BTC TxId: ', btcTxId);
+  console.log(`BTC ${BTC_TESTNET_TYPE} TxId: ${btcTxId}`);
 
   await btcService.sendRgbppCkbTransaction({ btc_txid: btcTxId, ckb_virtual_result: ckbVirtualTxResult });
 
@@ -59,11 +60,14 @@ const transfer = async ({ rgbppLockArgsList, toBtcAddress, xudtTypeArgs, transfe
 };
 
 // Please use your real BTC UTXO information on the BTC Testnet
+// BTC Testnet3: https://mempool.space/testnet
+// BTC Signet: https://mempool.space/signet
+
 // rgbppLockArgs: outIndexU32 + btcTxId
 transfer({
-  rgbppLockArgsList: [buildRgbppLockArgs(1, '64252b582aea1249ed969a20385fae48bba35bf1ab9b3df3b0fcddc754ccf592')],
+  rgbppLockArgsList: [buildRgbppLockArgs(1, '5ddd7b60ba93e01d9781be50eaa5c1aa634f799fc9c47bf59d1566eacf47b1e8')],
   toBtcAddress: 'tb1qvt7p9g6mw70sealdewtfp0sekquxuru6j3gwmt',
   // Please use your own RGB++ xudt asset's xudtTypeArgs
-  xudtTypeArgs: '0x1ba116c119d1cfd98a53e9d1a615cf2af2bb87d95515c9d217d367054cfc696b',
+  xudtTypeArgs: '0x562e4e8a2f64a3e9c24beb4b7dd002d0ad3b842d0cc77924328e36ad114e3ebe',
   transferAmount: BigInt(800_0000_0000),
 });

--- a/examples/rgbpp/xudt/3-btc-leap-ckb.ts
+++ b/examples/rgbpp/xudt/3-btc-leap-ckb.ts
@@ -1,7 +1,7 @@
 import { buildRgbppLockArgs, getXudtTypeScript } from 'rgbpp/ckb';
 import { serializeScript } from '@nervosnetwork/ckb-sdk-utils';
 import { genBtcJumpCkbVirtualTx, sendRgbppUtxos } from 'rgbpp';
-import { isMainnet, collector, btcService, btcDataSource, btcAccount } from '../env';
+import { isMainnet, collector, btcService, btcDataSource, btcAccount, BTC_TESTNET_TYPE } from '../env';
 import { saveCkbVirtualTxResult } from '../shared/utils';
 import { signAndSendPsbt } from '../shared/btc-account';
 
@@ -25,6 +25,7 @@ const leapFromBtcToCKB = async ({ rgbppLockArgsList, toCkbAddress, xudtTypeArgs,
     transferAmount,
     toCkbAddress,
     isMainnet,
+    btcTestnetType: BTC_TESTNET_TYPE,
   });
 
   // Save ckbVirtualTxResult
@@ -44,7 +45,7 @@ const leapFromBtcToCKB = async ({ rgbppLockArgsList, toCkbAddress, xudtTypeArgs,
   });
 
   const { txId: btcTxId } = await signAndSendPsbt(psbt, btcAccount, btcService);
-  console.log('BTC TxId: ', btcTxId);
+  console.log(`BTC ${BTC_TESTNET_TYPE} TxId: ${btcTxId}`);
 
   await btcService.sendRgbppCkbTransaction({ btc_txid: btcTxId, ckb_virtual_result: ckbVirtualTxResult });
 
@@ -68,6 +69,9 @@ const leapFromBtcToCKB = async ({ rgbppLockArgsList, toCkbAddress, xudtTypeArgs,
 };
 
 // Please use your real BTC UTXO information on the BTC Testnet
+// BTC Testnet3: https://mempool.space/testnet
+// BTC Signet: https://mempool.space/signet
+
 // rgbppLockArgs: outIndexU32 + btcTxId
 leapFromBtcToCKB({
   rgbppLockArgsList: [buildRgbppLockArgs(1, '6edd4b9327506fab09fb9a0f5e5f35136a6a94bd4c9dd79af04921618fa6c800')],

--- a/examples/rgbpp/xudt/4-unlock-btc-time-cell.ts
+++ b/examples/rgbpp/xudt/4-unlock-btc-time-cell.ts
@@ -1,12 +1,12 @@
 import { buildBtcTimeCellsSpentTx, signBtcTimeCellSpentTx } from 'rgbpp';
 import { sendCkbTx, getBtcTimeLockScript } from 'rgbpp/ckb';
-import { CKB_PRIVATE_KEY, btcService, ckbAddress, collector, isMainnet } from '../env';
+import { BTC_TESTNET_TYPE, CKB_PRIVATE_KEY, btcService, ckbAddress, collector, isMainnet } from '../env';
 
 // Warning: Wait at least 6 BTC confirmation blocks to spend the BTC time cells after 3-btc-leap-ckb.ts
 const unlockBtcTimeCell = async ({ btcTimeCellArgs }: { btcTimeCellArgs: string }) => {
   const btcTimeCells = await collector.getCells({
     lock: {
-      ...getBtcTimeLockScript(false),
+      ...getBtcTimeLockScript(isMainnet, BTC_TESTNET_TYPE),
       args: btcTimeCellArgs,
     },
     isDataMustBeEmpty: false,
@@ -20,6 +20,7 @@ const unlockBtcTimeCell = async ({ btcTimeCellArgs }: { btcTimeCellArgs: string 
     btcTimeCells,
     btcAssetsApi: btcService,
     isMainnet,
+    btcTestnetType: BTC_TESTNET_TYPE,
   });
 
   const signedTx = await signBtcTimeCellSpentTx({
@@ -37,5 +38,5 @@ const unlockBtcTimeCell = async ({ btcTimeCellArgs }: { btcTimeCellArgs: string 
 // The btcTimeCellArgs is from the outputs[0].lock.args(BTC Time lock args) of the 3-btc-leap-ckb.ts CKB transaction
 unlockBtcTimeCell({
   btcTimeCellArgs:
-    '0x7f000000100000005b0000005f0000004b000000100000003000000031000000d23761b364210735c19c60561d213fb3beae2fd6172743719eff6920e020baac011600000000016c61f984f12d3c8a4f649e60acda5deda0b8837c060000001c95b9d726e4ab337d6a4572680598947954d7b6ff4f1e767e605eeeec49e7ed',
+    '0x7f000000100000005b0000005f0000004b000000100000003000000031000000d23761b364210735c19c60561d213fb3beae2fd6172743719eff6920e020baac011600000000016c61f984f12d3c8a4f649e60acda5deda0b8837c06000000799a0f55202939e6801924c87c66df75932ecf79774370beebe31eaa94b6d8b8',
 });

--- a/examples/rgbpp/xudt/4-unlock-btc-time-cell.ts
+++ b/examples/rgbpp/xudt/4-unlock-btc-time-cell.ts
@@ -32,7 +32,7 @@ const unlockBtcTimeCell = async ({ btcTimeCellArgs }: { btcTimeCellArgs: string 
   });
 
   const txHash = await sendCkbTx({ collector, signedTx });
-  console.info(`BTC time cell has been spent and tx hash is ${txHash}`);
+  console.info(`BTC time cell has been spent and CKB tx hash is ${txHash}`);
 };
 
 // The btcTimeCellArgs is from the outputs[0].lock.args(BTC Time lock args) of the 3-btc-leap-ckb.ts CKB transaction

--- a/examples/rgbpp/xudt/launch/1-prepare-launch.ts
+++ b/examples/rgbpp/xudt/launch/1-prepare-launch.ts
@@ -13,7 +13,7 @@ import {
   getSecp256k1CellDep,
 } from 'rgbpp/ckb';
 import { RGBPP_TOKEN_INFO } from './0-rgbpp-token-info';
-import { CKB_PRIVATE_KEY, ckbAddress, collector, isMainnet } from '../../env';
+import { BTC_TESTNET_TYPE, CKB_PRIVATE_KEY, ckbAddress, collector, isMainnet } from '../../env';
 
 const prepareLaunchCell = async ({
   outIndex,
@@ -44,7 +44,7 @@ const prepareLaunchCell = async ({
 
   const outputs: CKBComponents.CellOutput[] = [
     {
-      lock: genRgbppLockScript(buildRgbppLockArgs(outIndex, btcTxId), isMainnet),
+      lock: genRgbppLockScript(buildRgbppLockArgs(outIndex, btcTxId), isMainnet, BTC_TESTNET_TYPE),
       capacity: append0x(launchCellCapacity.toString(16)),
     },
   ];
@@ -82,8 +82,10 @@ const prepareLaunchCell = async ({
 };
 
 // Please use your real BTC UTXO information on the BTC Testnet
+// BTC Testnet3: https://mempool.space/testnet
+// BTC Signet: https://mempool.space/signet
 prepareLaunchCell({
   outIndex: 1,
-  btcTxId: '6259ea7852e294afbd2aaf9ccd5c9c1f95087b0b08ba7e47ae35ce31170732bc',
+  btcTxId: 'c1f7fe5d4898194ed8ee5a38597cd28c7981e32e0e6aeb770f3f1b87df21434c',
   rgbppTokenInfo: RGBPP_TOKEN_INFO,
 });

--- a/examples/rgbpp/xudt/launch/1-prepare-launch.ts
+++ b/examples/rgbpp/xudt/launch/1-prepare-launch.ts
@@ -78,7 +78,7 @@ const prepareLaunchCell = async ({
   const signedTx = collector.getCkb().signTransaction(CKB_PRIVATE_KEY)(unsignedTx);
   const txHash = await collector.getCkb().rpc.sendTransaction(signedTx, 'passthrough');
 
-  console.info(`Launch cell has been created and the tx hash ${txHash}`);
+  console.info(`Launch cell has been created and the CKB tx hash ${txHash}`);
 };
 
 // Please use your real BTC UTXO information on the BTC Testnet

--- a/examples/rgbpp/xudt/launch/2-launch-rgbpp.ts
+++ b/examples/rgbpp/xudt/launch/2-launch-rgbpp.ts
@@ -64,7 +64,7 @@ const launchRgppAsset = async ({ ownerRgbppLockArgs, launchAmount, rgbppTokenInf
       });
 
       const txHash = await sendCkbTx({ collector, signedTx: ckbTx });
-      console.info(`RGB++ Asset has been launched and tx hash is ${txHash}`);
+      console.info(`RGB++ Asset has been launched and CKB tx hash is ${txHash}`);
     } catch (error) {
       if (!(error instanceof BtcAssetsApiError)) {
         console.error(error);

--- a/examples/rgbpp/xudt/launch/2-launch-rgbpp.ts
+++ b/examples/rgbpp/xudt/launch/2-launch-rgbpp.ts
@@ -7,7 +7,7 @@ import {
   sendCkbTx,
 } from 'rgbpp/ckb';
 import { RGBPP_TOKEN_INFO } from './0-rgbpp-token-info';
-import { btcAccount, btcDataSource, btcService, collector, isMainnet } from '../../env';
+import { BTC_TESTNET_TYPE, btcAccount, btcDataSource, btcService, collector, isMainnet } from '../../env';
 import { saveCkbVirtualTxResult } from '../../shared/utils';
 import { signAndSendPsbt } from '../../shared/btc-account';
 
@@ -25,6 +25,7 @@ const launchRgppAsset = async ({ ownerRgbppLockArgs, launchAmount, rgbppTokenInf
     rgbppTokenInfo,
     launchAmount,
     isMainnet,
+    btcTestnetType: BTC_TESTNET_TYPE,
   });
 
   // Save ckbVirtualTxResult
@@ -47,7 +48,7 @@ const launchRgppAsset = async ({ ownerRgbppLockArgs, launchAmount, rgbppTokenInf
   });
 
   const { txId: btcTxId, rawTxHex: btcTxBytes } = await signAndSendPsbt(psbt, btcAccount, btcService);
-  console.log('BTC TxId: ', btcTxId);
+  console.log(`BTC ${BTC_TESTNET_TYPE} TxId: ${btcTxId}`);
 
   const interval = setInterval(async () => {
     try {
@@ -73,9 +74,12 @@ const launchRgppAsset = async ({ ownerRgbppLockArgs, launchAmount, rgbppTokenInf
 };
 
 // Please use your real BTC UTXO information on the BTC Testnet which should be same as the 1-prepare-launch.ts
+// BTC Testnet3: https://mempool.space/testnet
+// BTC Signet: https://mempool.space/signet
+
 // rgbppLockArgs: outIndexU32 + btcTxId
 launchRgppAsset({
-  ownerRgbppLockArgs: buildRgbppLockArgs(1, '6259ea7852e294afbd2aaf9ccd5c9c1f95087b0b08ba7e47ae35ce31170732bc'),
+  ownerRgbppLockArgs: buildRgbppLockArgs(1, 'c1f7fe5d4898194ed8ee5a38597cd28c7981e32e0e6aeb770f3f1b87df21434c'),
   rgbppTokenInfo: RGBPP_TOKEN_INFO,
   // The total issuance amount of RGBPP Token, the decimal is determined by RGBPP Token info
   launchAmount: BigInt(2100_0000) * BigInt(10 ** RGBPP_TOKEN_INFO.decimal),

--- a/examples/rgbpp/xudt/launch/3-distribute-rgbpp.ts
+++ b/examples/rgbpp/xudt/launch/3-distribute-rgbpp.ts
@@ -1,7 +1,16 @@
 import { serializeScript } from '@nervosnetwork/ckb-sdk-utils';
 import { BtcAssetsApiError, genBtcBatchTransferCkbVirtualTx, sendRgbppUtxos } from 'rgbpp';
 import { RGBPP_TOKEN_INFO } from './0-rgbpp-token-info';
-import { isMainnet, collector, btcDataSource, btcService, CKB_PRIVATE_KEY, ckbAddress, btcAccount } from '../../env';
+import {
+  isMainnet,
+  collector,
+  btcDataSource,
+  btcService,
+  CKB_PRIVATE_KEY,
+  ckbAddress,
+  btcAccount,
+  BTC_TESTNET_TYPE,
+} from '../../env';
 import {
   RgbppBtcAddressReceiver,
   appendCkbTxWitnesses,
@@ -35,6 +44,7 @@ const distributeRgbppAssetOnBtc = async ({ rgbppLockArgsList, receivers, xudtTyp
     xudtTypeBytes: serializeScript(xudtType),
     rgbppReceivers: receivers,
     isMainnet,
+    btcTestnetType: BTC_TESTNET_TYPE,
   });
 
   // Save ckbVirtualTxResult
@@ -59,7 +69,7 @@ const distributeRgbppAssetOnBtc = async ({ rgbppLockArgsList, receivers, xudtTyp
   });
 
   const { txId: btcTxId, rawTxHex: btcTxBytes } = await signAndSendPsbt(psbt, btcAccount, btcService);
-  console.log('BTC TxId: ', btcTxId);
+  console.log(`BTC ${BTC_TESTNET_TYPE} TxId: ${btcTxId}`);
 
   const interval = setInterval(async () => {
     try {
@@ -94,15 +104,18 @@ const distributeRgbppAssetOnBtc = async ({ rgbppLockArgsList, receivers, xudtTyp
 };
 
 // Please use your real BTC UTXO information on the BTC Testnet
+// BTC Testnet3: https://mempool.space/testnet
+// BTC Signet: https://mempool.space/signet
+
 // rgbppLockArgs: outIndexU32 + btcTxId
 distributeRgbppAssetOnBtc({
   // Warning: If rgbpp assets are distributed continuously, then the position of the current rgbpp asset utxo depends on the position of the previous change utxo distributed
-  rgbppLockArgsList: [buildRgbppLockArgs(2, '012bfee9c1e8a6e9e272b63ff54d5138efe910cc7aac413221cb3634ea176866')],
+  rgbppLockArgsList: [buildRgbppLockArgs(1, '5ab72e296c7e4f93302f5b1827c59860a95b94958942c65977bf25fcd7364bf3')],
   // The xudtTypeArgs comes from the logs "RGB++ Asset type script args" of 2-launch-rgbpp.ts
-  xudtTypeArgs: '0x4c1ecf2f14edae73b76ccf115ecfa40ba68ee315c96bd4fcfd771c2fb4c69e8f',
+  xudtTypeArgs: '0x157339c6b1ad2156bc9aa3f901abb07253f198160fb484226127ccafedd690c8',
   receivers: [
     {
-      toBtcAddress: 'tb1qvt7p9g6mw70sealdewtfp0sekquxuru6j3gwmt',
+      toBtcAddress: 'tb1qhp9fh9qsfeyh0yhewgu27ndqhs5qlrqwau28m7',
       transferAmount: BigInt(1000) * BigInt(10 ** RGBPP_TOKEN_INFO.decimal),
     },
   ],

--- a/examples/rgbpp/xudt/launch/3-distribute-rgbpp.ts
+++ b/examples/rgbpp/xudt/launch/3-distribute-rgbpp.ts
@@ -94,7 +94,7 @@ const distributeRgbppAssetOnBtc = async ({ rgbppLockArgsList, receivers, xudtTyp
       });
 
       const txHash = await sendCkbTx({ collector, signedTx });
-      console.info(`RGB++ Asset has been distributed and tx hash is ${txHash}`);
+      console.info(`RGB++ Asset has been distributed and CKB tx hash is ${txHash}`);
     } catch (error) {
       if (!(error instanceof BtcAssetsApiError)) {
         console.error(error);

--- a/examples/rgbpp/xudt/local/2-btc-transfer.ts
+++ b/examples/rgbpp/xudt/local/2-btc-transfer.ts
@@ -1,6 +1,6 @@
 import { BtcAssetsApiError, buildRgbppTransferTx } from 'rgbpp';
 import { appendCkbTxWitnesses, buildRgbppLockArgs, sendCkbTx, updateCkbTxWithRealBtcTxId } from 'rgbpp/ckb';
-import { isMainnet, collector, btcDataSource, btcService, btcAccount } from '../../env';
+import { isMainnet, collector, btcDataSource, btcService, btcAccount, BTC_TESTNET_TYPE } from '../../env';
 import { bitcoin } from 'rgbpp/btc';
 import { saveCkbVirtualTxResult } from '../../shared/utils';
 import { signAndSendPsbt } from '../../shared/btc-account';
@@ -26,6 +26,7 @@ const transfer = async ({ rgbppLockArgsList, toBtcAddress, xudtTypeArgs, transfe
       toAddress: toBtcAddress,
       fromPubkey: btcAccount.fromPubkey,
       dataSource: btcDataSource,
+      testnetType: BTC_TESTNET_TYPE,
     },
     isMainnet,
   });
@@ -38,12 +39,12 @@ const transfer = async ({ rgbppLockArgsList, toBtcAddress, xudtTypeArgs, transfe
   // Send BTC tx
   const psbt = bitcoin.Psbt.fromHex(btcPsbtHex);
   const { txId: btcTxId, rawTxHex: btcTxBytes } = await signAndSendPsbt(psbt, btcAccount, btcService);
-  console.log('BTC TxId: ', btcTxId);
+  console.log(`BTC ${BTC_TESTNET_TYPE} TxId: ${btcTxId}`);
 
   // Wait for BTC tx and proof to be ready, and then send isomorphic CKB transactions
   const interval = setInterval(async () => {
     try {
-      console.log('Waiting for BTC tx and proof to be ready');
+      console.log(`Waiting for BTC tx and proof to be ready`);
       const rgbppApiSpvProof = await btcService.getRgbppSpvProof(btcTxId, 0);
       clearInterval(interval);
       // Update CKB transaction with the real BTC txId
@@ -64,12 +65,15 @@ const transfer = async ({ rgbppLockArgsList, toBtcAddress, xudtTypeArgs, transfe
   }, 30 * 1000);
 };
 
-// Please use your real BTC UTXO information on the BTC Testnet
+// Please use your real BTC UTXO information on the BTC Signet Testnet
+// BTC Testnet3: https://mempool.space/testnet
+// BTC Signet: https://mempool.space/signet
+
 // rgbppLockArgs: outIndexU32 + btcTxId
 transfer({
-  rgbppLockArgsList: [buildRgbppLockArgs(1, '70b250e2a3cc7a33b47f7a4e94e41e1ee2501ce73b393d824db1dd4c872c5348')],
-  toBtcAddress: 'tb1qvt7p9g6mw70sealdewtfp0sekquxuru6j3gwmt',
+  rgbppLockArgsList: [buildRgbppLockArgs(2, '57212668f2738aa07a51861a2f8cd7a083aab05b01ede8b79dff948c0041f808')],
+  toBtcAddress: 'tb1qhp9fh9qsfeyh0yhewgu27ndqhs5qlrqwau28m7',
   // Please use your own RGB++ asset's xudtTypeArgs
-  xudtTypeArgs: '0x1ba116c119d1cfd98a53e9d1a615cf2af2bb87d95515c9d217d367054cfc696b',
+  xudtTypeArgs: '0x562e4e8a2f64a3e9c24beb4b7dd002d0ad3b842d0cc77924328e36ad114e3ebe',
   transferAmount: BigInt(800_0000_0000),
 });

--- a/examples/rgbpp/xudt/local/3-btc-leap-ckb.ts
+++ b/examples/rgbpp/xudt/local/3-btc-leap-ckb.ts
@@ -7,7 +7,7 @@ import {
   getXudtTypeScript,
   updateCkbTxWithRealBtcTxId,
 } from 'rgbpp/ckb';
-import { isMainnet, collector, btcDataSource, btcService, btcAccount } from '../../env';
+import { isMainnet, collector, btcDataSource, btcService, btcAccount, BTC_TESTNET_TYPE } from '../../env';
 import { saveCkbVirtualTxResult } from '../../shared/utils';
 import { signAndSendPsbt } from '../../shared/btc-account';
 
@@ -32,12 +32,15 @@ const leapFromBtcToCkb = async ({ rgbppLockArgsList, toCkbAddress, xudtTypeArgs,
     transferAmount,
     toCkbAddress,
     isMainnet,
+    btcTestnetType: BTC_TESTNET_TYPE,
   });
 
   // Save ckbVirtualTxResult
   saveCkbVirtualTxResult(ckbVirtualTxResult, '3-btc-leap-ckb-local');
 
   const { commitment, ckbRawTx } = ckbVirtualTxResult;
+
+  console.log('ckbRawTx', JSON.stringify(ckbRawTx));
 
   // Send BTC tx
   const psbt = await sendRgbppUtxos({
@@ -51,9 +54,7 @@ const leapFromBtcToCkb = async ({ rgbppLockArgsList, toCkbAddress, xudtTypeArgs,
   });
 
   const { txId: btcTxId, rawTxHex: btcTxBytes } = await signAndSendPsbt(psbt, btcAccount, btcService);
-  console.log('BTC Tx bytes: ', btcTxBytes);
-  console.log('BTC TxId: ', btcTxId);
-  console.log('ckbRawTx', JSON.stringify(ckbRawTx));
+  console.log(`BTC ${BTC_TESTNET_TYPE} TxId: ${btcTxId}`);
 
   // Wait for BTC tx and proof to be ready, and then send isomorphic CKB transactions
   const interval = setInterval(async () => {
@@ -69,6 +70,8 @@ const leapFromBtcToCkb = async ({ rgbppLockArgsList, toCkbAddress, xudtTypeArgs,
         rgbppApiSpvProof,
       });
 
+      console.log(JSON.stringify(ckbTx));
+
       const txHash = await sendCkbTx({ collector, signedTx: ckbTx });
       console.info(`RGB++ Asset has been leaped from BTC to CKB and the CKB tx hash is ${txHash}`);
     } catch (error) {
@@ -80,11 +83,14 @@ const leapFromBtcToCkb = async ({ rgbppLockArgsList, toCkbAddress, xudtTypeArgs,
 };
 
 // Please use your real BTC UTXO information on the BTC Testnet
+// BTC Testnet3: https://mempool.space/testnet
+// BTC Signet: https://mempool.space/signet
+
 // rgbppLockArgs: outIndexU32 + btcTxId
 leapFromBtcToCkb({
-  rgbppLockArgsList: [buildRgbppLockArgs(1, '24e622419156dd3a277a90bcbb40c7117462a18d5329dd1ada320ca8bdfba715')],
+  rgbppLockArgsList: [buildRgbppLockArgs(1, '3f6db9a387587006cb2fa8c6352bc728984bf39cb010789dffe574f27775a6ac')],
   toCkbAddress: 'ckt1qrfrwcdnvssswdwpn3s9v8fp87emat306ctjwsm3nmlkjg8qyza2cqgqq9kxr7vy7yknezj0vj0xptx6thk6pwyr0sxamv6q',
   // Please use your own RGB++ xudt asset's xudtTypeArgs
-  xudtTypeArgs: '0x1ba116c119d1cfd98a53e9d1a615cf2af2bb87d95515c9d217d367054cfc696b',
+  xudtTypeArgs: '0x562e4e8a2f64a3e9c24beb4b7dd002d0ad3b842d0cc77924328e36ad114e3ebe',
   transferAmount: BigInt(800_0000_0000),
 });

--- a/packages/ckb/README.md
+++ b/packages/ckb/README.md
@@ -46,10 +46,11 @@ export interface BtcTransferVirtualTxResult {
  * @param xudtTypeBytes The serialized hex string of the XUDT type script
  * @param rgbppLockArgsList The rgbpp assets cell lock script args array whose data structure is: out_index | bitcoin_tx_id
  * @param transferAmount The XUDT amount to be transferred, if the noMergeOutputCells is true, the transferAmount will be ignored
- * @param isMainnet
- * @param witnessLockPlaceholderSize The WitnessArgs.lock placeholder bytes array size and the default value is 5000
- * @param noMergeOutputCells The noMergeOutputCells indicates whether the CKB outputs need to be merged. By default, the outputs will be merged.
- * @param ckbFeeRate The CKB transaction fee rate, default value is 1100
+ * @param isMainnet True is for BTC and CKB Mainnet, flase is for BTC and CKB Testnet(see btcTestnetType for details about BTC Testnet)
+ * @param witnessLockPlaceholderSize(Optional) The WitnessArgs.lock placeholder bytes array size and the default value is 5000
+ * @param noMergeOutputCells(Optional) The noMergeOutputCells indicates whether the CKB outputs need to be merged. By default, the outputs will be merged.
+ * @param ckbFeeRate(Optional) The CKB transaction fee rate, default value is 1100
+ * @param btcTestnetType(Optional) The Bitcoin Testnet type including Testnet3 and Signet, default value is Testnet3
  */
 export const genBtcTransferCkbVirtualTx = async ({
   collector,
@@ -60,6 +61,7 @@ export const genBtcTransferCkbVirtualTx = async ({
   witnessLockPlaceholderSize,
   noMergeOutputCells,
   ckbFeeRate,
+  btcTestnetType
 }: BtcTransferVirtualTxParams): Promise<BtcTransferVirtualTxResult>
 ```
 
@@ -84,9 +86,9 @@ interface BtcJumpCkbVirtualTxResult {
  * @param xudtTypeBytes The serialized hex string of the XUDT type script
  * @param rgbppLockArgsList The rgbpp assets cell lock script args array whose data structure is: out_index | bitcoin_tx_id
  * @param transferAmount The XUDT amount to be transferred
- * @param witnessLockPlaceholderSize The WitnessArgs.lock placeholder bytes array size and the default value is 5000
- * @param ckbFeeRate The CKB transaction fee rate, default value is 1100
- * @param isMainnet
+ * @param witnessLockPlaceholderSize(Optional) The WitnessArgs.lock placeholder bytes array size and the default value is 5000
+ * @param ckbFeeRate(Optional) The CKB transaction fee rate, default value is 1100
+ * @param btcTestnetType(Optional) The Bitcoin Testnet type including Testnet3 and Signet, default value is Testnet3
  */
 export const genBtcJumpCkbVirtualTx = async ({
   collector,
@@ -96,6 +98,7 @@ export const genBtcJumpCkbVirtualTx = async ({
   toCkbAddress,
   witnessLockPlaceholderSize,
   ckbFeeRate,
+  btcTestnetType
 }: BtcJumpCkbVirtualTxParams): Promise<BtcJumpCkbVirtualTxResult>
 ```
 
@@ -111,9 +114,8 @@ The method `genCkbJumpBtcVirtualTx` can generate a CKB transaction for RGB++ xUD
  * @param fromCkbAddress The from ckb address who will use his private key to sign the ckb tx
  * @param toRgbppLockArgs The receiver rgbpp lock script args whose data structure is: out_index | bitcoin_tx_id
  * @param transferAmount The XUDT amount to be transferred
- * @param witnessLockPlaceholderSize The WitnessArgs.lock placeholder bytes array size and the default value is 5000
- * @param ckbFeeRate The CKB transaction fee rate, default value is 1100
- * @param isMainnet
+ * @param witnessLockPlaceholderSize(Optional) The WitnessArgs.lock placeholder bytes array size and the default value is 5000
+ * @param ckbFeeRate(Optional) The CKB transaction fee rate, default value is 1100
  */
 export const genCkbJumpBtcVirtualTx = async ({
   collector,
@@ -147,12 +149,15 @@ export interface SporeCreateVirtualTxResult {
  * @param collector The collector that collects CKB live cells and transactions
  * @param clusterRgbppLockArgs The cluster rgbpp cell lock script args whose data structure is: out_index | bitcoin_tx_id
  * @param sporeDataList The spore's data list, including name and description.
+ * @param isMainnet True is for BTC and CKB Mainnet, flase is for BTC and CKB Testnet(see btcTestnetType for details about BTC Testnet)
+ * @param btcTestnetType(Optional) The Bitcoin Testnet type including Testnet3 and Signet, default value is Testnet3
  */
 export const genCreateSporeCkbVirtualTx = async ({
   collector,
   clusterRgbppLockArgs,
   sporeDataList,
   isMainnet,
+  btcTestnetType
 }: CreateSporeCkbVirtualTxParams): Promise<SporeCreateVirtualTxResult>
 ```
 
@@ -179,8 +184,10 @@ export interface SporeTransferVirtualTxResult {
  * @param collector The collector that collects CKB live cells and transactions
  * @param sporeRgbppLockArgs The spore rgbpp cell lock script args whose data structure is: out_index | bitcoin_tx_id
  * @param sporeTypeBytes The spore type script serialized bytes
- * @param witnessLockPlaceholderSize The WitnessArgs.lock placeholder bytes array size and the default value is 5000
- * @param ckbFeeRate The CKB transaction fee rate, default value is 1100
+ * @param isMainnet True is for BTC and CKB Mainnet, flase is for BTC and CKB Testnet(see btcTestnetType for details about BTC Testnet)
+ * @param witnessLockPlaceholderSize(Optional) The WitnessArgs.lock placeholder bytes array size and the default value is 5000
+ * @param ckbFeeRate(Optional) The CKB transaction fee rate, default value is 1100
+ * @param btcTestnetType(Optional) The Bitcoin Testnet type including Testnet3 and Signet, default value is Testnet3
  */
 export const genTransferSporeCkbVirtualTx = async ({
   collector,
@@ -189,6 +196,7 @@ export const genTransferSporeCkbVirtualTx = async ({
   isMainnet,
   witnessLockPlaceholderSize,
   ckbFeeRate,
+  btcTestnetType
 }: TransferSporeCkbVirtualTxParams): Promise<SporeTransferVirtualTxResult>
 ```
 
@@ -216,8 +224,10 @@ export interface SporeLeapVirtualTxResult {
  * @param sporeRgbppLockArgs The spore rgbpp cell lock script args whose data structure is: out_index | bitcoin_tx_id
  * @param sporeTypeBytes The spore type script serialized bytes
  * @param toCkbAddress The receiver ckb address
- * @param witnessLockPlaceholderSize The WitnessArgs.lock placeholder bytes array size and the default value is 5000
- * @param ckbFeeRate The CKB transaction fee rate, default value is 1100
+ * @param isMainnet True is for BTC and CKB Mainnet, flase is for BTC and CKB Testnet(see btcTestnetType for details about BTC Testnet)
+ * @param witnessLockPlaceholderSize(Optional) The WitnessArgs.lock placeholder bytes array size and the default value is 5000
+ * @param ckbFeeRate(Optional) The CKB transaction fee rate, default value is 1100
+ * @param btcTestnetType(Optional) The Bitcoin Testnet type including Testnet3 and Signet, default value is Testnet3
  */
 export const genLeapSporeFromBtcToCkbVirtualTx = async ({
   collector,
@@ -227,6 +237,7 @@ export const genLeapSporeFromBtcToCkbVirtualTx = async ({
   isMainnet,
   witnessLockPlaceholderSize,
   ckbFeeRate,
+  btcTestnetType
 }: LeapSporeFromBtcToCkbVirtualTxParams): Promise<SporeLeapVirtualTxResult>
 ```
 
@@ -241,8 +252,10 @@ The method `genLeapSporeFromCkbToBtcRawTx` can generate a CKB transaction for RG
  * @param sporeRgbppLockArgs The spore rgbpp cell lock script args whose data structure is: out_index | bitcoin_tx_id
  * @param sporeTypeBytes The spore type script serialized bytes
  * @param toCkbAddress The receiver ckb address
- * @param witnessLockPlaceholderSize The WitnessArgs.lock placeholder bytes array size and the default value is 5000
- * @param ckbFeeRate The CKB transaction fee rate, default value is 1100
+ * @param isMainnet True is for BTC and CKB Mainnet, flase is for BTC and CKB Testnet
+ * @param witnessLockPlaceholderSize(Optional) The WitnessArgs.lock placeholder bytes array size and the default value is 5000
+ * @param ckbFeeRate(Optional) The CKB transaction fee rate, default value is 1100
+ * @param btcTestnetType(Optional) The Bitcoin Testnet type including Testnet3 and Signet
  */
 export const genLeapSporeFromCkbToBtcRawTx = async ({
   collector,

--- a/packages/ckb/README.md
+++ b/packages/ckb/README.md
@@ -116,6 +116,7 @@ The method `genCkbJumpBtcVirtualTx` can generate a CKB transaction for RGB++ xUD
  * @param transferAmount The XUDT amount to be transferred
  * @param witnessLockPlaceholderSize(Optional) The WitnessArgs.lock placeholder bytes array size and the default value is 5000
  * @param ckbFeeRate(Optional) The CKB transaction fee rate, default value is 1100
+ * @param btcTestnetType(Optional) The Bitcoin Testnet type including Testnet3 and Signet, default value is Testnet3
  */
 export const genCkbJumpBtcVirtualTx = async ({
   collector,

--- a/packages/ckb/src/constants/index.ts
+++ b/packages/ckb/src/constants/index.ts
@@ -1,3 +1,5 @@
+import { BTCTestnetType } from '../types';
+
 export const CKB_UNIT = BigInt(10000_0000);
 export const MAX_FEE = BigInt(2000_0000);
 export const MIN_CAPACITY = BigInt(61) * BigInt(10000_0000);
@@ -103,6 +105,39 @@ const TestnetInfo = {
       txHash: '0x5e8d2a517d50fd4bb4d01737a7952a1f1d35c8afc77240695bb569cd7d9d5a1f',
       index: '0x0',
     },
+    depType: 'code',
+  } as CKBComponents.CellDep,
+
+  // The CKB testnet RGB++ deployment information for the BTC Signet network
+  RgbppSignetLockScript: {
+    codeHash: '0x61ca7a4796a4eb19ca4f0d065cb9b10ddcf002f10f7cbb810c706cb6bb5c3248',
+    hashType: 'type',
+    args: '',
+  } as CKBComponents.Script,
+
+  RgbppSignetLockDep: {
+    outPoint: { txHash: '0xf1de59e973b85791ec32debbba08dff80c63197e895eb95d67fc1e9f6b413e00', index: '0x0' },
+    depType: 'code',
+  } as CKBComponents.CellDep,
+
+  RgbppSignetLockConfigDep: {
+    outPoint: { txHash: '0xf1de59e973b85791ec32debbba08dff80c63197e895eb95d67fc1e9f6b413e00', index: '0x1' },
+    depType: 'code',
+  } as CKBComponents.CellDep,
+
+  BtcTimeSignetLockScript: {
+    codeHash: '0x00cdf8fab0f8ac638758ebf5ea5e4052b1d71e8a77b9f43139718621f6849326',
+    hashType: 'type',
+    args: '',
+  } as CKBComponents.Script,
+
+  BtcTimeSignetLockDep: {
+    outPoint: { txHash: '0xde0f87878a97500f549418e5d46d2f7704c565a262aa17036c9c1c13ad638529', index: '0x0' },
+    depType: 'code',
+  } as CKBComponents.CellDep,
+
+  BtcTimeSignetLockConfigDep: {
+    outPoint: { txHash: '0xde0f87878a97500f549418e5d46d2f7704c565a262aa17036c9c1c13ad638529', index: '0x1' },
     depType: 'code',
   } as CKBComponents.CellDep,
 };
@@ -218,21 +253,46 @@ export const getXudtTypeScript = (isMainnet: boolean) =>
   isMainnet ? MainnetInfo.XUDTTypeScript : TestnetInfo.XUDTTypeScript;
 export const getXudtDep = (isMainnet: boolean) => (isMainnet ? MainnetInfo.XUDTTypeDep : TestnetInfo.XUDTTypeDep);
 
-export const getRgbppLockScript = (isMainnet: boolean) =>
-  isMainnet ? MainnetInfo.RgbppLockScript : TestnetInfo.RgbppLockScript;
-export const getRgbppLockDep = (isMainnet: boolean) =>
-  isMainnet ? MainnetInfo.RgbppLockDep : TestnetInfo.RgbppLockDep;
+export const getRgbppLockScript = (isMainnet: boolean, btcTestnetType?: BTCTestnetType) => {
+  if (isMainnet) {
+    return MainnetInfo.RgbppLockScript;
+  }
+  return btcTestnetType === 'Signet' ? TestnetInfo.RgbppSignetLockScript : TestnetInfo.RgbppLockScript;
+};
 
-export const getRgbppLockConfigDep = (isMainnet: boolean) =>
-  isMainnet ? MainnetInfo.RgbppLockConfigDep : TestnetInfo.RgbppLockConfigDep;
+export const getRgbppLockDep = (isMainnet: boolean, btcTestnetType?: BTCTestnetType) => {
+  if (isMainnet) {
+    return MainnetInfo.RgbppLockDep;
+  }
+  return btcTestnetType === 'Signet' ? TestnetInfo.RgbppSignetLockDep : TestnetInfo.RgbppLockDep;
+};
 
-export const getBtcTimeLockScript = (isMainnet: boolean) =>
-  isMainnet ? MainnetInfo.BtcTimeLockScript : TestnetInfo.BtcTimeLockScript;
-export const getBtcTimeLockDep = (isMainnet: boolean) =>
-  isMainnet ? MainnetInfo.BtcTimeLockDep : TestnetInfo.BtcTimeLockDep;
+export const getRgbppLockConfigDep = (isMainnet: boolean, btcTestnetType?: BTCTestnetType) => {
+  if (isMainnet) {
+    return MainnetInfo.RgbppLockConfigDep;
+  }
+  return btcTestnetType === 'Signet' ? TestnetInfo.RgbppSignetLockConfigDep : TestnetInfo.RgbppLockConfigDep;
+};
 
-export const getBtcTimeLockConfigDep = (isMainnet: boolean) =>
-  isMainnet ? MainnetInfo.BtcTimeLockConfigDep : TestnetInfo.BtcTimeLockConfigDep;
+export const getBtcTimeLockScript = (isMainnet: boolean, btcTestnetType?: BTCTestnetType) => {
+  if (isMainnet) {
+    return MainnetInfo.BtcTimeLockScript;
+  }
+  return btcTestnetType === 'Signet' ? TestnetInfo.BtcTimeSignetLockScript : TestnetInfo.BtcTimeLockScript;
+};
+export const getBtcTimeLockDep = (isMainnet: boolean, btcTestnetType?: BTCTestnetType) => {
+  if (isMainnet) {
+    return MainnetInfo.BtcTimeLockDep;
+  }
+  return btcTestnetType === 'Signet' ? TestnetInfo.BtcTimeSignetLockDep : TestnetInfo.BtcTimeLockDep;
+};
+
+export const getBtcTimeLockConfigDep = (isMainnet: boolean, btcTestnetType?: BTCTestnetType) => {
+  if (isMainnet) {
+    return MainnetInfo.BtcTimeLockConfigDep;
+  }
+  return btcTestnetType === 'Signet' ? TestnetInfo.BtcTimeSignetLockConfigDep : TestnetInfo.BtcTimeLockConfigDep;
+};
 
 export const getUniqueTypeScript = (isMainnet: boolean) =>
   isMainnet ? MainnetInfo.UniqueTypeScript : TestnetInfo.UniqueTypeScript;

--- a/packages/ckb/src/constants/index.ts
+++ b/packages/ckb/src/constants/index.ts
@@ -110,34 +110,34 @@ const TestnetInfo = {
 
   // The CKB testnet RGB++ deployment information for the BTC Signet network
   RgbppSignetLockScript: {
-    codeHash: '0x61ca7a4796a4eb19ca4f0d065cb9b10ddcf002f10f7cbb810c706cb6bb5c3248',
+    codeHash: '0xd07598deec7ce7b5665310386b4abd06a6d48843e953c5cc2112ad0d5a220364',
     hashType: 'type',
     args: '',
   } as CKBComponents.Script,
 
   RgbppSignetLockDep: {
-    outPoint: { txHash: '0xf1de59e973b85791ec32debbba08dff80c63197e895eb95d67fc1e9f6b413e00', index: '0x0' },
+    outPoint: { txHash: '0x61efdeddbaa0bb4132c0eb174b3e8002ff5ec430f61ba46f30768d683c516eec', index: '0x0' },
     depType: 'code',
   } as CKBComponents.CellDep,
 
   RgbppSignetLockConfigDep: {
-    outPoint: { txHash: '0xf1de59e973b85791ec32debbba08dff80c63197e895eb95d67fc1e9f6b413e00', index: '0x1' },
+    outPoint: { txHash: '0x61efdeddbaa0bb4132c0eb174b3e8002ff5ec430f61ba46f30768d683c516eec', index: '0x1' },
     depType: 'code',
   } as CKBComponents.CellDep,
 
   BtcTimeSignetLockScript: {
-    codeHash: '0x00cdf8fab0f8ac638758ebf5ea5e4052b1d71e8a77b9f43139718621f6849326',
+    codeHash: '0x80a09eca26d77cea1f5a69471c59481be7404febf40ee90f886c36a948385b55',
     hashType: 'type',
     args: '',
   } as CKBComponents.Script,
 
   BtcTimeSignetLockDep: {
-    outPoint: { txHash: '0xde0f87878a97500f549418e5d46d2f7704c565a262aa17036c9c1c13ad638529', index: '0x0' },
+    outPoint: { txHash: '0x5364b3535965e9eac9a35dd7af8e9e45a61d30a16e115923c032f80b28783e21', index: '0x0' },
     depType: 'code',
   } as CKBComponents.CellDep,
 
   BtcTimeSignetLockConfigDep: {
-    outPoint: { txHash: '0xde0f87878a97500f549418e5d46d2f7704c565a262aa17036c9c1c13ad638529', index: '0x1' },
+    outPoint: { txHash: '0x5364b3535965e9eac9a35dd7af8e9e45a61d30a16e115923c032f80b28783e21', index: '0x1' },
     depType: 'code',
   } as CKBComponents.CellDep,
 };

--- a/packages/ckb/src/rgbpp/btc-jump-ckb.ts
+++ b/packages/ckb/src/rgbpp/btc-jump-ckb.ts
@@ -99,7 +99,7 @@ export const genBtcJumpCkbVirtualTx = async ({
   // The BTC time cell does not need to be bound to the BTC UTXO
   const outputs: CKBComponents.CellOutput[] = [
     {
-      lock: genBtcTimeLockScript(toLock, isMainnet),
+      lock: genBtcTimeLockScript(toLock, isMainnet, btcTestnetType),
       type: xudtType,
       capacity: append0x(receiverOutputCapacity.toString(16)),
     },

--- a/packages/ckb/src/rgbpp/btc-jump-ckb.ts
+++ b/packages/ckb/src/rgbpp/btc-jump-ckb.ts
@@ -34,9 +34,9 @@ import { addressToScript, getTransactionSize } from '@nervosnetwork/ckb-sdk-util
  * @param rgbppLockArgsList The rgbpp assets cell lock script args array whose data structure is: out_index | bitcoin_tx_id
  * @param transferAmount The XUDT amount to be transferred
  * @param toCkbAddress The receiver ckb address
- * @param witnessLockPlaceholderSize The WitnessArgs.lock placeholder bytes array size and the default value is 5000
- * @param ckbFeeRate The CKB transaction fee rate, default value is 1100
- * @param isMainnet
+ * @param witnessLockPlaceholderSize(Optional) The WitnessArgs.lock placeholder bytes array size and the default value is 5000
+ * @param ckbFeeRate(Optional) The CKB transaction fee rate, default value is 1100
+ * @param btcTestnetType(Optional) The Bitcoin Testnet type including Testnet3 and Signet, default value is Testnet3
  */
 export const genBtcJumpCkbVirtualTx = async ({
   collector,
@@ -46,6 +46,7 @@ export const genBtcJumpCkbVirtualTx = async ({
   toCkbAddress,
   witnessLockPlaceholderSize,
   ckbFeeRate,
+  btcTestnetType,
 }: BtcJumpCkbVirtualTxParams): Promise<BtcJumpCkbVirtualTxResult> => {
   const isMainnet = toCkbAddress.startsWith('ckb');
   const xudtType = blockchain.Script.unpack(xudtTypeBytes) as CKBComponents.Script;
@@ -134,7 +135,7 @@ export const genBtcJumpCkbVirtualTx = async ({
     outputsData.push(otherRgbppCell.outputData);
   }
 
-  const cellDeps = await fetchTypeIdCellDeps(isMainnet, { rgbpp: true, xudt: true });
+  const cellDeps = await fetchTypeIdCellDeps(isMainnet, { rgbpp: true, xudt: true }, btcTestnetType);
   if (needPaymasterCell) {
     cellDeps.push(getSecp256k1CellDep(isMainnet));
   }

--- a/packages/ckb/src/rgbpp/btc-jump-ckb.ts
+++ b/packages/ckb/src/rgbpp/btc-jump-ckb.ts
@@ -57,7 +57,7 @@ export const genBtcJumpCkbVirtualTx = async ({
 
   const deduplicatedLockArgsList = deduplicateList(rgbppLockArgsList);
 
-  const rgbppLocks = deduplicatedLockArgsList.map((args) => genRgbppLockScript(args, isMainnet));
+  const rgbppLocks = deduplicatedLockArgsList.map((args) => genRgbppLockScript(args, isMainnet, btcTestnetType));
   let rgbppTargetCells: IndexerCell[] = [];
   let rgbppOtherTypeCells: IndexerCell[] = [];
   for await (const rgbppLock of rgbppLocks) {
@@ -113,7 +113,7 @@ export const genBtcJumpCkbVirtualTx = async ({
     const udtChangeCapacity = isCapacitySufficient ? sumInputsCapacity - receiverOutputCapacity : rgbppCellCapacity;
     outputs.push({
       // The Vouts[0] for OP_RETURN and Vouts[1] for RGBPP assets, BTC time cells don't need btc tx out_index
-      lock: genRgbppLockScript(buildPreLockArgs(1), isMainnet),
+      lock: genRgbppLockScript(buildPreLockArgs(1), isMainnet, btcTestnetType),
       type: xudtType,
       capacity: append0x(udtChangeCapacity.toString(16)),
     });
@@ -130,7 +130,7 @@ export const genBtcJumpCkbVirtualTx = async ({
     outputs.push({
       ...otherRgbppCell.output,
       // Vouts[targetRgbppOutputLen + 1], ..., Vouts[targetRgbppOutputLen + rgbppOtherTypeCells.length] for other RGBPP assets
-      lock: genRgbppLockScript(buildPreLockArgs(targetRgbppOutputLen + index + 1), isMainnet),
+      lock: genRgbppLockScript(buildPreLockArgs(targetRgbppOutputLen + index + 1), isMainnet, btcTestnetType),
     });
     outputsData.push(otherRgbppCell.outputData);
   }

--- a/packages/ckb/src/rgbpp/btc-time.ts
+++ b/packages/ckb/src/rgbpp/btc-time.ts
@@ -116,6 +116,7 @@ export const buildBtcTimeCellsSpentTx = async ({
  * @param masterCkbAddress The master CKB address
  * @param outputCapacityRange(Optional) [u64; 2], filter cells by output capacity range, [inclusive, exclusive]
  * @param ckbFeeRate(Optional) The CKB transaction fee rate, default value is 1100
+ * @param isMainnet True is for BTC and CKB Mainnet, flase is for BTC and CKB Testnet
  */
 export const signBtcTimeCellSpentTx = async ({
   secp256k1PrivateKey,
@@ -158,7 +159,6 @@ export const signBtcTimeCellSpentTx = async ({
 
   const keyMap = new Map<string, string>();
   keyMap.set(scriptToHash(masterLock), secp256k1PrivateKey);
-  keyMap.set(scriptToHash(getBtcTimeLockScript(isMainnet)), '');
 
   const cells = rawTx.inputs.map((input, index) => ({
     outPoint: input.previousOutput,
@@ -193,11 +193,12 @@ export const isBtcTimeCellsSpent = async ({
   collector,
   ckbAddress,
   btcTxId,
+  btcTestnetType,
 }: BtcTimeCellStatusParams): Promise<boolean> => {
   const isMainnet = ckbAddress.startsWith('ckb');
   const lock = addressToScript(ckbAddress);
   const btcTimeLock: CKBComponents.Script = {
-    ...getBtcTimeLockScript(isMainnet),
+    ...getBtcTimeLockScript(isMainnet, btcTestnetType),
     args: genBtcTimeLockArgs(lock, btcTxId, BTC_JUMP_CONFIRMATION_BLOCKS),
   };
   const btcTimeCells = await collector.getCells({ lock: btcTimeLock, isDataMustBeEmpty: false });

--- a/packages/ckb/src/rgbpp/btc-time.ts
+++ b/packages/ckb/src/rgbpp/btc-time.ts
@@ -39,12 +39,14 @@ export const buildBtcTimeUnlockWitness = (btcTxProof: Hex): Hex => {
  * The btc time lock args data structure is: lock_script | after | new_bitcoin_tx_id
  * @param btcTimeCells The BTC time cells of xUDT
  * @param btcAssetsApi BTC Assets Api
- * @param isMainnet
+ * @param isMainnet True is for BTC and CKB Mainnet, flase is for BTC and CKB Testnet(see btcTestnetType for details about BTC Testnet)
+ * @param btcTestnetType(Optional) The Bitcoin Testnet type including Testnet3 and Signet, default value is Testnet3
  */
 export const buildBtcTimeCellsSpentTx = async ({
   btcTimeCells,
   btcAssetsApi,
   isMainnet,
+  btcTestnetType,
 }: BtcTimeCellsParams): Promise<CKBComponents.RawTransaction> => {
   const sortedBtcTimeCells = btcTimeCells.sort(compareInputs);
   const inputs: CKBComponents.CellInput[] = sortedBtcTimeCells.map((cell) => ({
@@ -60,7 +62,11 @@ export const buildBtcTimeCellsSpentTx = async ({
 
   const outputsData = sortedBtcTimeCells.map((cell) => cell.outputData);
 
-  const cellDeps: CKBComponents.CellDep[] = await fetchTypeIdCellDeps(isMainnet, { btcTime: true, xudt: true });
+  const cellDeps: CKBComponents.CellDep[] = await fetchTypeIdCellDeps(
+    isMainnet,
+    { btcTime: true, xudt: true },
+    btcTestnetType,
+  );
 
   const witnesses: Hex[] = [];
 
@@ -108,9 +114,8 @@ export const buildBtcTimeCellsSpentTx = async ({
  * @param ckbRawTx The CKB raw transaction to be signed
  * @param collector The collector that collects CKB live cells and transactions
  * @param masterCkbAddress The master CKB address
- * @param outputCapacityRange [u64; 2], filter cells by output capacity range, [inclusive, exclusive]
- * @param ckbFeeRate The CKB transaction fee rate, default value is 1100
- * @param isMainnet
+ * @param outputCapacityRange(Optional) [u64; 2], filter cells by output capacity range, [inclusive, exclusive]
+ * @param ckbFeeRate(Optional) The CKB transaction fee rate, default value is 1100
  */
 export const signBtcTimeCellSpentTx = async ({
   secp256k1PrivateKey,

--- a/packages/ckb/src/rgbpp/btc-transfer.ts
+++ b/packages/ckb/src/rgbpp/btc-transfer.ts
@@ -52,10 +52,11 @@ import signWitnesses from '@nervosnetwork/ckb-sdk-core/lib/signWitnesses';
  * @param xudtTypeBytes The serialized hex string of the XUDT type script
  * @param rgbppLockArgsList The rgbpp assets cell lock script args array whose data structure is: out_index | bitcoin_tx_id
  * @param transferAmount The XUDT amount to be transferred, if the noMergeOutputCells is true, the transferAmount will be ignored
- * @param isMainnet
- * @param noMergeOutputCells The noMergeOutputCells indicates whether the CKB outputs need to be merged. By default, the outputs will be merged.
- * @param witnessLockPlaceholderSize The WitnessArgs.lock placeholder bytes array size and the default value is 5000
- * @param ckbFeeRate The CKB transaction fee rate, default value is 1100
+ * @param isMainnet True is for BTC and CKB Mainnet, flase is for BTC and CKB Testnet(see btcTestnetType for details about BTC Testnet)
+ * @param noMergeOutputCells(Optional) The noMergeOutputCells indicates whether the CKB outputs need to be merged. By default, the outputs will be merged.
+ * @param witnessLockPlaceholderSize(Optional) The WitnessArgs.lock placeholder bytes array size and the default value is 5000
+ * @param ckbFeeRate(Optional) The CKB transaction fee rate, default value is 1100
+ * @param btcTestnetType(Optional) The Bitcoin Testnet type including Testnet3 and Signet, default value is Testnet3
  */
 export const genBtcTransferCkbVirtualTx = async ({
   collector,
@@ -66,6 +67,7 @@ export const genBtcTransferCkbVirtualTx = async ({
   noMergeOutputCells,
   witnessLockPlaceholderSize,
   ckbFeeRate,
+  btcTestnetType,
 }: BtcTransferVirtualTxParams): Promise<BtcTransferVirtualTxResult> => {
   const xudtType = blockchain.Script.unpack(xudtTypeBytes) as CKBComponents.Script;
 
@@ -170,7 +172,7 @@ export const genBtcTransferCkbVirtualTx = async ({
     handleNonTargetRgbppCells(outputs.length);
   }
 
-  const cellDeps = await fetchTypeIdCellDeps(isMainnet, { rgbpp: true, xudt: true });
+  const cellDeps = await fetchTypeIdCellDeps(isMainnet, { rgbpp: true, xudt: true }, btcTestnetType);
   if (needPaymasterCell) {
     cellDeps.push(getSecp256k1CellDep(isMainnet));
   }
@@ -224,7 +226,8 @@ export const genBtcTransferCkbVirtualTx = async ({
  * @param xudtTypeBytes The serialized hex string of the XUDT type script
  * @param rgbppLockArgsList The rgbpp assets cell lock script args array whose data structure is: out_index | bitcoin_tx_id
  * @param rgbppReceivers The rgbpp receiver list which include toBtcAddress and transferAmount
- * @param isMainnet
+ * @param isMainnet True is for BTC and CKB Mainnet, flase is for BTC and CKB Testnet(see btcTestnetType for details about BTC Testnet)
+ * @param btcTestnetType(Optional) The Bitcoin Testnet type including Testnet3 and Signet, default value is Testnet3
  */
 export const genBtcBatchTransferCkbVirtualTx = async ({
   collector,
@@ -232,6 +235,7 @@ export const genBtcBatchTransferCkbVirtualTx = async ({
   rgbppLockArgsList,
   rgbppReceivers,
   isMainnet,
+  btcTestnetType,
 }: BtcBatchTransferVirtualTxParams): Promise<BtcBatchTransferVirtualTxResult> => {
   const xudtType = blockchain.Script.unpack(xudtTypeBytes) as CKBComponents.Script;
 
@@ -285,7 +289,7 @@ export const genBtcBatchTransferCkbVirtualTx = async ({
   }
 
   const cellDeps = [
-    ...(await fetchTypeIdCellDeps(isMainnet, { rgbpp: true, xudt: true })),
+    ...(await fetchTypeIdCellDeps(isMainnet, { rgbpp: true, xudt: true }, btcTestnetType)),
     getSecp256k1CellDep(isMainnet),
   ];
   const witnesses: Hex[] = [];
@@ -330,6 +334,7 @@ export const genBtcBatchTransferCkbVirtualTx = async ({
  * @param collector The collector that collects CKB live cells and transactions
  * @param ckbRawTx CKB raw transaction
  * @param sumInputsCapacity The sum capacity of ckb inputs which is to be used to calculate ckb tx fee
+ * @param isMainnet True is for BTC and CKB Mainnet, flase is for BTC and CKB Testnet
  * @param ckbFeeRate The CKB transaction fee rate, default value is 1100
  */
 export const appendIssuerCellToBtcBatchTransfer = async ({

--- a/packages/ckb/src/rgbpp/ckb-builder.ts
+++ b/packages/ckb/src/rgbpp/ckb-builder.ts
@@ -154,7 +154,7 @@ export const sendCkbTx = async ({ collector, signedTx }: SendCkbTxParams) => {
  * Replace the RGBPP_TX_ID_PLACEHOLDER with the real btc tx id of the rgbpp lock args and BTC time lock args
  * @param ckbRawTx CKB raw transaction
  * @param btcTxId The BTC transaction id
- * @param isMainnet
+ * @param isMainnet True is for BTC and CKB Mainnet, flase is for BTC and CKB Testnet
  */
 export const updateCkbTxWithRealBtcTxId = ({
   ckbRawTx,

--- a/packages/ckb/src/rgbpp/ckb-jump-btc.ts
+++ b/packages/ckb/src/rgbpp/ckb-jump-btc.ts
@@ -21,8 +21,9 @@ import { addressToScript, getTransactionSize } from '@nervosnetwork/ckb-sdk-util
  * @param fromCkbAddress The from ckb address who will use his private key to sign the ckb tx
  * @param toRgbppLockArgs The receiver rgbpp lock script args whose data structure is: out_index | bitcoin_tx_id
  * @param transferAmount The XUDT amount to be transferred
- * @param witnessLockPlaceholderSize The WitnessArgs.lock placeholder bytes array size and the default value is 5000
- * @param ckbFeeRate The CKB transaction fee rate, default value is 1100
+ * @param witnessLockPlaceholderSize(Optional)  The WitnessArgs.lock placeholder bytes array size and the default value is 5000
+ * @param ckbFeeRate(Optional)  The CKB transaction fee rate, default value is 1100
+ * @param btcTestnetType(Optional)  The Bitcoin Testnet type including Testnet3 and Signet, default value is Testnet3
  */
 export const genCkbJumpBtcVirtualTx = async ({
   collector,
@@ -32,6 +33,7 @@ export const genCkbJumpBtcVirtualTx = async ({
   transferAmount,
   witnessLockPlaceholderSize,
   ckbFeeRate,
+  btcTestnetType,
 }: CkbJumpBtcVirtualTxParams): Promise<CKBComponents.RawTransaction> => {
   const isMainnet = fromCkbAddress.startsWith('ckb');
   const xudtType = blockchain.Script.unpack(xudtTypeBytes) as CKBComponents.Script;
@@ -59,7 +61,7 @@ export const genCkbJumpBtcVirtualTx = async ({
 
   const outputs: CKBComponents.CellOutput[] = [
     {
-      lock: genRgbppLockScript(toRgbppLockArgs, isMainnet),
+      lock: genRgbppLockScript(toRgbppLockArgs, isMainnet, btcTestnetType),
       type: xudtType,
       capacity: append0x(rpbppCellCapacity.toString(16)),
     },
@@ -137,6 +139,7 @@ export const genCkbBatchJumpBtcVirtualTx = async ({
   rgbppReceivers,
   witnessLockPlaceholderSize,
   ckbFeeRate,
+  btcTestnetType,
 }: CkbBatchJumpBtcVirtualTxParams): Promise<CKBComponents.RawTransaction> => {
   const isMainnet = fromCkbAddress.startsWith('ckb');
   const xudtType = blockchain.Script.unpack(xudtTypeBytes) as CKBComponents.Script;
@@ -166,7 +169,7 @@ export const genCkbBatchJumpBtcVirtualTx = async ({
   const rpbppCellCapacity = calculateRgbppCellCapacity(xudtType);
   const sumRgbppCellCapacity = rpbppCellCapacity * BigInt(rgbppReceivers.length);
   const outputs: CKBComponents.CellOutput[] = rgbppReceivers.map((receiver) => ({
-    lock: genRgbppLockScript(receiver.toRgbppLockArgs, isMainnet),
+    lock: genRgbppLockScript(receiver.toRgbppLockArgs, isMainnet, btcTestnetType),
     type: xudtType,
     capacity: append0x(rpbppCellCapacity.toString(16)),
   }));

--- a/packages/ckb/src/rgbpp/ckb-jump-btc.ts
+++ b/packages/ckb/src/rgbpp/ckb-jump-btc.ts
@@ -131,6 +131,7 @@ export const genCkbJumpBtcVirtualTx = async ({
  * @param rgbppReceivers The rgbpp receiver list which include toRgbppLockArgs and transferAmount
  * @param witnessLockPlaceholderSize The WitnessArgs.lock placeholder bytes array size and the default value is 5000
  * @param ckbFeeRate The CKB transaction fee rate, default value is 1100
+ * @param btcTestnetType(Optional) The Bitcoin Testnet type including Testnet3 and Signet, default value is Testnet3
  */
 export const genCkbBatchJumpBtcVirtualTx = async ({
   collector,

--- a/packages/ckb/src/rgbpp/ckb-jump-btc.ts
+++ b/packages/ckb/src/rgbpp/ckb-jump-btc.ts
@@ -23,7 +23,6 @@ import { addressToScript, getTransactionSize } from '@nervosnetwork/ckb-sdk-util
  * @param transferAmount The XUDT amount to be transferred
  * @param witnessLockPlaceholderSize The WitnessArgs.lock placeholder bytes array size and the default value is 5000
  * @param ckbFeeRate The CKB transaction fee rate, default value is 1100
- * @param isMainnet
  */
 export const genCkbJumpBtcVirtualTx = async ({
   collector,
@@ -130,7 +129,6 @@ export const genCkbJumpBtcVirtualTx = async ({
  * @param rgbppReceivers The rgbpp receiver list which include toRgbppLockArgs and transferAmount
  * @param witnessLockPlaceholderSize The WitnessArgs.lock placeholder bytes array size and the default value is 5000
  * @param ckbFeeRate The CKB transaction fee rate, default value is 1100
- * @param isMainnet
  */
 export const genCkbBatchJumpBtcVirtualTx = async ({
   collector,

--- a/packages/ckb/src/rgbpp/ckb-jump-btc.ts
+++ b/packages/ckb/src/rgbpp/ckb-jump-btc.ts
@@ -129,8 +129,8 @@ export const genCkbJumpBtcVirtualTx = async ({
  * @param xudtTypeBytes The serialized hex string of the XUDT type script
  * @param fromCkbAddress The from ckb address who will use his private key to sign the ckb tx
  * @param rgbppReceivers The rgbpp receiver list which include toRgbppLockArgs and transferAmount
- * @param witnessLockPlaceholderSize The WitnessArgs.lock placeholder bytes array size and the default value is 5000
- * @param ckbFeeRate The CKB transaction fee rate, default value is 1100
+ * @param witnessLockPlaceholderSize(Optional)  The WitnessArgs.lock placeholder bytes array size and the default value is 5000
+ * @param ckbFeeRate(Optional)  The CKB transaction fee rate, default value is 1100
  * @param btcTestnetType(Optional) The Bitcoin Testnet type including Testnet3 and Signet, default value is Testnet3
  */
 export const genCkbBatchJumpBtcVirtualTx = async ({

--- a/packages/ckb/src/rgbpp/launch.ts
+++ b/packages/ckb/src/rgbpp/launch.ts
@@ -47,7 +47,7 @@ export const genRgbppLaunchCkbVirtualTx = async ({
   isMainnet,
   btcTestnetType,
 }: RgbppLaunchCkbVirtualTxParams): Promise<RgbppLaunchVirtualTxResult> => {
-  const ownerLock = genRgbppLockScript(ownerRgbppLockArgs, isMainnet);
+  const ownerLock = genRgbppLockScript(ownerRgbppLockArgs, isMainnet, btcTestnetType);
   let emptyCells = await collector.getCells({ lock: ownerLock });
   if (!emptyCells || emptyCells.length === 0) {
     throw new NoLiveCellError('The owner address has no empty cells');
@@ -61,7 +61,7 @@ export const genRgbppLaunchCkbVirtualTx = async ({
   let rgbppCellCapacity = sumInputsCapacity - infoCellCapacity;
   const outputs: CKBComponents.CellOutput[] = [
     {
-      lock: genRgbppLockScript(buildPreLockArgs(1), isMainnet),
+      lock: genRgbppLockScript(buildPreLockArgs(1), isMainnet, btcTestnetType),
       type: {
         ...getXudtTypeScript(isMainnet),
         args: append0x(scriptToHash(ownerLock)),

--- a/packages/ckb/src/rgbpp/launch.ts
+++ b/packages/ckb/src/rgbpp/launch.ts
@@ -69,7 +69,7 @@ export const genRgbppLaunchCkbVirtualTx = async ({
       capacity: append0x(rgbppCellCapacity.toString(16)),
     },
     {
-      lock: genBtcTimeLockScript(UNLOCKABLE_LOCK_SCRIPT, isMainnet),
+      lock: genBtcTimeLockScript(UNLOCKABLE_LOCK_SCRIPT, isMainnet, btcTestnetType),
       type: {
         ...getUniqueTypeScript(isMainnet),
         args: generateUniqueTypeArgs(inputs[0], 1),

--- a/packages/ckb/src/rgbpp/launch.ts
+++ b/packages/ckb/src/rgbpp/launch.ts
@@ -32,9 +32,10 @@ import { getTransactionSize, scriptToHash } from '@nervosnetwork/ckb-sdk-utils';
  * @param ownerRgbppLockArgs The owner RGBPP lock args whose data structure is: out_index | bitcoin_tx_id
  * @param launchAmount The total amount of RGBPP assets issued
  * @param rgbppTokenInfo The RGBPP token info https://github.com/ckb-cell/unique-cell?tab=readme-ov-file#xudt-information
- * @param witnessLockPlaceholderSize The WitnessArgs.lock placeholder bytes array size and the default value is 5000
- * @param ckbFeeRate The CKB transaction fee rate, default value is 1100
- * @param isMainnet
+ * @param isMainnet True is for BTC and CKB Mainnet, flase is for BTC and CKB Testnet(see btcTestnetType for details about BTC Testnet)
+ * @param witnessLockPlaceholderSize(Optional) The WitnessArgs.lock placeholder bytes array size and the default value is 5000
+ * @param ckbFeeRate(Optional) The CKB transaction fee rate, default value is 1100
+ * @param btcTestnetType(Optional) The Bitcoin Testnet type including Testnet3 and Signet, default value is Testnet3
  */
 export const genRgbppLaunchCkbVirtualTx = async ({
   collector,
@@ -44,6 +45,7 @@ export const genRgbppLaunchCkbVirtualTx = async ({
   witnessLockPlaceholderSize,
   ckbFeeRate,
   isMainnet,
+  btcTestnetType,
 }: RgbppLaunchCkbVirtualTxParams): Promise<RgbppLaunchVirtualTxResult> => {
   const ownerLock = genRgbppLockScript(ownerRgbppLockArgs, isMainnet);
   let emptyCells = await collector.getCells({ lock: ownerLock });
@@ -77,7 +79,7 @@ export const genRgbppLaunchCkbVirtualTx = async ({
   ];
 
   const outputsData = [append0x(u128ToLe(launchAmount)), encodeRgbppTokenInfo(rgbppTokenInfo)];
-  const cellDeps = await fetchTypeIdCellDeps(isMainnet, { rgbpp: true, xudt: true, unique: true });
+  const cellDeps = await fetchTypeIdCellDeps(isMainnet, { rgbpp: true, xudt: true, unique: true }, btcTestnetType);
 
   const witnesses: Hex[] = inputs.map((_, index) => (index === 0 ? RGBPP_WITNESS_PLACEHOLDER : '0x'));
 

--- a/packages/ckb/src/spore/cluster.ts
+++ b/packages/ckb/src/spore/cluster.ts
@@ -19,8 +19,10 @@ import { bytesToHex, getTransactionSize } from '@nervosnetwork/ckb-sdk-utils';
  * @param collector The collector that collects CKB live cells and transactions
  * @param rgbppLockArgs The rgbpp assets cell lock script args whose data structure is: out_index | bitcoin_tx_id
  * @param clusterData The cluster's data, including name and description.
- * @param witnessLockPlaceholderSize The WitnessArgs.lock placeholder bytes array size and the default value is 5000
- * @param ckbFeeRate The CKB transaction fee rate, default value is 1100
+ * @param isMainnet True is for BTC and CKB Mainnet, flase is for BTC and CKB Testnet(see btcTestnetType for details about BTC Testnet)
+ * @param witnessLockPlaceholderSize(Optional) The WitnessArgs.lock placeholder bytes array size and the default value is 5000
+ * @param ckbFeeRate(Optional) The CKB transaction fee rate, default value is 1100
+ * @param btcTestnetType(Optional) The Bitcoin Testnet type including Testnet3 and Signet, default value is Testnet3
  */
 export const genCreateClusterCkbVirtualTx = async ({
   collector,
@@ -29,6 +31,7 @@ export const genCreateClusterCkbVirtualTx = async ({
   isMainnet,
   witnessLockPlaceholderSize,
   ckbFeeRate,
+  btcTestnetType,
 }: CreateClusterCkbVirtualTxParams): Promise<SporeVirtualTxResult> => {
   const rgbppLock = {
     ...getRgbppLockScript(isMainnet),
@@ -60,7 +63,10 @@ export const genCreateClusterCkbVirtualTx = async ({
     },
   ];
   const outputsData: Hex[] = [bytesToHex(packRawClusterData(clusterData))];
-  const cellDeps = [...(await fetchTypeIdCellDeps(isMainnet, { rgbpp: true })), getClusterTypeDep(isMainnet)];
+  const cellDeps = [
+    ...(await fetchTypeIdCellDeps(isMainnet, { rgbpp: true }, btcTestnetType)),
+    getClusterTypeDep(isMainnet),
+  ];
   const sporeCoBuild = generateClusterCreateCoBuild(outputs[0], outputsData[0]);
   const witnesses = [RGBPP_WITNESS_PLACEHOLDER, sporeCoBuild];
 

--- a/packages/ckb/src/spore/cluster.ts
+++ b/packages/ckb/src/spore/cluster.ts
@@ -8,7 +8,6 @@ import {
   RGBPP_WITNESS_PLACEHOLDER,
   getClusterTypeDep,
   getClusterTypeScript,
-  getRgbppLockScript,
 } from '../constants';
 import { generateClusterCreateCoBuild, generateClusterId } from '../utils/spore';
 import { NoRgbppLiveCellError } from '../error';
@@ -33,10 +32,7 @@ export const genCreateClusterCkbVirtualTx = async ({
   ckbFeeRate,
   btcTestnetType,
 }: CreateClusterCkbVirtualTxParams): Promise<SporeVirtualTxResult> => {
-  const rgbppLock = {
-    ...getRgbppLockScript(isMainnet),
-    args: append0x(rgbppLockArgs),
-  };
+  const rgbppLock = genRgbppLockScript(rgbppLockArgs, isMainnet, btcTestnetType);
   const rgbppCells = await collector.getCells({ lock: rgbppLock });
   if (!rgbppCells || rgbppCells.length === 0) {
     throw new NoRgbppLiveCellError('No rgbpp cells found with the rgbpp lock args');
@@ -55,7 +51,7 @@ export const genCreateClusterCkbVirtualTx = async ({
     {
       ...rgbppCell.output,
       // The BTC transaction Vouts[0] for OP_RETURN, Vouts[1] for cluster
-      lock: genRgbppLockScript(buildPreLockArgs(1), isMainnet),
+      lock: genRgbppLockScript(buildPreLockArgs(1), isMainnet, btcTestnetType),
       type: {
         ...getClusterTypeScript(isMainnet),
         args: clusterId,

--- a/packages/ckb/src/spore/leap.ts
+++ b/packages/ckb/src/spore/leap.ts
@@ -39,8 +39,10 @@ import { buildBtcTimeUnlockWitness } from '../rgbpp';
  * @param sporeRgbppLockArgs The spore rgbpp cell lock script args whose data structure is: out_index | bitcoin_tx_id
  * @param sporeTypeBytes The spore type script serialized bytes
  * @param toCkbAddress The receiver ckb address
- * @param witnessLockPlaceholderSize The WitnessArgs.lock placeholder bytes array size and the default value is 5000
- * @param ckbFeeRate The CKB transaction fee rate, default value is 1100
+ * @param isMainnet True is for BTC and CKB Mainnet, flase is for BTC and CKB Testnet(see btcTestnetType for details about BTC Testnet)
+ * @param witnessLockPlaceholderSize(Optional) The WitnessArgs.lock placeholder bytes array size and the default value is 5000
+ * @param ckbFeeRate(Optional) The CKB transaction fee rate, default value is 1100
+ * @param btcTestnetType(Optional) The Bitcoin Testnet type including Testnet3 and Signet, default value is Testnet3
  */
 export const genLeapSporeFromBtcToCkbVirtualTx = async ({
   collector,
@@ -50,6 +52,7 @@ export const genLeapSporeFromBtcToCkbVirtualTx = async ({
   isMainnet,
   witnessLockPlaceholderSize,
   ckbFeeRate,
+  btcTestnetType,
 }: LeapSporeFromBtcToCkbVirtualTxParams): Promise<SporeLeapVirtualTxResult> => {
   const sporeRgbppLock = {
     ...getRgbppLockScript(isMainnet),
@@ -76,7 +79,10 @@ export const genLeapSporeFromBtcToCkbVirtualTx = async ({
     },
   ];
   const outputsData: Hex[] = [sporeCell.outputData];
-  const cellDeps = [...(await fetchTypeIdCellDeps(isMainnet, { rgbpp: true })), getSporeTypeDep(isMainnet)];
+  const cellDeps = [
+    ...(await fetchTypeIdCellDeps(isMainnet, { rgbpp: true }, btcTestnetType)),
+    getSporeTypeDep(isMainnet),
+  ];
   const sporeCoBuild = generateSporeTransferCoBuild([sporeCell], outputs);
   const witnesses = [RGBPP_WITNESS_PLACEHOLDER, sporeCoBuild];
 
@@ -116,12 +122,14 @@ export const genLeapSporeFromBtcToCkbVirtualTx = async ({
  * The btc time lock args data structure is: lock_script | after | new_bitcoin_tx_id
  * @param btcTimeCells The BTC time cells of spore
  * @param btcAssetsApi BTC Assets Api
- * @param isMainnet
+ * @param isMainnet True is for BTC and CKB Mainnet, flase is for BTC and CKB Testnet(see btcTestnetType for details about BTC Testnet)
+ * @param btcTestnetType(Optional) The Bitcoin Testnet type including Testnet3 and Signet, default value is Testnet3
  */
 export const buildSporeBtcTimeCellsSpentTx = async ({
   btcTimeCells,
   btcAssetsApi,
   isMainnet,
+  btcTestnetType,
 }: BtcTimeCellsParams): Promise<CKBComponents.RawTransaction> => {
   const sortedBtcTimeCells = btcTimeCells.sort(compareInputs);
   const inputs: CKBComponents.CellInput[] = sortedBtcTimeCells.map((cell) => ({
@@ -138,7 +146,7 @@ export const buildSporeBtcTimeCellsSpentTx = async ({
   const outputsData = sortedBtcTimeCells.map((cell) => cell.outputData);
 
   const cellDeps: CKBComponents.CellDep[] = [
-    ...(await fetchTypeIdCellDeps(isMainnet, { btcTime: true })),
+    ...(await fetchTypeIdCellDeps(isMainnet, { btcTime: true }, btcTestnetType)),
     getSporeTypeDep(isMainnet),
   ];
 
@@ -191,8 +199,9 @@ export const buildSporeBtcTimeCellsSpentTx = async ({
  * @param sporeRgbppLockArgs The spore rgbpp cell lock script args whose data structure is: out_index | bitcoin_tx_id
  * @param sporeTypeBytes The spore type script serialized bytes
  * @param toCkbAddress The receiver ckb address
- * @param witnessLockPlaceholderSize The WitnessArgs.lock placeholder bytes array size and the default value is 5000
- * @param ckbFeeRate The CKB transaction fee rate, default value is 1100
+ * @param isMainnet True is for BTC and CKB Mainnet, flase is for BTC and CKB Testnet
+ * @param witnessLockPlaceholderSize(Optional) The WitnessArgs.lock placeholder bytes array size and the default value is 5000
+ * @param ckbFeeRate(Optional) The CKB transaction fee rate, default value is 1100
  */
 export const genLeapSporeFromCkbToBtcRawTx = async ({
   collector,
@@ -228,7 +237,7 @@ export const genLeapSporeFromCkbToBtcRawTx = async ({
     },
   ];
   const outputsData: Hex[] = [sporeCell.outputData];
-  const cellDeps = [...(await fetchTypeIdCellDeps(isMainnet, { rgbpp: true })), getSporeTypeDep(isMainnet)];
+  const cellDeps = [getSporeTypeDep(isMainnet)];
   const sporeCoBuild = generateSporeTransferCoBuild([sporeCell], outputs);
   const witnesses = [RGBPP_WITNESS_PLACEHOLDER, sporeCoBuild];
 

--- a/packages/ckb/src/spore/leap.ts
+++ b/packages/ckb/src/spore/leap.ts
@@ -75,7 +75,7 @@ export const genLeapSporeFromBtcToCkbVirtualTx = async ({
   const outputs: CKBComponents.CellOutput[] = [
     {
       ...sporeCell.output,
-      lock: genBtcTimeLockScript(toLock, isMainnet),
+      lock: genBtcTimeLockScript(toLock, isMainnet, btcTestnetType),
     },
   ];
   const outputsData: Hex[] = [sporeCell.outputData];

--- a/packages/ckb/src/spore/leap.ts
+++ b/packages/ckb/src/spore/leap.ts
@@ -55,7 +55,7 @@ export const genLeapSporeFromBtcToCkbVirtualTx = async ({
   btcTestnetType,
 }: LeapSporeFromBtcToCkbVirtualTxParams): Promise<SporeLeapVirtualTxResult> => {
   const sporeRgbppLock = {
-    ...getRgbppLockScript(isMainnet),
+    ...getRgbppLockScript(isMainnet, btcTestnetType),
     args: append0x(sporeRgbppLockArgs),
   };
   const sporeCells = await collector.getCells({ lock: sporeRgbppLock, isDataMustBeEmpty: false });
@@ -211,6 +211,7 @@ export const genLeapSporeFromCkbToBtcRawTx = async ({
   isMainnet,
   witnessLockPlaceholderSize,
   ckbFeeRate,
+  btcTestnetType,
 }: LeapSporeFromCkbToBtcVirtualTxParams): Promise<CKBComponents.RawTransaction> => {
   const fromLock = addressToScript(fromCkbAddress);
   const sporeType = blockchain.Script.unpack(sporeTypeBytes) as CKBComponents.Script;
@@ -231,7 +232,7 @@ export const genLeapSporeFromCkbToBtcRawTx = async ({
     {
       ...sporeCell.output,
       lock: {
-        ...getRgbppLockScript(isMainnet),
+        ...getRgbppLockScript(isMainnet, btcTestnetType),
         args: append0x(toRgbppLockArgs),
       },
     },

--- a/packages/ckb/src/spore/spore.ts
+++ b/packages/ckb/src/spore/spore.ts
@@ -66,10 +66,7 @@ export const genCreateSporeCkbVirtualTx = async ({
   isMainnet,
   btcTestnetType,
 }: CreateSporeCkbVirtualTxParams): Promise<SporeCreateVirtualTxResult> => {
-  const clusterRgbppLock = {
-    ...getRgbppLockScript(isMainnet),
-    args: append0x(clusterRgbppLockArgs),
-  };
+  const clusterRgbppLock = genRgbppLockScript(clusterRgbppLockArgs, isMainnet, btcTestnetType);
   const clusterCells = await collector.getCells({ lock: clusterRgbppLock, isDataMustBeEmpty: false });
   if (!clusterCells || clusterCells.length === 0) {
     throw new NoRgbppLiveCellError('No cluster rgbpp cells found with the cluster rgbpp lock args');
@@ -99,7 +96,7 @@ export const genCreateSporeCkbVirtualTx = async ({
 
   const sporeOutputs = sporeDataList.map((data, index) => ({
     // The BTC transaction Vouts[0] for OP_RETURN, Vouts[1] for cluster and Vouts[2]... for spore
-    lock: genRgbppLockScript(buildPreLockArgs(index + 2), isMainnet),
+    lock: genRgbppLockScript(buildPreLockArgs(index + 2), isMainnet, btcTestnetType),
     type: {
       ...getSporeTypeScript(isMainnet),
       // The CKB transaction outputs[0] fro cluster and outputs[1]... for spore
@@ -113,7 +110,7 @@ export const genCreateSporeCkbVirtualTx = async ({
     {
       ...clusterCell.output,
       // The BTC transaction Vouts[0] for OP_RETURN, Vouts[1] for cluster
-      lock: genRgbppLockScript(buildPreLockArgs(1), isMainnet),
+      lock: genRgbppLockScript(buildPreLockArgs(1), isMainnet, btcTestnetType),
     },
     ...sporeOutputs,
   ];
@@ -248,7 +245,6 @@ export const appendIssuerCellToSporesCreate = async ({
 
   const keyMap = new Map<string, string>();
   keyMap.set(scriptToHash(issuerLock), secp256k1PrivateKey);
-  keyMap.set(scriptToHash(getRgbppLockScript(isMainnet)), '');
 
   const issuerCellIndex = rgbppInputsLength;
   const cells = rawTx.inputs.map((input, index) => ({
@@ -303,10 +299,7 @@ export const genTransferSporeCkbVirtualTx = async ({
   ckbFeeRate,
   btcTestnetType,
 }: TransferSporeCkbVirtualTxParams): Promise<SporeTransferVirtualTxResult> => {
-  const sporeRgbppLock = {
-    ...getRgbppLockScript(isMainnet),
-    args: append0x(sporeRgbppLockArgs),
-  };
+  const sporeRgbppLock = genRgbppLockScript(sporeRgbppLockArgs, isMainnet, btcTestnetType);
   const sporeCells = await collector.getCells({ lock: sporeRgbppLock, isDataMustBeEmpty: false });
 
   throwErrorWhenSporeCellsInvalid(sporeCells, sporeTypeBytes, isMainnet);
@@ -324,7 +317,7 @@ export const genTransferSporeCkbVirtualTx = async ({
     {
       ...sporeCell.output,
       // The BTC transaction Vouts[0] for OP_RETURN, Vouts[1] for spore
-      lock: genRgbppLockScript(buildPreLockArgs(1), isMainnet),
+      lock: genRgbppLockScript(buildPreLockArgs(1), isMainnet, btcTestnetType),
     },
   ];
   const outputsData: Hex[] = [sporeCell.outputData];

--- a/packages/ckb/src/spore/spore.ts
+++ b/packages/ckb/src/spore/spore.ts
@@ -56,12 +56,15 @@ import signWitnesses from '@nervosnetwork/ckb-sdk-core/lib/signWitnesses';
  * @param collector The collector that collects CKB live cells and transactions
  * @param clusterRgbppLockArgs The cluster rgbpp cell lock script args whose data structure is: out_index | bitcoin_tx_id
  * @param sporeDataList The spore's data list, including name and description.
+ * @param isMainnet True is for BTC and CKB Mainnet, flase is for BTC and CKB Testnet(see btcTestnetType for details about BTC Testnet)
+ * @param btcTestnetType(Optional) The Bitcoin Testnet type including Testnet3 and Signet, default value is Testnet3
  */
 export const genCreateSporeCkbVirtualTx = async ({
   collector,
   clusterRgbppLockArgs,
   sporeDataList,
   isMainnet,
+  btcTestnetType,
 }: CreateSporeCkbVirtualTxParams): Promise<SporeCreateVirtualTxResult> => {
   const clusterRgbppLock = {
     ...getRgbppLockScript(isMainnet),
@@ -116,7 +119,7 @@ export const genCreateSporeCkbVirtualTx = async ({
   ];
   const outputsData: Hex[] = [clusterCell.outputData, ...sporeOutputsData];
   const cellDeps = [
-    ...(await fetchTypeIdCellDeps(isMainnet, { rgbpp: true })),
+    ...(await fetchTypeIdCellDeps(isMainnet, { rgbpp: true }, btcTestnetType)),
     getClusterTypeDep(isMainnet),
     getSporeTypeDep(isMainnet),
     clusterCellDep,
@@ -161,8 +164,8 @@ const CELL_DEP_SIZE = 32 + 4 + 1;
  * @param collector The collector that collects CKB live cells and transactions
  * @param ckbRawTx CKB raw transaction
  * @param sumInputsCapacity The sum capacity of ckb inputs which is to be used to calculate ckb tx fee
- * @param witnessLockPlaceholderSize The WitnessArgs.lock placeholder bytes array size and the default value is 65
- * @param ckbFeeRate The CKB transaction fee rate, default value is 1100
+ * @param witnessLockPlaceholderSize(Optional) The WitnessArgs.lock placeholder bytes array size and the default value is 65
+ * @param ckbFeeRate(Optional) The CKB transaction fee rate, default value is 1100
  */
 export const buildAppendingIssuerCellToSporesCreateTx = async ({
   issuerAddress,
@@ -217,7 +220,8 @@ export const buildAppendingIssuerCellToSporesCreateTx = async ({
  * @param collector The collector that collects CKB live cells and transactions
  * @param ckbRawTx CKB raw transaction
  * @param sumInputsCapacity The sum capacity of ckb inputs which is to be used to calculate ckb tx fee
- * @param ckbFeeRate The CKB transaction fee rate, default value is 1100
+ * @param isMainnet True is for BTC and CKB Mainnet, flase is for BTC and CKB Testnet(see btcTestnetType for details about BTC Testnet)
+ * @param ckbFeeRate(Optional) The CKB transaction fee rate, default value is 1100
  */
 export const appendIssuerCellToSporesCreate = async ({
   secp256k1PrivateKey,
@@ -285,8 +289,10 @@ export const appendIssuerCellToSporesCreate = async ({
  * @param collector The collector that collects CKB live cells and transactions
  * @param sporeRgbppLockArgs The spore rgbpp cell lock script args whose data structure is: out_index | bitcoin_tx_id
  * @param sporeTypeBytes The spore type script serialized bytes
- * @param witnessLockPlaceholderSize The WitnessArgs.lock placeholder bytes array size and the default value is 5000
- * @param ckbFeeRate The CKB transaction fee rate, default value is 1100
+ * @param isMainnet True is for BTC and CKB Mainnet, flase is for BTC and CKB Testnet(see btcTestnetType for details about BTC Testnet)
+ * @param witnessLockPlaceholderSize(Optional) The WitnessArgs.lock placeholder bytes array size and the default value is 5000
+ * @param ckbFeeRate(Optional) The CKB transaction fee rate, default value is 1100
+ * @param btcTestnetType(Optional) The Bitcoin Testnet type including Testnet3 and Signet, default value is Testnet3
  */
 export const genTransferSporeCkbVirtualTx = async ({
   collector,
@@ -295,6 +301,7 @@ export const genTransferSporeCkbVirtualTx = async ({
   isMainnet,
   witnessLockPlaceholderSize,
   ckbFeeRate,
+  btcTestnetType,
 }: TransferSporeCkbVirtualTxParams): Promise<SporeTransferVirtualTxResult> => {
   const sporeRgbppLock = {
     ...getRgbppLockScript(isMainnet),
@@ -321,7 +328,10 @@ export const genTransferSporeCkbVirtualTx = async ({
     },
   ];
   const outputsData: Hex[] = [sporeCell.outputData];
-  const cellDeps = [...(await fetchTypeIdCellDeps(isMainnet, { rgbpp: true })), getSporeTypeDep(isMainnet)];
+  const cellDeps = [
+    ...(await fetchTypeIdCellDeps(isMainnet, { rgbpp: true }, btcTestnetType)),
+    getSporeTypeDep(isMainnet),
+  ];
   const sporeCoBuild = generateSporeTransferCoBuild([sporeCell], outputs);
   const witnesses = [RGBPP_WITNESS_PLACEHOLDER, sporeCoBuild];
 

--- a/packages/ckb/src/types/common.ts
+++ b/packages/ckb/src/types/common.ts
@@ -2,3 +2,5 @@ export type Hex = string;
 export type U32 = bigint;
 export type Address = string;
 export type Capacity = bigint;
+
+export type BTCTestnetType = 'Testnet3' | 'Signet';

--- a/packages/ckb/src/types/rgbpp.ts
+++ b/packages/ckb/src/types/rgbpp.ts
@@ -101,8 +101,6 @@ export interface AppendWitnessesParams {
   rgbppApiSpvProof: RgbppApiSpvProof;
   // The hex string of btc transaction, refer to https://github.com/bitcoinjs/bitcoinjs-lib/blob/master/ts_src/transaction.ts#L609
   btcTxBytes: Hex;
-  // The Bitcoin Testnet type including Testnet3 and Signet, default value is Testnet3
-  btcTestnetType?: BTCTestnetType;
 }
 
 export interface AppendPaymasterCellAndSignTxParams {
@@ -177,6 +175,8 @@ export interface CkbJumpBtcVirtualTxParams {
   witnessLockPlaceholderSize?: number;
   // The CKB transaction fee rate, default value is 1100
   ckbFeeRate?: bigint;
+  // The Bitcoin Testnet type including Testnet3 and Signet, default value is Testnet3
+  btcTestnetType?: BTCTestnetType;
 }
 
 export interface UpdateCkbTxWithRealBtcTxIdParams {
@@ -195,6 +195,8 @@ export interface BtcTimeCellStatusParams {
   ckbAddress: Address;
   // The BTC transaction id
   btcTxId: Hex;
+  // The Bitcoin Testnet type including Testnet3 and Signet, default value is Testnet3
+  btcTestnetType?: BTCTestnetType;
 }
 
 export interface RgbppLockArgsReceiver {
@@ -217,6 +219,8 @@ export interface CkbBatchJumpBtcVirtualTxParams {
   witnessLockPlaceholderSize?: number;
   // The CKB transaction fee rate, default value is 1100
   ckbFeeRate?: bigint;
+  // The Bitcoin Testnet type including Testnet3 and Signet, default value is Testnet3
+  btcTestnetType?: BTCTestnetType;
 }
 
 export interface AppendIssuerCellToBtcBatchTransfer {

--- a/packages/ckb/src/types/rgbpp.ts
+++ b/packages/ckb/src/types/rgbpp.ts
@@ -1,7 +1,7 @@
 import { BtcAssetsApi, RgbppApiSpvProof } from '@rgbpp-sdk/service';
 import { Collector } from '../collector';
 import { IndexerCell } from './collector';
-import { Address, Hex } from './common';
+import { Address, Hex, BTCTestnetType } from './common';
 
 export interface ConstructPaymasterParams {
   // The collector that collects CKB live cells and transactions
@@ -25,7 +25,10 @@ export interface BtcTransferVirtualTxParams {
   rgbppLockArgsList: Hex[];
   // The XUDT amount to be transferred, if the noMergeOutputCells is true, the transferAmount will be ignored
   transferAmount: bigint;
+  // True is for BTC and CKB Mainnet, flase is for BTC and CKB Testnet(see btcTestnetType for details about BTC Testnet)
   isMainnet: boolean;
+  // The Bitcoin Testnet type including Testnet3 and Signet, default value is Testnet3
+  btcTestnetType?: BTCTestnetType;
   // The noMergeOutputCells indicates whether the CKB outputs need to be merged. By default, the outputs will be merged.
   noMergeOutputCells?: boolean;
   // The WitnessArgs.lock placeholder bytes array size and the default value is 5000
@@ -50,7 +53,10 @@ export interface BtcBatchTransferVirtualTxParams {
   rgbppLockArgsList: Hex[];
   // The rgbpp receiver list which include toRgbppLockArgs and transferAmount
   rgbppReceivers: RgbppBtcAddressReceiver[];
+  // True is for BTC and CKB Mainnet, flase is for BTC and CKB Testnet(see btcTestnetType for details about BTC Testnet)
   isMainnet: boolean;
+  // The Bitcoin Testnet type including Testnet3 and Signet, default value is Testnet3
+  btcTestnetType?: BTCTestnetType;
 }
 
 export interface RgbppCkbVirtualTx {
@@ -95,6 +101,8 @@ export interface AppendWitnessesParams {
   rgbppApiSpvProof: RgbppApiSpvProof;
   // The hex string of btc transaction, refer to https://github.com/bitcoinjs/bitcoinjs-lib/blob/master/ts_src/transaction.ts#L609
   btcTxBytes: Hex;
+  // The Bitcoin Testnet type including Testnet3 and Signet, default value is Testnet3
+  btcTestnetType?: BTCTestnetType;
 }
 
 export interface AppendPaymasterCellAndSignTxParams {
@@ -106,6 +114,7 @@ export interface AppendPaymasterCellAndSignTxParams {
   sumInputsCapacity: Hex;
   // The paymaster cell to be inserted into CKB transaction to pay an extra output cell
   paymasterCell: IndexerCell;
+  // True is for BTC and CKB Mainnet, flase is for BTC and CKB Testnet
   isMainnet: boolean;
   // The CKB transaction fee rate, default value is 1100
   ckbFeeRate?: bigint;
@@ -130,7 +139,10 @@ export interface BtcTimeCellsParams {
   btcTimeCells: IndexerCell[];
   // BTC Assets Api
   btcAssetsApi: BtcAssetsApi;
+  // True is for BTC and CKB Mainnet, flase is for BTC and CKB Testnet
   isMainnet: boolean;
+  // The Bitcoin Testnet type including Testnet3 and Signet, default value is Testnet3
+  btcTestnetType?: BTCTestnetType;
 }
 
 export interface SignBtcTimeCellsTxParams {
@@ -142,6 +154,7 @@ export interface SignBtcTimeCellsTxParams {
   collector: Collector;
   // The master CKB address to pay the time cells spent tx fee
   masterCkbAddress: Address;
+  // True is for BTC and CKB Mainnet, flase is for BTC and CKB Testnet
   isMainnet: boolean;
   // [u64; 2], filter cells by output capacity range, [inclusive, exclusive]
   outputCapacityRange?: Hex[];
@@ -171,6 +184,7 @@ export interface UpdateCkbTxWithRealBtcTxIdParams {
   ckbRawTx: CKBComponents.RawTransaction;
   // The BTC transaction id
   btcTxId: Hex;
+  // True is for BTC and CKB Mainnet, flase is for BTC and CKB Testnet
   isMainnet: boolean;
 }
 
@@ -216,6 +230,7 @@ export interface AppendIssuerCellToBtcBatchTransfer {
   ckbRawTx: CKBComponents.RawTransaction;
   // The sum capacity of the ckb inputs
   sumInputsCapacity: Hex;
+  // True is for BTC and CKB Mainnet, flase is for BTC and CKB Testnet
   isMainnet: boolean;
   // The CKB transaction fee rate, default value is 1100
   ckbFeeRate?: bigint;
@@ -242,9 +257,12 @@ export interface RgbppLaunchCkbVirtualTxParams {
   launchAmount: bigint;
   // The RGBPP token info https://github.com/ckb-cell/unique-cell?tab=readme-ov-file#xudt-information
   rgbppTokenInfo: RgbppTokenInfo;
+  // True is for BTC and CKB Mainnet, flase is for BTC and CKB Testnet(see btcTestnetType for details about BTC Testnet)
+  isMainnet: boolean;
+  // The Bitcoin Testnet type including Testnet3 and Signet, default value is Testnet3
+  btcTestnetType?: BTCTestnetType;
   // The WitnessArgs.lock placeholder bytes array size and the default value is 5000
   witnessLockPlaceholderSize?: number;
   // The CKB transaction fee rate, default value is 1100
   ckbFeeRate?: bigint;
-  isMainnet: boolean;
 }

--- a/packages/ckb/src/types/spore.ts
+++ b/packages/ckb/src/types/spore.ts
@@ -1,5 +1,5 @@
 import { RawClusterData, RawSporeData } from '@spore-sdk/core';
-import { Address, Hex } from './common';
+import { Address, Hex, BTCTestnetType } from './common';
 import { Collector } from '../collector';
 import { IndexerCell } from './collector';
 
@@ -10,7 +10,10 @@ export interface CreateClusterCkbVirtualTxParams {
   rgbppLockArgs: Hex;
   // The cluster's data, including name and description.
   clusterData: RawClusterData;
+  // True is for BTC and CKB Mainnet, flase is for BTC and CKB Testnet
   isMainnet: boolean;
+  // The Bitcoin Testnet type including Testnet3 and Signet, default value is Testnet3
+  btcTestnetType?: BTCTestnetType;
   // The WitnessArgs.lock placeholder bytes array size and the default value is 5000
   witnessLockPlaceholderSize?: number;
   // The CKB transaction fee rate, default value is 1100
@@ -35,7 +38,10 @@ export interface CreateSporeCkbVirtualTxParams {
   clusterRgbppLockArgs: Hex;
   // The cluster's data, including name and description.
   sporeDataList: RawSporeData[];
+  // True is for BTC and CKB Mainnet, flase is for BTC and CKB Testnet
   isMainnet: boolean;
+  // The Bitcoin Testnet type including Testnet3 and Signet, default value is Testnet3
+  btcTestnetType?: BTCTestnetType;
   // The WitnessArgs.lock placeholder bytes array size and the default value is 5000
   witnessLockPlaceholderSize?: number;
   // The CKB transaction fee rate, default value is 1100
@@ -81,6 +87,7 @@ export interface AppendIssuerCellToSporeCreate {
   ckbRawTx: CKBComponents.RawTransaction;
   // The sum capacity of the ckb inputs
   sumInputsCapacity: Hex;
+  // True is for BTC and CKB Mainnet, flase is for BTC and CKB Testnet
   isMainnet: boolean;
   // The CKB transaction fee rate, default value is 1100
   ckbFeeRate?: bigint;
@@ -100,7 +107,10 @@ export interface TransferSporeCkbVirtualTxParams {
   sporeRgbppLockArgs: Hex;
   // The spore type script serialized bytes
   sporeTypeBytes: Hex;
+  // True is for BTC and CKB Mainnet, flase is for BTC and CKB Testnet
   isMainnet: boolean;
+  // The Bitcoin Testnet type including Testnet3 and Signet, default value is Testnet3
+  btcTestnetType?: BTCTestnetType;
   // The WitnessArgs.lock placeholder bytes array size and the default value is 5000
   witnessLockPlaceholderSize?: number;
   // The CKB transaction fee rate, default value is 1100
@@ -131,7 +141,10 @@ export interface LeapSporeFromBtcToCkbVirtualTxParams {
   sporeTypeBytes: Hex;
   // The receiver ckb address
   toCkbAddress: Address;
+  // True is for BTC and CKB Mainnet, flase is for BTC and CKB Testnet
   isMainnet: boolean;
+  // The Bitcoin Testnet type including Testnet3 and Signet, default value is Testnet3
+  btcTestnetType?: BTCTestnetType;
   // The WitnessArgs.lock placeholder bytes array size and the default value is 5000
   witnessLockPlaceholderSize?: number;
   // The CKB transaction fee rate, default value is 1100
@@ -147,7 +160,10 @@ export interface LeapSporeFromCkbToBtcVirtualTxParams {
   toRgbppLockArgs: Hex;
   // The spore type script serialized bytes
   sporeTypeBytes: Hex;
+  // True is for BTC and CKB Mainnet, flase is for BTC and CKB Testnet
   isMainnet: boolean;
+  // The Bitcoin Testnet type including Testnet3 and Signet, default value is Testnet3
+  btcTestnetType?: BTCTestnetType;
   // The WitnessArgs.lock placeholder bytes array size and the default value is 5000
   witnessLockPlaceholderSize?: number;
   // The CKB transaction fee rate, default value is 1100

--- a/packages/ckb/src/utils/cell-dep.ts
+++ b/packages/ckb/src/utils/cell-dep.ts
@@ -1,14 +1,17 @@
 import axios from 'axios';
 import { getBtcTimeLockDep, getRgbppLockDep, getUniqueTypeDep, getXudtDep } from '../constants';
+import { BTCTestnetType } from '../types';
 
 interface CellDepsObject {
   rgbpp: {
     mainnet: CKBComponents.CellDep;
     testnet: CKBComponents.CellDep;
+    signet: CKBComponents.CellDep;
   };
   btcTime: {
     mainnet: CKBComponents.CellDep;
     testnet: CKBComponents.CellDep;
+    signet: CKBComponents.CellDep;
   };
   xudt: {
     testnet: CKBComponents.CellDep;
@@ -44,6 +47,7 @@ export interface CellDepsSelected {
 export const fetchTypeIdCellDeps = async (
   isMainnet: boolean,
   selected: CellDepsSelected,
+  btcTestnetType?: BTCTestnetType,
 ): Promise<CKBComponents.CellDep[]> => {
   let rgbppLockDep = getRgbppLockDep(isMainnet);
   let btcTimeDep = getBtcTimeLockDep(isMainnet);
@@ -52,8 +56,13 @@ export const fetchTypeIdCellDeps = async (
 
   const cellDepsObj = await fetchCellDepsJson();
   if (cellDepsObj) {
-    rgbppLockDep = isMainnet ? cellDepsObj.rgbpp.mainnet : cellDepsObj.rgbpp.testnet;
-    btcTimeDep = isMainnet ? cellDepsObj.btcTime.mainnet : cellDepsObj.btcTime.testnet;
+    if (btcTestnetType === 'Signet') {
+      rgbppLockDep = cellDepsObj.rgbpp.signet;
+      btcTimeDep = cellDepsObj.btcTime.signet;
+    } else {
+      rgbppLockDep = isMainnet ? cellDepsObj.rgbpp.mainnet : cellDepsObj.rgbpp.testnet;
+      btcTimeDep = isMainnet ? cellDepsObj.btcTime.mainnet : cellDepsObj.btcTime.testnet;
+    }
     if (!isMainnet) {
       xudtDep = cellDepsObj.xudt.testnet;
       uniqueDep = cellDepsObj.unique.testnet;

--- a/packages/ckb/src/utils/cell-dep.ts
+++ b/packages/ckb/src/utils/cell-dep.ts
@@ -49,8 +49,8 @@ export const fetchTypeIdCellDeps = async (
   selected: CellDepsSelected,
   btcTestnetType?: BTCTestnetType,
 ): Promise<CKBComponents.CellDep[]> => {
-  let rgbppLockDep = getRgbppLockDep(isMainnet);
-  let btcTimeDep = getBtcTimeLockDep(isMainnet);
+  let rgbppLockDep = getRgbppLockDep(isMainnet, btcTestnetType);
+  let btcTimeDep = getBtcTimeLockDep(isMainnet, btcTestnetType);
   let xudtDep = getXudtDep(isMainnet);
   let uniqueDep = getUniqueTypeDep(isMainnet);
 

--- a/packages/rgbpp/src/rgbpp/types.ts
+++ b/packages/rgbpp/src/rgbpp/types.ts
@@ -29,6 +29,7 @@ export interface RgbppTransferBtcParams {
 export interface RgbppTransferTxParams {
   ckb: RgbppTransferCkbParams;
   btc: RgbppTransferBtcParams;
+  // True is for BTC and CKB Mainnet, flase is for BTC and CKB Testnet
   isMainnet: boolean;
 }
 

--- a/packages/rgbpp/src/rgbpp/types.ts
+++ b/packages/rgbpp/src/rgbpp/types.ts
@@ -1,5 +1,5 @@
 import { DataSource } from '@rgbpp-sdk/btc';
-import { BtcTransferVirtualTxResult, Collector, Hex } from '@rgbpp-sdk/ckb';
+import { BTCTestnetType, BtcTransferVirtualTxResult, Collector, Hex } from '@rgbpp-sdk/ckb';
 
 export interface RgbppTransferCkbParams {
   // The collector that collects CKB live cells and transactions
@@ -24,6 +24,8 @@ export interface RgbppTransferBtcParams {
   fromPubkey?: Hex;
   // The fee rate of the BTC transaction
   feeRate?: number;
+  // The Bitcoin Testnet type including Testnet3 and Signet, default value is Testnet3
+  testnetType?: BTCTestnetType;
 }
 
 export interface RgbppTransferTxParams {

--- a/packages/rgbpp/src/rgbpp/xudt.ts
+++ b/packages/rgbpp/src/rgbpp/xudt.ts
@@ -18,7 +18,8 @@ import { RgbppTransferTxParams, RgbppTransferTxResult } from './types';
  * @param toAddress The receiver BTC address
  * @param dataSource The BTC data source
  * @param feeRate The fee rate of the BTC transaction
- * @param isMainnet
+ * @param isMainnet True is for BTC and CKB Mainnet, flase is for BTC and CKB Testnet(see btcTestnetType for details about BTC Testnet)
+ * @param btcTestnetType(Optional) The Bitcoin Testnet type including Testnet3 and Signet, default value is Testnet3
  */
 export const buildRgbppTransferTx = async ({
   ckb: { collector, xudtTypeArgs, rgbppLockArgsList, transferAmount, feeRate: ckbFeeRate },
@@ -37,6 +38,7 @@ export const buildRgbppTransferTx = async ({
     transferAmount,
     isMainnet,
     ckbFeeRate,
+    btcTestnetType: btc.testnetType,
   });
 
   const { commitment, ckbRawTx } = ckbVirtualTxResult;

--- a/packages/rgbpp/src/rgbpp/xudt.ts
+++ b/packages/rgbpp/src/rgbpp/xudt.ts
@@ -19,7 +19,7 @@ import { RgbppTransferTxParams, RgbppTransferTxResult } from './types';
  * @param dataSource The BTC data source
  * @param feeRate The fee rate of the BTC transaction
  * @param isMainnet True is for BTC and CKB Mainnet, flase is for BTC and CKB Testnet(see btcTestnetType for details about BTC Testnet)
- * @param btcTestnetType(Optional) The Bitcoin Testnet type including Testnet3 and Signet, default value is Testnet3
+ * @param testnetType(Optional) The Bitcoin Testnet type including Testnet3 and Signet, default value is Testnet3
  */
 export const buildRgbppTransferTx = async ({
   ckb: { collector, xudtTypeArgs, rgbppLockArgsList, transferAmount, feeRate: ckbFeeRate },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -127,7 +127,7 @@ importers:
         specifier: ^0.109.1
         version: 0.109.1
       rgbpp:
-        specifier: ^0.3.0
+        specifier: workspace:*
         version: link:../../packages/rgbpp
     devDependencies:
       '@types/dotenv':


### PR DESCRIPTION
## Changes

- Add CKB RGB++ Testnet deployment information for the BTC Signet network
- Add optional parameter `btcTestnetType` to RGB++ functions
- Update all the examples for the BTC Signet network

## RGB++ xUDT Transactions

> I have tested all the RGB++ xUDT transactions on BTC Signet network with the local model and the Spore examples need to be tested by @Dawn-githup.  And I will focus on the [PR#218](https://github.com/ckb-cell/rgbpp-sdk/pull/218) and [`ckb-sdk-python`](https://github.com/ckb-cell/rgbpp-sdk-python/pull/1). Thanks a lot.

### Launch RGB++ xUDT

btc tx: https://mempool.space/signet/tx/5ab72e296c7e4f93302f5b1827c59860a95b94958942c65977bf25fcd7364bf3
ckb tx: https://pudge.explorer.nervos.org/transaction/0x68f8e86cacac5601691d4e8f821b02a542869cd9c5cdf858186f76acd196cc60	

### Distribute RGB++ xUDT

btc tx: https://mempool.space/signet/tx/ae78c4c939ff9257b9e43a389c1533721e175b4aa2d855b5ee9b73a1b63d72f5
ckb tx: https://pudge.explorer.nervos.org/transaction/0xd75f8928fc36f85d2509e1ad4925650e85f389ab3df92f2f3101a8e42bd53e57

### Transfer RGB++ xUDT on BTC

btc tx: https://mempool.space/signet/tx/57212668f2738aa07a51861a2f8cd7a083aab05b01ede8b79dff948c0041f808
ckb tx: https://pudge.explorer.nervos.org/transaction/0x56ccdf0abb893dbac269d18e2a0cd915933952f35e597b9e82bfe5b6047bef84

### Leap RGB++ xUDT from CKB to BTC

ckb tx: https://pudge.explorer.nervos.org/transaction/0xcf25d9569c6a0568a2178708fab67b3c3c3bf64819a6aa228dd43b86396325ee

### Leap RGB++ xUDT from BTC to CKB

btc tx: https://mempool.space/signet/tx/b8d8b694aa1ee3ebbe70437779cf2e9375df667cc8241980e6392920550f9a79
ckb tx: https://pudge.explorer.nervos.org/transaction/0xd26a9965eafbec3de6287d764ced3aeb703a14fe6b9b5c8e9f3e143ffd647fd4

### Unlock BTC Time cell

ckb tx: https://pudge.explorer.nervos.org/transaction/0xc765c862ea05b398af9a02b7e2a9fe948e2c01463d6b8a481c21328f45663145