### PR TITLE
feat(service): adapt btc-assets-api#184 and #186

### DIFF
--- a/.changeset/clean-snails-admire.md
+++ b/.changeset/clean-snails-admire.md
@@ -1,0 +1,5 @@
+---
+"@rgbpp-sdk/service": minor
+---
+
+Add "type_script" in the return type of /rgbpp/v1/address/{btc_address}/balance API, and add "typeHash" in the return type of rgbpp asset APIs

--- a/packages/service/src/service/service.ts
+++ b/packages/service/src/service/service.ts
@@ -1,4 +1,3 @@
-import { Cell } from '@ckb-lumos/base';
 import { BtcAssetsApiBase } from './base';
 import {
   BtcApis,
@@ -18,6 +17,7 @@ import {
 } from '../types';
 import {
   RgbppApis,
+  RgbppCell,
   RgbppApiSpvProof,
   RgbppApiPaymasterInfo,
   RgbppApiTransactionState,
@@ -117,15 +117,15 @@ export class BtcAssetsApi extends BtcAssetsApiBase implements BtcApis, RgbppApis
   }
 
   getRgbppAssetsByBtcTxId(btcTxId: string) {
-    return this.request<Cell[]>(`/rgbpp/v1/assets/${btcTxId}`);
+    return this.request<RgbppCell[]>(`/rgbpp/v1/assets/${btcTxId}`);
   }
 
   getRgbppAssetsByBtcUtxo(btcTxId: string, vout: number) {
-    return this.request<Cell[]>(`/rgbpp/v1/assets/${btcTxId}/${vout}`);
+    return this.request<RgbppCell[]>(`/rgbpp/v1/assets/${btcTxId}/${vout}`);
   }
 
   getRgbppAssetsByBtcAddress(btcAddress: string, params?: RgbppApiAssetsByAddressParams) {
-    return this.request<Cell[]>(`/rgbpp/v1/address/${btcAddress}/assets`, {
+    return this.request<RgbppCell[]>(`/rgbpp/v1/address/${btcAddress}/assets`, {
       params,
     });
   }

--- a/packages/service/src/types/rgbpp.ts
+++ b/packages/service/src/types/rgbpp.ts
@@ -1,12 +1,12 @@
-import { Cell } from '@ckb-lumos/base';
+import { Cell, Hash, Script } from '@ckb-lumos/base';
 
 export interface RgbppApis {
   getRgbppPaymasterInfo(): Promise<RgbppApiPaymasterInfo>;
   getRgbppTransactionHash(btcTxId: string): Promise<RgbppApiCkbTransactionHash>;
   getRgbppTransactionState(btcTxId: string): Promise<RgbppApiTransactionState>;
-  getRgbppAssetsByBtcTxId(btcTxId: string): Promise<Cell[]>;
-  getRgbppAssetsByBtcUtxo(btcTxId: string, vout: number): Promise<Cell[]>;
-  getRgbppAssetsByBtcAddress(btcAddress: string, params?: RgbppApiAssetsByAddressParams): Promise<Cell[]>;
+  getRgbppAssetsByBtcTxId(btcTxId: string): Promise<RgbppCell[]>;
+  getRgbppAssetsByBtcUtxo(btcTxId: string, vout: number): Promise<RgbppCell[]>;
+  getRgbppAssetsByBtcAddress(btcAddress: string, params?: RgbppApiAssetsByAddressParams): Promise<RgbppCell[]>;
   getRgbppBalanceByBtcAddress(btcAddress: string, params?: RgbppApiBalanceByAddressParams): Promise<RgbppApiBalance>;
   getRgbppSpvProof(btcTxId: string, confirmations: number): Promise<RgbppApiSpvProof>;
   sendRgbppCkbTransaction(payload: RgbppApiSendCkbTransactionPayload): Promise<RgbppApiTransactionState>;
@@ -43,6 +43,10 @@ export interface RgbppApiTransactionState {
   };
 }
 
+export interface RgbppCell extends Cell {
+  typeHash?: Hash;
+}
+
 export interface RgbppApiAssetsByAddressParams {
   type_script?: string;
   no_cache?: boolean;
@@ -64,6 +68,7 @@ export interface RgbppApiXudtBalance {
   available_amount: string;
   pending_amount: string;
   type_hash: string;
+  type_script: Script;
 }
 
 export interface RgbppApiSpvProof {

--- a/packages/service/tests/Service.test.ts
+++ b/packages/service/tests/Service.test.ts
@@ -1,7 +1,7 @@
-import { Cell, blockchain } from '@ckb-lumos/base';
+import { Cell, blockchain, Script } from '@ckb-lumos/base';
 import { bytes } from '@ckb-lumos/codec';
 import { describe, expect, it } from 'vitest';
-import { BtcAssetsApiError, BtcAssetsApi, ErrorCodes, ErrorMessages } from '../src';
+import { BtcAssetsApiError, BtcAssetsApi, ErrorCodes, ErrorMessages, RgbppCell } from '../src';
 
 describe(
   'BtcServiceApi',
@@ -240,7 +240,7 @@ describe(
         expect(res).toBeDefined();
         expect(res.length).toBeGreaterThan(0);
         for (const cell of res) {
-          expectCell(cell);
+          expectRgbppCell(cell);
         }
       });
       it('getRgbppAssetsByBtcUtxo()', async () => {
@@ -248,7 +248,7 @@ describe(
         expect(res).toBeDefined();
         expect(res.length).toBeGreaterThan(0);
         for (const cell of res) {
-          expectCell(cell);
+          expectRgbppCell(cell);
         }
       });
       it('getRgbppAssetsByBtcAddress()', async () => {
@@ -258,7 +258,7 @@ describe(
         expect(res).toBeDefined();
         expect(res.length).toBeGreaterThan(0);
         for (const cell of res) {
-          expectCell(cell);
+          expectRgbppCell(cell);
         }
       });
       it('getRgbppBalanceByBtcAddress()', async () => {
@@ -274,6 +274,7 @@ describe(
           expect(xudt.available_amount).toBeTypeOf('string');
           expect(xudt.pending_amount).toBeTypeOf('string');
           expect(xudt.type_hash).toBeTypeOf('string');
+          expectScript(xudt.type_script);
         }
       });
       it('getRgbppSpvProof()', async () => {
@@ -315,4 +316,19 @@ function expectCell(cell: Cell) {
   expect(cell.outPoint?.index).toBeTypeOf('string');
 
   expect(cell.data).toBeTypeOf('string');
+}
+
+function expectRgbppCell(cell: RgbppCell) {
+  expectCell(cell);
+
+  if (cell.typeHash) {
+    expect(cell.typeHash).toBeTypeOf('string');
+  }
+}
+
+function expectScript(script: Script) {
+  expect(script).toBeDefined();
+  expect(script.codeHash).toBeTypeOf('string');
+  expect(script.hashType).toBeTypeOf('string');
+  expect(script.args).toBeTypeOf('string');
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -150,7 +150,7 @@ importers:
         version: 0.109.1
       rgbpp:
         specifier: ^0.3.0
-        version: link:../../packages/rgbpp
+        version: 0.3.0(@ckb-lumos/lumos@0.22.0-next.5)(lodash@4.17.21)
     devDependencies:
       '@types/dotenv':
         specifier: ^8.2.0
@@ -2027,6 +2027,53 @@ packages:
     requiresBuild: true
     dev: true
     optional: true
+
+  /@rgbpp-sdk/btc@0.3.0(@ckb-lumos/lumos@0.22.0-next.5):
+    resolution: {integrity: sha512-0KLVRAlYxA/m2K1FTrrtAHezfaEg0MXfEmlHjMIK1oOUjUuis5UAJPSyB83Ql5RjVRFFolxdyPoW2Xe7MhAp4A==}
+    dependencies:
+      '@bitcoinerlab/secp256k1': 1.1.1
+      '@ckb-lumos/codec': 0.22.2
+      '@nervosnetwork/ckb-types': 0.109.1
+      '@rgbpp-sdk/ckb': 0.3.0(@ckb-lumos/lumos@0.22.0-next.5)(lodash@4.17.21)
+      '@rgbpp-sdk/service': 0.3.0
+      bip32: 4.0.0
+      bitcoinjs-lib: 6.1.5
+      ecpair: 2.1.0
+      lodash: 4.17.21
+      p-limit: 3.1.0
+    transitivePeerDependencies:
+      - '@ckb-lumos/lumos'
+      - debug
+    dev: false
+
+  /@rgbpp-sdk/ckb@0.3.0(@ckb-lumos/lumos@0.22.0-next.5)(lodash@4.17.21):
+    resolution: {integrity: sha512-Qf6Yhgakz8UhkZ+PulIHdrMVSDbZPW7+GDTA8KLrfVB/EEMoXA5L5LVanJKrYKTgBkGXYwEXW8Tti0Lr76SBmA==}
+    dependencies:
+      '@ckb-lumos/base': 0.22.2
+      '@ckb-lumos/codec': 0.22.2
+      '@exact-realty/multipart-parser': 1.0.13
+      '@nervosnetwork/ckb-sdk-core': 0.109.1
+      '@nervosnetwork/ckb-sdk-utils': 0.109.1
+      '@nervosnetwork/ckb-types': 0.109.1
+      '@rgbpp-sdk/service': 0.3.0
+      '@spore-sdk/core': 0.2.0-beta.6(@ckb-lumos/lumos@0.22.0-next.5)(lodash@4.17.21)
+      axios: 1.6.8
+      camelcase-keys: 7.0.2
+      js-sha256: 0.11.0
+    transitivePeerDependencies:
+      - '@ckb-lumos/lumos'
+      - debug
+      - lodash
+    dev: false
+
+  /@rgbpp-sdk/service@0.3.0:
+    resolution: {integrity: sha512-MvVBVWbdYQVnjnCf3xYH6HXqHaUmL7DjUVucTYMjbB0cMeBqVjEAkX1RIVUqqcCpgSeYnK1nFEQHXB51rx8bMw==}
+    dependencies:
+      '@ckb-lumos/base': 0.22.2
+      '@ckb-lumos/codec': 0.22.2
+      '@nervosnetwork/ckb-types': 0.109.1
+      lodash: 4.17.21
+    dev: false
 
   /@rollup/rollup-android-arm-eabi@4.13.2:
     resolution: {integrity: sha512-3XFIDKWMFZrMnao1mJhnOT1h2g0169Os848NhhmGweEcfJ4rCi+3yMCOLG4zA61rbJdkcrM/DjVZm9Hg5p5w7g==}
@@ -6793,6 +6840,18 @@ packages:
 
   /rfdc@1.3.1:
     resolution: {integrity: sha512-r5a3l5HzYlIC68TpmYKlxWjmOP6wiPJ1vWv2HeLhNsRZMrCkxeqxiHlQ21oXmQ4F3SiryXBHhAD7JZqvOJjFmg==}
+
+  /rgbpp@0.3.0(@ckb-lumos/lumos@0.22.0-next.5)(lodash@4.17.21):
+    resolution: {integrity: sha512-SvvQsTwcTpxedKhzKY+fJQCavfnO2wtyAgO6zkuXBxveLKQQrsvCNumhwzfLOkZW8PhEDz4qAks3WhYnyOR2Vw==}
+    dependencies:
+      '@rgbpp-sdk/btc': 0.3.0(@ckb-lumos/lumos@0.22.0-next.5)
+      '@rgbpp-sdk/ckb': 0.3.0(@ckb-lumos/lumos@0.22.0-next.5)(lodash@4.17.21)
+      '@rgbpp-sdk/service': 0.3.0
+    transitivePeerDependencies:
+      - '@ckb-lumos/lumos'
+      - debug
+      - lodash
+    dev: false
 
   /rimraf@3.0.2:
     resolution: {integrity: sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==}


### PR DESCRIPTION
## Changes
- Add "type_script" in the return type of `/rgbpp/v1/address/{btc_address}/balance` API, and add "typeHash" in the return type of rgbpp assets-related APIs, adapting changes in [btc-assets-api#184](https://github.com/ckb-cell/btc-assets-api/pull/184) and [btc-assets-api#186](https://github.com/ckb-cell/btc-assets-api/pull/186)
- Update `pnpm-lock.yaml` file to the latest