### PR TITLE
feat(btc): support including multi-origin UTXOs

### DIFF
--- a/.changeset/orange-mice-trade.md
+++ b/.changeset/orange-mice-trade.md
@@ -1,0 +1,9 @@
+---
+"@rgbpp-sdk/btc": minor
+---
+
+Support including multi-origin UTXOs in the same transaction
+
+  - Add `pubkeyMap` option in the sendUtxos(), sendRgbppUtxos() and sendRbf() API
+  - Rename `inputsPubkey` option to `pubkeyMap` in the sendRbf() API
+  - Delete `onlyProvableUtxos` option from the sendRgbppUtxos() API

--- a/packages/btc/README.md
+++ b/packages/btc/README.md
@@ -312,6 +312,7 @@ interface SendUtxosProps {
 
   // EXPERIMENTAL: the below props are unstable and can be altered at any time
   skipInputsValidation?: boolean;
+  pubkeyMap?: AddressToPubkeyMap;
 }
 ```
 
@@ -352,7 +353,7 @@ interface SendRgbppUtxosProps {
   excludeUtxos?: BaseOutput[];
 
   // EXPERIMENTAL: the below props are experimental and can be altered at any time
-  onlyProvableUtxos?: boolean;
+  pubkeyMap?: AddressToPubkeyMap;
 }
 ```
 
@@ -386,7 +387,7 @@ interface SendRbfProps {
   requireGreaterFeeAndRate?: boolean;
 
   // EXPERIMENTAL: the below props are experimental and can be altered at any time
-  inputsPubkey?: Record<string, string>; // Record<address, pubkey>
+  pubkeyMap?: AddressToPubkeyMap;
 }
 ```
 
@@ -512,4 +513,10 @@ enum NetworkType {
   TESTNET,
   REGTEST,
 }
+```
+
+#### AddressToPubkeyMap
+
+```typescript
+type AddressToPubkeyMap = Record<string, string>;
 ```

--- a/packages/btc/src/address.ts
+++ b/packages/btc/src/address.ts
@@ -210,3 +210,18 @@ function getAddressTypeDust(addressType: AddressType) {
     return 546;
   }
 }
+
+/**
+ * Add address/pubkey pair to a Record<address, pubkey> map
+ */
+export function addAddressToPubkeyMap(
+  pubkeyMap: Record<string, string>,
+  address: string,
+  pubkey?: string,
+): Record<string, string> {
+  const newMap = { ...pubkeyMap };
+  if (pubkey) {
+    newMap[address] = pubkey;
+  }
+  return newMap;
+}

--- a/packages/btc/src/address.ts
+++ b/packages/btc/src/address.ts
@@ -15,6 +15,13 @@ export enum AddressType {
 }
 
 /**
+ * Type: Record<Address, Pubkey>
+ *
+ * The map of address and pubkey, usually for recognizing the P2TR inputs in the transaction.
+ */
+export type AddressToPubkeyMap = Record<string, string>;
+
+/**
  * Check weather the address is supported as a from address.
  * Currently, only P2WPKH and P2TR addresses are supported.
  */
