### PR TITLE
Bump RGB++ SDK to v0.4.0

### DIFF
--- a/.changeset/great-baboons-smash.md
+++ b/.changeset/great-baboons-smash.md
@@ -1,5 +1,0 @@
----
-"rgbpp": minor
----
-
-feat: Export buildRgbppTransferTx from rgbpp package

--- a/.changeset/orange-mice-trade.md
+++ b/.changeset/orange-mice-trade.md
@@ -1,9 +1,0 @@
----
-"@rgbpp-sdk/btc": minor
----
-
-Support including multi-origin UTXOs in the same transaction
-
-  - Add `pubkeyMap` option in the sendUtxos(), sendRgbppUtxos() and sendRbf() API
-  - Rename `inputsPubkey` option to `pubkeyMap` in the sendRbf() API
-  - Delete `onlyProvableUtxos` option from the sendRgbppUtxos() API

--- a/.changeset/silly-rules-collect.md
+++ b/.changeset/silly-rules-collect.md
@@ -1,5 +1,0 @@
----
-"@rgbpp-sdk/service": minor
----
-
-Add BtcAssetsApi.getRgbppApiBalanceByAddress() API for querying RGBPP XUDT balances by a BTC address

--- a/.changeset/spicy-cups-cheat.md
+++ b/.changeset/spicy-cups-cheat.md
@@ -1,9 +1,0 @@
----
-"@rgbpp-sdk/btc": minor
----
-
-Support Full-RBF feature with the sendRbf() and createSendRbfBuilder() API
-
-  - Add `excludeUtxos`, `skipInputsValidation` options in the `sendUtxos()` API to support the RBF feature
-  - Add `onlyProvableUtxos` option in the `sendRgbppUtxos()` API for future update supports
-  - Add `changeIndex` in the return type of the BTC Builder APIs

--- a/.changeset/wise-years-swim.md
+++ b/.changeset/wise-years-swim.md
@@ -1,5 +1,0 @@
----
-"@rgbpp-sdk/ckb": minor
----
-
-fix: Fix typo and remove useless queue types

--- a/packages/btc/CHANGELOG.md
+++ b/packages/btc/CHANGELOG.md
@@ -1,5 +1,27 @@
 # @rgbpp-sdk/btc
 
