### PR TITLE
feat(service): support /rgbpp/v1/address/{btc_address}/activity

### DIFF
--- a/.changeset/odd-cheetahs-shake.md
+++ b/.changeset/odd-cheetahs-shake.md
@@ -1,0 +1,5 @@
+---
+"@rgbpp-sdk/service": minor
+---
+
+Add support of /rgbpp/v1/address/{btc_address}/activity API for querying RGBPP asset activities by an BTC address

--- a/packages/service/README.md
+++ b/packages/service/README.md
@@ -398,7 +398,7 @@ interface RgbppApiActivity {
     btcTx: BtcApiTransaction;
     isRgbpp: boolean;
     isomorphicTx?: {
-      ckbRawTx?: CKBComponents.RawTransaction;
+      ckbVirtualTx?: CKBComponents.RawTransaction;
       ckbTx?: CKBComponents.Transaction;
       inputs?: CKBComponents.CellOutput[];
       outputs?: CKBComponents.CellOutput[];

--- a/packages/service/src/service/service.ts
+++ b/packages/service/src/service/service.ts
@@ -14,6 +14,8 @@ import {
   BtcApiUtxoParams,
   BtcApiTransactionParams,
   BtcApiRecommendedFeeRates,
+  RgbppApiActivityByAddressParams,
+  RgbppApiActivity,
 } from '../types';
 import {
   RgbppApis,
@@ -132,6 +134,12 @@ export class BtcAssetsApi extends BtcAssetsApiBase implements BtcApis, RgbppApis
 
   getRgbppBalanceByBtcAddress(btcAddress: string, params?: RgbppApiBalanceByAddressParams) {
     return this.request<RgbppApiBalance>(`/rgbpp/v1/address/${btcAddress}/balance`, {
+      params,
+    });
+  }
+
+  getRgbppActivityByBtcAddress(btcAddress: string, params?: RgbppApiActivityByAddressParams) {
+    return this.request<RgbppApiActivity>(`/rgbpp/v1/address/${btcAddress}/activity`, {
       params,
     });
   }

--- a/packages/service/src/types/btc.ts
+++ b/packages/service/src/types/btc.ts
@@ -15,7 +15,7 @@ export interface BtcApis {
 export interface BtcApiBlockchainInfo {
   chain: string;
   blocks: number;
-  bestblockhash: number;
+  bestblockhash: string;
   difficulty: number;
   mediantime: number;
 }

--- a/packages/service/src/types/rgbpp.ts
+++ b/packages/service/src/types/rgbpp.ts
@@ -1,4 +1,5 @@
 import { Cell, Hash, Script } from '@ckb-lumos/base';
+import { BtcApiTransaction } from './btc';
 
 export interface RgbppApis {
   getRgbppPaymasterInfo(): Promise<RgbppApiPaymasterInfo>;
@@ -8,6 +9,7 @@ export interface RgbppApis {
   getRgbppAssetsByBtcUtxo(btcTxId: string, vout: number): Promise<RgbppCell[]>;
   getRgbppAssetsByBtcAddress(btcAddress: string, params?: RgbppApiAssetsByAddressParams): Promise<RgbppCell[]>;
   getRgbppBalanceByBtcAddress(btcAddress: string, params?: RgbppApiBalanceByAddressParams): Promise<RgbppApiBalance>;
+  getRgbppActivityByBtcAddress(btcAddress: string, params?: RgbppApiActivityByAddressParams): Promise<RgbppApiActivity>;
   getRgbppSpvProof(btcTxId: string, confirmations: number): Promise<RgbppApiSpvProof>;
   sendRgbppCkbTransaction(payload: RgbppApiSendCkbTransactionPayload): Promise<RgbppApiTransactionState>;
   retryRgbppCkbTransaction(payload: RgbppApiRetryCkbTransactionPayload): Promise<RgbppApiTransactionRetry>;
@@ -71,6 +73,29 @@ export interface RgbppApiXudtBalance {
   type_script: Script;
 }
 
+export interface RgbppApiActivityByAddressParams {
+  rgbpp_only?: boolean;
+  type_script?: string;
+  after_btc_txid?: string;
+}
+export interface RgbppApiActivity {
+  address: string;
+  cursor: string;
+  txs: {
+    btcTx: BtcApiTransaction;
+    isRgbpp: boolean;
+    isomorphicTx?: {
+      ckbVirtualTx?: CKBComponents.RawTransaction;
+      ckbTx?: CKBComponents.Transaction;
+      inputs?: CKBComponents.CellOutput[];
+      outputs?: CKBComponents.CellOutput[];
+      status: {
+        confirmed: boolean;
+      };
+    };
+  }[];
+}
+
 export interface RgbppApiSpvProof {
   proof: string;
   spv_client: {
@@ -81,15 +106,14 @@ export interface RgbppApiSpvProof {
 
 export interface RgbppApiSendCkbTransactionPayload {
   btc_txid: string;
-  // Support ckbVirtaulTxResult and it's JSON string as request parameter
-  ckb_virtual_result:
-    | {
-        ckbRawTx: CKBComponents.RawTransaction;
-        needPaymasterCell: boolean;
-        sumInputsCapacity: string;
-        commitment: string;
-      }
-    | string;
+  // Support ckbVirtualTxResult and it's JSON string as request parameter
+  ckb_virtual_result: RgbppApiSendCkbVirtualResult | string;
+}
+export interface RgbppApiSendCkbVirtualResult {
+  ckbRawTx: CKBComponents.RawTransaction;
+  needPaymasterCell: boolean;
+  sumInputsCapacity: string;
+  commitment: string;
 }
 
 export interface RgbppApiRetryCkbTransactionPayload {

--- a/packages/service/tests/Service.test.ts
+++ b/packages/service/tests/Service.test.ts
@@ -146,7 +146,6 @@ describe(
       });
       it('getBtcTransactions()', async () => {
         const res = await service.getBtcTransactions(btcAddress);
-        console.log(res.map((tx) => tx.txid));
         expect(Array.isArray(res)).toBe(true);
         expect(res.length).toBeGreaterThan(0);
         res.forEach((transaction) => {
@@ -275,6 +274,30 @@ describe(
           expect(xudt.pending_amount).toBeTypeOf('string');
           expect(xudt.type_hash).toBeTypeOf('string');
           expectScript(xudt.type_script);
+        }
+      });
+      it('getRgbppActivityByBtcAddress()', async () => {
+        const res = await service.getRgbppActivityByBtcAddress(rgbppBtcAddress, {
+          type_script: rgbppCellType,
+        });
+        expect(res).toBeDefined();
+        expect(res.address).toBeTypeOf('string');
+        expect(res.cursor).toBeTypeOf('string');
+        expect(res.txs).toHaveProperty('length');
+        if (res.txs.length > 0) {
+          for (const tx of res.txs) {
+            expect(tx.btcTx).toBeDefined();
+            expect(tx.isRgbpp).toBeTypeOf('boolean');
+            if (tx.isRgbpp) {
+              expect(tx.isomorphicTx).toBeDefined();
+              expect(tx.isomorphicTx.status.confirmed).toBeTypeOf('boolean');
+              const hasTxOrVirtualTx = tx.isomorphicTx.ckbVirtualTx ?? tx.isomorphicTx.ckbTx;
+              if (hasTxOrVirtualTx) {
+                expect(tx.isomorphicTx.inputs).toBeDefined();
+                expect(tx.isomorphicTx.outputs).toBeDefined();
+              }
+            }
+          }
         }
       });
       it('getRgbppSpvProof()', async () => {


### PR DESCRIPTION
## Changes
- Add support of the `/rgbpp/v1/address/{btc_address}/activity` API for querying RGBPP asset activities by an BTC address, adapting changes in [btc-assets-api#182](https://github.com/ckb-cell/btc-assets-api/pull/182) and [btc-assets-api#194](https://github.com/ckb-cell/btc-assets-api/pull/194)
- Fix the type of `BtcApiBlockchainInfo.bestblockhash` to `string`
- Update types in the service lib README

## Known Issue
- https://github.com/ckb-cell/btc-assets-api/issues/214