@@ -215,7 +222,7 @@ function getAddressTypeDust(addressType: AddressType) {
  * Add address/pubkey pair to a Record<address, pubkey> map
  */
 export function addAddressToPubkeyMap(
-  pubkeyMap: Record<string, string>,
+  pubkeyMap: AddressToPubkeyMap,
   address: string,
   pubkey?: string,
 ): Record<string, string> {

--- a/packages/btc/src/api/sendRbf.ts
+++ b/packages/btc/src/api/sendRbf.ts
@@ -1,5 +1,6 @@
 import { BaseOutput, Utxo } from '../transaction/utxo';
 import { DataSource } from '../query/source';
+import { AddressToPubkeyMap } from '../address';
 import { ErrorCodes, TxBuildError } from '../error';
 import { InitOutput, TxBuilder } from '../transaction/build';
 import { isOpReturnScriptPubkey } from '../transaction/embed';
@@ -22,7 +23,7 @@ export interface SendRbfProps {
   requireGreaterFeeAndRate?: boolean;
 
   // EXPERIMENTAL: the below props are unstable and can be altered at any time
-  pubkeyMap?: Record<string, string>; // Record<address, pubkey>
+  pubkeyMap?: AddressToPubkeyMap;
 }
 
 export async function createSendRbfBuilder(props: SendRbfProps): Promise<{

--- a/packages/btc/src/api/sendRgbppUtxos.ts
+++ b/packages/btc/src/api/sendRgbppUtxos.ts
@@ -2,6 +2,7 @@ import { Collector, checkCkbTxInputsCapacitySufficient } from '@rgbpp-sdk/ckb';
 import { isRgbppLockCell, isBtcTimeLockCell, calculateCommitment } from '@rgbpp-sdk/ckb';
 import { bitcoin } from '../bitcoin';
 import { BaseOutput, Utxo } from '../transaction/utxo';
+import { AddressToPubkeyMap } from '../address';
 import { DataSource } from '../query/source';
 import { NetworkType } from '../preset/types';
 import { ErrorCodes, TxBuildError } from '../error';
@@ -31,7 +32,7 @@ export interface SendRgbppUtxosProps {
   excludeUtxos?: BaseOutput[];
 
   // EXPERIMENTAL: the below props are unstable and can be altered at any time
-  pubkeyMap?: Record<string, string>; // Record<address, pubkey>
+  pubkeyMap?: AddressToPubkeyMap;
 }
 
 /**

--- a/packages/btc/src/api/sendUtxos.ts
+++ b/packages/btc/src/api/sendUtxos.ts
@@ -2,7 +2,7 @@ import { bitcoin } from '../bitcoin';
 import { DataSource } from '../query/source';
 import { TxBuilder, InitOutput } from '../transaction/build';
 import { BaseOutput, Utxo, prepareUtxoInputs } from '../transaction/utxo';
-import { addAddressToPubkeyMap } from '../address';
+import { AddressToPubkeyMap, addAddressToPubkeyMap } from '../address';
 
 export interface SendUtxosProps {
   inputs: Utxo[];
@@ -18,7 +18,7 @@ export interface SendUtxosProps {
 
   // EXPERIMENTAL: the below props are unstable and can be altered at any time
   skipInputsValidation?: boolean;
-  pubkeyMap?: Record<string, string>; // Record<address, pubkey>
+  pubkeyMap?: AddressToPubkeyMap;
 }
 
 export async function createSendUtxosBuilder(props: SendUtxosProps): Promise<{

--- a/packages/btc/src/transaction/fee.ts
+++ b/packages/btc/src/transaction/fee.ts
@@ -1,61 +1,105 @@
 import { ECPairInterface } from 'ecpair';
+import { AddressType } from '../address';
 import { NetworkType } from '../preset/types';
-import { networkTypeToNetwork } from '../preset/network';
-import { AddressType, publicKeyToAddress } from '../address';
-import { bitcoin, ECPair, isTaprootInput } from '../bitcoin';
 import { toXOnly, tweakSigner } from '../utils';
+import { networkTypeToNetwork } from '../preset/network';
+import { isP2trScript, isP2wpkhScript } from '../script';
+import { bitcoin, ECPair, isTaprootInput } from '../bitcoin';
+import { Utxo } from './utxo';
+
+interface FeeEstimateAccount {
+  payment: bitcoin.Payment;
+  addressType: AddressType;
+  address: string;
+  scriptPubkey: string;
+  tapInternalKey?: Buffer;
+}
 
 export class FeeEstimator {
   public networkType: NetworkType;
-  public addressType: AddressType;
   public network: bitcoin.Network;
 
   private readonly keyPair: ECPairInterface;
-  public publicKey: string;
-  public address: string;
+  public readonly pubkey: string;
+  public accounts: {
+    p2wpkh: FeeEstimateAccount;
+    p2tr: FeeEstimateAccount;
+  };
 
-  constructor(wif: string, networkType: NetworkType, addressType: AddressType) {
+  constructor(wif: string, networkType: NetworkType) {
     const network = networkTypeToNetwork(networkType);
-    const keyPair = ECPair.fromWIF(wif, network);
-
-    this.keyPair = keyPair;
-    this.publicKey = keyPair.publicKey.toString('hex');
-    this.address = publicKeyToAddress(this.publicKey, addressType, networkType);
-
-    this.addressType = addressType;
     this.networkType = networkType;
     this.network = network;
+
+    const keyPair = ECPair.fromWIF(wif, network);
+    this.pubkey = keyPair.publicKey.toString('hex');
+    this.keyPair = keyPair;
+
+    const p2wpkh = bitcoin.payments.p2wpkh({
+      pubkey: keyPair.publicKey,
+      network,
+    });
+    const p2tr = bitcoin.payments.p2tr({
+      internalPubkey: toXOnly(keyPair.publicKey),
+      network,
+    });
+    this.accounts = {
+      p2wpkh: {
+        payment: p2wpkh,
+        address: p2wpkh.address!,
+        addressType: AddressType.P2WPKH,
+        scriptPubkey: p2wpkh.output!.toString('hex'),
+      },
+      p2tr: {
+        payment: p2tr,
+        address: p2tr.address!,
+        addressType: AddressType.P2TR,
+        tapInternalKey: toXOnly(keyPair.publicKey),
+        scriptPubkey: p2tr.output!.toString('hex'),
+      },
+    };
   }
 
-  static fromRandom(addressType: AddressType, networkType: NetworkType) {
+  static fromRandom(networkType: NetworkType) {
     const network = networkTypeToNetwork(networkType);
     const keyPair = ECPair.makeRandom({ network });
-    return new FeeEstimator(keyPair.toWIF(), networkType, addressType);
+    return new FeeEstimator(keyPair.toWIF(), networkType);
+  }
+
+  replaceUtxo(utxo: Utxo): Utxo {
+    if (utxo.addressType === AddressType.P2WPKH || isP2wpkhScript(utxo.scriptPk)) {
+      utxo.scriptPk = this.accounts.p2wpkh.scriptPubkey;
+      utxo.pubkey = this.pubkey;
+    }
+    if (utxo.addressType === AddressType.P2TR || isP2trScript(utxo.scriptPk)) {
+      utxo.scriptPk = this.accounts.p2tr.scriptPubkey;
+      utxo.pubkey = this.pubkey;
+    }
+
+    return utxo;
   }
 
   async signPsbt(psbt: bitcoin.Psbt): Promise<bitcoin.Psbt> {
-    psbt.data.inputs.forEach((v) => {
-      const isNotSigned = !(v.finalScriptSig || v.finalScriptWitness);
-      const isP2TR = this.addressType === AddressType.P2TR;
-      const lostInternalPubkey = !v.tapInternalKey;
-      // Special measures taken for compatibility with certain applications.
-      if (isNotSigned && isP2TR && lostInternalPubkey) {
-        const tapInternalKey = toXOnly(Buffer.from(this.publicKey, 'hex'));
-        const { output } = bitcoin.payments.p2tr({
-          internalPubkey: tapInternalKey,
-          network: networkTypeToNetwork(this.networkType),
-        });
-        if (v.witnessUtxo?.script.toString('hex') == output?.toString('hex')) {
-          v.tapInternalKey = tapInternalKey;
-        }
-      }
+    // Tweak signer for P2TR inputs
+    const tweakedSigner = tweakSigner(this.keyPair, {
+      network: this.network,
     });
 
     psbt.data.inputs.forEach((input, index) => {
+      // Fill tapInternalKey for P2TR inputs if missing
+      if (input.witnessUtxo) {
+        const isNotSigned = !(input.finalScriptSig || input.finalScriptWitness);
+        const isP2trInput = isP2trScript(input.witnessUtxo.script);
+        const lostInternalPubkey = !input.tapInternalKey;
+        if (isNotSigned && isP2trInput && lostInternalPubkey) {
+          if (input.witnessUtxo.script.toString('hex') === this.accounts.p2tr.scriptPubkey) {
+            input.tapInternalKey = this.accounts.p2tr.tapInternalKey!;
+          }
+        }
+      }
+
+      // Sign P2WPKH/P2TR inputs
       if (isTaprootInput(input)) {
-        const tweakedSigner = tweakSigner(this.keyPair, {
-          network: this.network,
-        });
         psbt.signInput(index, tweakedSigner);
       } else {
         psbt.signInput(index, this.keyPair);

--- a/packages/btc/src/transaction/utxo.ts
+++ b/packages/btc/src/transaction/utxo.ts
@@ -1,7 +1,7 @@
 import cloneDeep from 'lodash/cloneDeep';
 import { ErrorCodes, TxBuildError } from '../error';
 import { DataSource } from '../query/source';
-import { AddressType } from '../address';
+import { AddressType, AddressToPubkeyMap } from '../address';
 import { TxInput } from './build';
 import { limitPromiseBatchSize, remove0x, toXOnly } from '../utils';
 import { isP2trScript } from '../script';
@@ -65,7 +65,7 @@ export function utxoToInput(utxo: Utxo): TxInput {
  */
 export function fillUtxoPubkey(
   utxo: Utxo,
-  pubkeyMap: Record<string, string>, // Record<address, pubkey>
+  pubkeyMap: AddressToPubkeyMap,
   options?: {
     requirePubkey?: boolean;
   },
@@ -94,7 +94,7 @@ export async function prepareUtxoInputs(props: {
   source: DataSource;
   requirePubkey?: boolean;
   requireConfirmed?: boolean;
-  pubkeyMap?: Record<string, string>; // Record<address, pubkey>
+  pubkeyMap?: AddressToPubkeyMap;
 }): Promise<Utxo[]> {
   const pubkeyMap = props.pubkeyMap ?? {};
   const utxos = props.utxos.map((utxo) => {


### PR DESCRIPTION
## Changes
- Support including multi-origin UTXOs (P2TR/P2WPKH) as inputs in the same BTC transaction
- Support the `pubkeyMap` option in the sendUtxos(), sendRgbppUtxos() and sendRbf() API
- Rename the option `inputsPubkey` to `pubkeyMap` in the sendRbf() API (any better advice?)
- Delete the `onlyProvableUtxos` option from the sendRgbppUtxos() API as it's no longer needed

## Related issues
- Resolves #141 

## Checklist
- [x] Merge #150
- [x] Rebase code and resolve TODO: https://github.com/ckb-cell/rgbpp-sdk/pull/228/files#diff-edc3633c4a7f724d2bf01933b610458356c78d5daced02105729b6c1ea5ef718R108
- [x] Add changeset for the PR
- [ ] Test @Dawn-githup
- [x] Integration tests on 96d3904 (Merge da4257b49858fe954835e9cc130df6cbadcca278 into 20441ecc9c54c5dc5ae6e3ce6bf2acccffb73cb6) -> https://github.com/ckb-cell/rgbpp-sdk/actions/runs/9565198963
  