### PR TITLE
fix(ci): comment format in release/snapshot workflows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,7 +66,7 @@ jobs:
         with:
           script: |
             const packages = JSON.parse(process.env.PACKAGES)
-            const packagesTable = packages.map((p) => `| ${p.name} | \`${p.version}\` |`)
+            const packagesTable = packages.map((p) => `| ${p.name} | \`${p.version}\` |`).join('\n')
             const body = ['New official version of the rgbpp-sdk packages have been released:', '| Name | Version |', '| --- | --- |', packagesTable].join('\n')
             github.rest.repos.createCommitComment({
               commit_sha: context.sha,

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -81,7 +81,7 @@ jobs:
         with:
           script: |
             const packages = JSON.parse(process.env.PACKAGES)
-            const packagesTable = packages.map((p) => `| ${p.name} | \`${p.version}\` |`)
+            const packagesTable = packages.map((p) => `| ${p.name} | \`${p.version}\` |`).join('\n')
             const body = ['New snapshot version of the rgbpp-sdk packages have been released:', '| Name | Version |', '| --- | --- |', packagesTable].join('\n')
             github.rest.repos.createCommitComment({
               commit_sha: context.sha,


### PR DESCRIPTION
## Changes
- Fix comment format in `release` and `snapshot` workflows (reported by @duanyytop)

## Fix

Previously, the comment on the commit that triggers the release/snapshot workflow was not formatted correctly, causing it to show only the first line of the table. Here's an example: https://github.com/ckb-cell/rgbpp-sdk/commit/53fc8eec4fb15974f4734de3913e528f4b1d0efc#commitcomment-143869323

The table should be fixed to:
| Name | Version |
| --- | --- |
| @rgbpp-sdk/btc | `0.0.0-snap-20240705090030` |
| @rgbpp-sdk/ckb | `0.0.0-snap-20240705090030` |
| rgbpp | `0.0.0-snap-20240705090030` |
| @rgbpp-sdk/service | `0.0.0-snap-20240705090030` |