+## 0.4.0
+
+### Minor Changes
+
+- [#228](https://github.com/ckb-cell/rgbpp-sdk/pull/228): Support including multi-origin UTXOs in the same transaction ([@ShookLyngs](https://github.com/ShookLyngs))
+
+  - Add `pubkeyMap` option in the sendUtxos(), sendRgbppUtxos() and sendRbf() API
+  - Rename `inputsPubkey` option to `pubkeyMap` in the sendRbf() API
+  - Delete `onlyProvableUtxos` option from the sendRgbppUtxos() API
+
+- [#150](https://github.com/ckb-cell/rgbpp-sdk/pull/150): Support Full-RBF feature with the sendRbf() and createSendRbfBuilder() API ([@ShookLyngs](https://github.com/ShookLyngs))
+
+  - Add `excludeUtxos`, `skipInputsValidation` options in the `sendUtxos()` API to support the RBF feature
+  - Add `onlyProvableUtxos` option in the `sendRgbppUtxos()` API for future update supports
+  - Add `changeIndex` in the return type of the BTC Builder APIs
+
+### Patch Changes
+
+- Updated dependencies [[`e5f41fd`](https://github.com/ckb-cell/rgbpp-sdk/commit/e5f41fd2b275182d2ab3fdf17e3b8853025fd2b9), [`6e840c1`](https://github.com/ckb-cell/rgbpp-sdk/commit/6e840c196fbece06430c559aebbdadaf7fb6e632)]:
+  - @rgbpp-sdk/service@0.4.0
+  - @rgbpp-sdk/ckb@0.4.0
+
 ## v0.3.0
 
 ### Minor Changes

--- a/packages/btc/package.json
+++ b/packages/btc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rgbpp-sdk/btc",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "scripts": {
     "test": "vitest",
     "build": "tsc -p tsconfig.build.json",

--- a/packages/ckb/CHANGELOG.md
+++ b/packages/ckb/CHANGELOG.md
@@ -1,10 +1,21 @@
 # @rgbpp-sdk/ckb
 
+## 0.4.0
+
+### Minor Changes
+
+- [#236](https://github.com/ckb-cell/rgbpp-sdk/pull/236): Fix typo and remove useless queue types ([@duanyytop](https://github.com/duanyytop))
+
+### Patch Changes
+
+- Updated dependencies [[`e5f41fd`](https://github.com/ckb-cell/rgbpp-sdk/commit/e5f41fd2b275182d2ab3fdf17e3b8853025fd2b9)]:
+  - @rgbpp-sdk/service@0.4.0
+
 ## v0.3.0
 
 ### Minor Changes
 
-- [#197](https://github.com/ckb-cell/rgbpp-sdk/pull/197): feat: Return needPaymasterCell for RGB++ ckb cirtual tx ([@duanyytop](https://github.com/duanyytop))
+- [#197](https://github.com/ckb-cell/rgbpp-sdk/pull/197): Return needPaymasterCell for RGB++ ckb cirtual tx ([@duanyytop](https://github.com/duanyytop))
 
 - [#191](https://github.com/ckb-cell/rgbpp-sdk/pull/191): Dynamic fetching cell deps deployed by TypeID ([@duanyytop](https://github.com/duanyytop))
 

--- a/packages/ckb/package.json
+++ b/packages/ckb/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rgbpp-sdk/ckb",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "scripts": {
     "test": "vitest",
     "build": "tsc -p tsconfig.build.json",

--- a/packages/rgbpp/CHANGELOG.md
+++ b/packages/rgbpp/CHANGELOG.md
@@ -1,5 +1,18 @@
 # rgbpp
 
+## 0.4.0
+
+### Minor Changes
+
+- [#216](https://github.com/ckb-cell/rgbpp-sdk/pull/216): Export buildRgbppTransferTx from rgbpp package ([@duanyytop](https://github.com/duanyytop))
+
+### Patch Changes
+
+- Updated dependencies [[`1ecac34`](https://github.com/ckb-cell/rgbpp-sdk/commit/1ecac341d5ced04e59bfdcd432a9bce84bedd959), [`e5f41fd`](https://github.com/ckb-cell/rgbpp-sdk/commit/e5f41fd2b275182d2ab3fdf17e3b8853025fd2b9), [`08200c9`](https://github.com/ckb-cell/rgbpp-sdk/commit/08200c974ef336661723cc7556a003932babda9a), [`6e840c1`](https://github.com/ckb-cell/rgbpp-sdk/commit/6e840c196fbece06430c559aebbdadaf7fb6e632)]:
+  - @rgbpp-sdk/btc@0.4.0
+  - @rgbpp-sdk/service@0.4.0
+  - @rgbpp-sdk/ckb@0.4.0
+
 ## v0.3.0
 
 ### Patch Changes

--- a/packages/rgbpp/package.json
+++ b/packages/rgbpp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rgbpp",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "scripts": {
     "build": "tsc -p tsconfig.build.json",
     "lint": "tsc && eslint --ext .ts src/* && prettier --check 'src/*.ts'",

--- a/packages/service/CHANGELOG.md
+++ b/packages/service/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @rgbpp-sdk/service
 
+## 0.4.0
+
+### Minor Changes
+
+- [#222](https://github.com/ckb-cell/rgbpp-sdk/pull/222): Add BtcAssetsApi.getRgbppApiBalanceByAddress() API for querying RGBPP XUDT balances by a BTC address ([@ShookLyngs](https://github.com/ShookLyngs))
+
 ## v0.3.0
 
 ### Minor Changes

--- a/packages/service/package.json
+++ b/packages/service/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rgbpp-sdk/service",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "scripts": {
     "test": "vitest",
     "build": "tsc -p tsconfig.build.json",


### PR DESCRIPTION
# v0.4.0

## @rgbpp-sdk/btc

### Minor Changes

- [#228](https://github.com/ckb-cell/rgbpp-sdk/pull/228): Support including multi-origin UTXOs in the same transaction ([@ShookLyngs](https://github.com/ShookLyngs))

  - Add `pubkeyMap` option in the sendUtxos(), sendRgbppUtxos() and sendRbf() API
  - Rename `inputsPubkey` option to `pubkeyMap` in the sendRbf() API
  - Delete `onlyProvableUtxos` option from the sendRgbppUtxos() API

- [#150](https://github.com/ckb-cell/rgbpp-sdk/pull/150): Support Full-RBF feature with the sendRbf() and createSendRbfBuilder() API ([@ShookLyngs](https://github.com/ShookLyngs))

  - Add `excludeUtxos`, `skipInputsValidation` options in the `sendUtxos()` API to support the RBF feature
  - Add `onlyProvableUtxos` option in the `sendRgbppUtxos()` API for future update supports
  - Add `changeIndex` in the return type of the BTC Builder APIs

### Patch Changes

- Updated dependencies [[`e5f41fd`](https://github.com/ckb-cell/rgbpp-sdk/commit/e5f41fd2b275182d2ab3fdf17e3b8853025fd2b9), [`6e840c1`](https://github.com/ckb-cell/rgbpp-sdk/commit/6e840c196fbece06430c559aebbdadaf7fb6e632)]:
  - @rgbpp-sdk/service@0.4.0
  - @rgbpp-sdk/ckb@0.4.0

## @rgbpp-sdk/ckb

### Minor Changes

- [#236](https://github.com/ckb-cell/rgbpp-sdk/pull/236): Fix typo and remove useless queue types ([@duanyytop](https://github.com/duanyytop))

### Patch Changes

- Updated dependencies [[`e5f41fd`](https://github.com/ckb-cell/rgbpp-sdk/commit/e5f41fd2b275182d2ab3fdf17e3b8853025fd2b9)]:
  - @rgbpp-sdk/service@0.4.0

## @rgbpp-sdk/service

### Minor Changes

- [#222](https://github.com/ckb-cell/rgbpp-sdk/pull/222): Add BtcAssetsApi.getRgbppApiBalanceByAddress() API for querying RGBPP XUDT balances by a BTC address ([@ShookLyngs](https://github.com/ShookLyngs))

## rgbpp

### Minor Changes

- [#216](https://github.com/ckb-cell/rgbpp-sdk/pull/216): Export buildRgbppTransferTx from rgbpp package ([@duanyytop](https://github.com/duanyytop))

### Patch Changes

- Updated dependencies [[`1ecac34`](https://github.com/ckb-cell/rgbpp-sdk/commit/1ecac341d5ced04e59bfdcd432a9bce84bedd959), [`e5f41fd`](https://github.com/ckb-cell/rgbpp-sdk/commit/e5f41fd2b275182d2ab3fdf17e3b8853025fd2b9), [`08200c9`](https://github.com/ckb-cell/rgbpp-sdk/commit/08200c974ef336661723cc7556a003932babda9a), [`6e840c1`](https://github.com/ckb-cell/rgbpp-sdk/commit/6e840c196fbece06430c559aebbdadaf7fb6e632)]:
  - @rgbpp-sdk/btc@0.4.0
  - @rgbpp-sdk/service@0.4.0
  - @rgbpp-sdk/ckb@0.4.0
