### PR TITLE
feat(rgpp-sdk/ckb): Allow RGB++ spore cell not to reserve CKB

### DIFF
--- a/.changeset/sweet-singers-hang.md
+++ b/.changeset/sweet-singers-hang.md
@@ -1,0 +1,5 @@
+---
+"@rgbpp-sdk/ckb": minor
+---
+
+feat: Allow rgbpp spore cell to not reserve CKB

--- a/examples/rgbpp/spore/launch/3-create-spores.ts
+++ b/examples/rgbpp/spore/launch/3-create-spores.ts
@@ -33,6 +33,8 @@ interface SporeCreateParams {
 
 // Warning: Before runing this file for the first time, please run 2-prepare-cluster.ts
 const createSpores = async ({ clusterRgbppLockArgs, receivers }: SporeCreateParams) => {
+  // True is to reserve more CKB to leap from BTC to CKB, otherwise, not to reserve CKB
+  const reserveMoreCkbForLeap = true;
   const ckbVirtualTxResult = await genCreateSporeCkbVirtualTx({
     collector,
     sporeDataList: receivers.map((receiver) => receiver.sporeData),
@@ -40,6 +42,7 @@ const createSpores = async ({ clusterRgbppLockArgs, receivers }: SporeCreatePara
     isMainnet,
     ckbFeeRate: BigInt(2000),
     btcTestnetType: BTC_TESTNET_TYPE,
+    reserveMoreCkb: reserveMoreCkbForLeap,
   });
 
   // Save ckbVirtualTxResult

--- a/examples/rgbpp/spore/launch/3-create-spores.ts
+++ b/examples/rgbpp/spore/launch/3-create-spores.ts
@@ -33,7 +33,7 @@ interface SporeCreateParams {
 
 // Warning: Before runing this file for the first time, please run 2-prepare-cluster.ts
 const createSpores = async ({ clusterRgbppLockArgs, receivers }: SporeCreateParams) => {
-  // True is to reserve more CKB to leap from BTC to CKB, otherwise, not to reserve CKB
+  // True is to reserve more CKB to leap from BTC to CKB, otherwise, not to reserve CKB, default value is true
   const reserveMoreCkbForLeap = true;
   const ckbVirtualTxResult = await genCreateSporeCkbVirtualTx({
     collector,

--- a/packages/ckb/README.md
+++ b/packages/ckb/README.md
@@ -152,13 +152,15 @@ export interface SporeCreateVirtualTxResult {
  * @param sporeDataList The spore's data list, including name and description.
  * @param isMainnet True is for BTC and CKB Mainnet, false is for BTC and CKB Testnet(see btcTestnetType for details about BTC Testnet)
  * @param btcTestnetType(Optional) The Bitcoin Testnet type including Testnet3 and Signet, default value is Testnet3
+ * @param reserveMoreCkb(Optional) True is to reserve more CKB to leap from BTC to CKB, otherwise, not to reserve CKB, default value is true
  */
 export const genCreateSporeCkbVirtualTx = async ({
   collector,
   clusterRgbppLockArgs,
   sporeDataList,
   isMainnet,
-  btcTestnetType
+  btcTestnetType,
+  reserveMoreCkb
 }: CreateSporeCkbVirtualTxParams): Promise<SporeCreateVirtualTxResult>
 ```
 

--- a/packages/ckb/src/spore/leap.ts
+++ b/packages/ckb/src/spore/leap.ts
@@ -1,5 +1,5 @@
 import { BtcTimeCellsParams, RgbppCkbVirtualTx } from '../types/rgbpp';
-import { append0x, calculateTransactionFee, fetchTypeIdCellDeps } from '../utils';
+import { append0x, calculateTransactionFee, fetchTypeIdCellDeps, isSporeCapacitySufficient } from '../utils';
 import {
   btcTxIdFromBtcTimeLockArgs,
   buildSpvClientCellDep,
@@ -63,6 +63,7 @@ export const genLeapSporeFromBtcToCkbVirtualTx = async ({
   throwErrorWhenSporeCellsInvalid(sporeCells, sporeTypeBytes, isMainnet);
 
   const sporeCell = sporeCells![0];
+  const needPaymasterCell = !isSporeCapacitySufficient(sporeCell);
 
   const inputs: CKBComponents.CellInput[] = [
     {
@@ -112,7 +113,7 @@ export const genLeapSporeFromBtcToCkbVirtualTx = async ({
     ckbRawTx,
     commitment,
     sporeCell,
-    needPaymasterCell: false,
+    needPaymasterCell,
     sumInputsCapacity: sporeCell.output.capacity,
   };
 };

--- a/packages/ckb/src/spore/spore.ts
+++ b/packages/ckb/src/spore/spore.ts
@@ -58,7 +58,7 @@ import signWitnesses from '@nervosnetwork/ckb-sdk-core/lib/signWitnesses';
  * @param sporeDataList The spore's data list, including name and description.
  * @param isMainnet True is for BTC and CKB Mainnet, false is for BTC and CKB Testnet(see btcTestnetType for details about BTC Testnet)
  * @param btcTestnetType(Optional) The Bitcoin Testnet type including Testnet3 and Signet, default value is Testnet3
- * @param reserveMoreCkb(Optional) True is to reserve more CKB to leap from BTC to CKB, otherwise, not to reserve CKB
+ * @param reserveMoreCkb(Optional) True is to reserve more CKB to leap from BTC to CKB, otherwise, not to reserve CKB, default value is true
  */
 export const genCreateSporeCkbVirtualTx = async ({
   collector,
@@ -66,7 +66,7 @@ export const genCreateSporeCkbVirtualTx = async ({
   sporeDataList,
   isMainnet,
   btcTestnetType,
-  reserveMoreCkb = true,
+  reserveMoreCkb,
 }: CreateSporeCkbVirtualTxParams): Promise<SporeCreateVirtualTxResult> => {
   const clusterRgbppLock = genRgbppLockScript(clusterRgbppLockArgs, isMainnet, btcTestnetType);
   const clusterCells = await collector.getCells({ lock: clusterRgbppLock, isDataMustBeEmpty: false });

--- a/packages/ckb/src/spore/spore.ts
+++ b/packages/ckb/src/spore/spore.ts
@@ -58,6 +58,7 @@ import signWitnesses from '@nervosnetwork/ckb-sdk-core/lib/signWitnesses';
  * @param sporeDataList The spore's data list, including name and description.
  * @param isMainnet True is for BTC and CKB Mainnet, false is for BTC and CKB Testnet(see btcTestnetType for details about BTC Testnet)
  * @param btcTestnetType(Optional) The Bitcoin Testnet type including Testnet3 and Signet, default value is Testnet3
+ * @param reserveMoreCkb(Optional) True is to reserve more CKB to leap from BTC to CKB, otherwise, not to reserve CKB
  */
 export const genCreateSporeCkbVirtualTx = async ({
   collector,
@@ -65,6 +66,7 @@ export const genCreateSporeCkbVirtualTx = async ({
   sporeDataList,
   isMainnet,
   btcTestnetType,
+  reserveMoreCkb = true,
 }: CreateSporeCkbVirtualTxParams): Promise<SporeCreateVirtualTxResult> => {
   const clusterRgbppLock = genRgbppLockScript(clusterRgbppLockArgs, isMainnet, btcTestnetType);
   const clusterCells = await collector.getCells({ lock: clusterRgbppLock, isDataMustBeEmpty: false });
@@ -102,7 +104,7 @@ export const genCreateSporeCkbVirtualTx = async ({
       // The CKB transaction outputs[0] fro cluster and outputs[1]... for spore
       args: generateSporeId(inputs[0], index + 1),
     },
-    capacity: append0x(calculateRgbppSporeCellCapacity(data).toString(16)),
+    capacity: append0x(calculateRgbppSporeCellCapacity(data, reserveMoreCkb).toString(16)),
   }));
   const sporeOutputsData = sporeDataList.map((data) => bytesToHex(packRawSporeData(data)));
 

--- a/packages/ckb/src/types/spore.ts
+++ b/packages/ckb/src/types/spore.ts
@@ -46,7 +46,7 @@ export interface CreateSporeCkbVirtualTxParams {
   witnessLockPlaceholderSize?: number;
   // The CKB transaction fee rate, default value is 1100
   ckbFeeRate?: bigint;
-  // True is to reserve more CKB to leap from BTC to CKB, otherwise, not to reserve CKB
+  // True is to reserve more CKB to leap from BTC to CKB, otherwise, not to reserve CKB, default value is true
   reserveMoreCkb?: boolean;
 }
 

--- a/packages/ckb/src/types/spore.ts
+++ b/packages/ckb/src/types/spore.ts
@@ -46,6 +46,8 @@ export interface CreateSporeCkbVirtualTxParams {
   witnessLockPlaceholderSize?: number;
   // The CKB transaction fee rate, default value is 1100
   ckbFeeRate?: bigint;
+  // True is to reserve more CKB to leap from BTC to CKB, otherwise, not to reserve CKB
+  reserveMoreCkb?: boolean;
 }
 
 export interface SporeCreateVirtualTxResult {

--- a/packages/ckb/src/utils/ckb-tx.spec.ts
+++ b/packages/ckb/src/utils/ckb-tx.spec.ts
@@ -138,8 +138,8 @@ describe('ckb tx utils', () => {
       content: hexToBytes(utf8ToHex('First Spore')),
       clusterId: '0xbc5168a4f90116fada921e185d4b018e784dc0f6266e539a3c092321c932700a',
     };
-    const capacity = calculateRgbppSporeCellCapacity(sporeData);
-    expect(capacity).toBe(BigInt(319_0000_0000));
+    expect(calculateRgbppSporeCellCapacity(sporeData)).toBe(BigInt(319_0000_0000));
+    expect(calculateRgbppSporeCellCapacity(sporeData, false)).toBe(BigInt(224_0000_0000));
   });
 
   it('deduplicateList', () => {
@@ -226,14 +226,8 @@ describe('ckb tx utils', () => {
     };
     expect(true).toBe(isSporeCapacitySufficient(sporeCell));
 
-    const sporeCell1 = {
-      ...sporeCell,
-      output: {
-        ...sporeCell.output,
-        capacity: '0x5e9f53e00', // 254 CKB
-      },
-    };
-    expect(false).toBe(isSporeCapacitySufficient(sporeCell1));
+    sporeCell.output.capacity = '0x5e9f53e00'; // 254 CKB
+    expect(false).toBe(isSporeCapacitySufficient(sporeCell));
   });
 
   it('checkCkbTxInputsCapacitySufficient', { timeout: 20000 }, async () => {

--- a/packages/ckb/src/utils/ckb-tx.spec.ts
+++ b/packages/ckb/src/utils/ckb-tx.spec.ts
@@ -11,11 +11,13 @@ import {
   isScriptEqual,
   isTypeAssetSupported,
   checkCkbTxInputsCapacitySufficient,
+  calculateCellOccupiedCapacity,
 } from './ckb-tx';
 import { hexToBytes } from '@nervosnetwork/ckb-sdk-utils';
 import { Collector } from '../collector';
 import { NoLiveCellError } from '../error';
 import { utf8ToHex } from './hex';
+import { IndexerCell } from '../types';
 
 describe('ckb tx utils', () => {
   it('calculateTransactionFee', () => {
@@ -170,6 +172,32 @@ describe('ckb tx utils', () => {
         '0x123456',
       ),
     );
+  });
+
+  it('calculateCellOccupiedCapacity', () => {
+    const cell: IndexerCell = {
+      output: {
+        capacity: '0x5e9f53e00',
+        lock: {
+          args: '0x6b6a9580fc2aceb920c63adea27a667acfc180f67cf875b36f31b42546ac4920',
+          codeHash: '0x61ca7a4796a4eb19ca4f0d065cb9b10ddcf002f10f7cbb810c706cb6bb5c3248',
+          hashType: 'type',
+        },
+        type: {
+          args: '0x6b6a9580fc2aceb920c63adea27a667acfc180f67cf875b36f31b42546ac4920',
+          codeHash: '0x25c29dc317811a6f6f3985a7a9ebc4838bd388d19d0feeecf0bcd60f6c0975bb',
+          hashType: 'type',
+        },
+      },
+      outPoint: {
+        index: '0x1',
+        txHash: '0x1a6d2b18faed84293b81ada9d00600a3cdb637fa43a5cfa20eb63934757352ea',
+      },
+      blockNumber: '0x0',
+      txIndex: '0x0',
+      outputData: '0x6b6a9580fc2aceb920c63adea27a667acfc180f67cf875b36f31b42546ac4920',
+    };
+    expect(BigInt(17000000000)).toBe(calculateCellOccupiedCapacity(cell));
   });
 
   it('checkCkbTxInputsCapacitySufficient', { timeout: 20000 }, async () => {

--- a/packages/ckb/src/utils/ckb-tx.spec.ts
+++ b/packages/ckb/src/utils/ckb-tx.spec.ts
@@ -12,6 +12,7 @@ import {
   isTypeAssetSupported,
   checkCkbTxInputsCapacitySufficient,
   calculateCellOccupiedCapacity,
+  isSporeCapacitySufficient,
 } from './ckb-tx';
 import { hexToBytes } from '@nervosnetwork/ckb-sdk-utils';
 import { Collector } from '../collector';
@@ -198,6 +199,41 @@ describe('ckb tx utils', () => {
       outputData: '0x6b6a9580fc2aceb920c63adea27a667acfc180f67cf875b36f31b42546ac4920',
     };
     expect(BigInt(17000000000)).toBe(calculateCellOccupiedCapacity(cell));
+  });
+
+  it('isSporeCapacitySufficient', () => {
+    const sporeCell: IndexerCell = {
+      output: {
+        capacity: '0x639f53e00', // 267.42177280 CKB
+        lock: {
+          args: '0x6b6a9580fc2aceb920c63adea27a667acfc180f67cf875b36f31b42546ac4920',
+          codeHash: '0x61ca7a4796a4eb19ca4f0d065cb9b10ddcf002f10f7cbb810c706cb6bb5c3248',
+          hashType: 'type',
+        },
+        type: {
+          args: '0x6b6a9580fc2aceb920c63adea27a667acfc180f67cf875b36f31b42546ac4920',
+          codeHash: '0x25c29dc317811a6f6f3985a7a9ebc4838bd388d19d0feeecf0bcd60f6c0975bb',
+          hashType: 'type',
+        },
+      },
+      outPoint: {
+        index: '0x1',
+        txHash: '0x1a6d2b18faed84293b81ada9d00600a3cdb637fa43a5cfa20eb63934757352ea',
+      },
+      blockNumber: '0x0',
+      txIndex: '0x0',
+      outputData: '0x6b6a9580fc2aceb920c63adea27a667acfc180f67cf875b36f31b42546ac4920',
+    };
+    expect(true).toBe(isSporeCapacitySufficient(sporeCell));
+
+    const sporeCell1 = {
+      ...sporeCell,
+      output: {
+        ...sporeCell.output,
+        capacity: '0x5e9f53e00', // 254 CKB
+      },
+    };
+    expect(false).toBe(isSporeCapacitySufficient(sporeCell1));
   });
 
   it('checkCkbTxInputsCapacitySufficient', { timeout: 20000 }, async () => {

--- a/packages/ckb/src/utils/ckb-tx.ts
+++ b/packages/ckb/src/utils/ckb-tx.ts
@@ -149,8 +149,8 @@ export const calculateRgbppSporeCellCapacity = (sporeData: SporeDataProps, reser
 // Calculate the occupied capacity of the CKB cell
 export const calculateCellOccupiedCapacity = (cell: IndexerCell): bigint => {
   const cellDataSize = remove0x(cell.outputData).length / 2;
-  const lockSize = remove0x(cell.output.lock.args).length / 2 + 33;
-  const typeSize = cell.output.type ? remove0x(cell.output.type.args).length + 1 + 20 : 0;
+  const lockSize = remove0x(cell.output.lock.args).length / 2 + 1 + 32;
+  const typeSize = cell.output.type ? remove0x(cell.output.type.args).length / 2 + 1 + 32 : 0;
   const cellSize = cellDataSize + lockSize + typeSize + CELL_CAPACITY_SIZE;
   return BigInt(cellSize) * CKB_UNIT;
 };

--- a/packages/ckb/src/utils/ckb-tx.ts
+++ b/packages/ckb/src/utils/ckb-tx.ts
@@ -158,7 +158,7 @@ export const calculateCellOccupiedCapacity = (cell: IndexerCell): bigint => {
 export const isSporeCapacitySufficient = (sporeCell: IndexerCell) => {
   const occupiedCapacity = calculateCellOccupiedCapacity(sporeCell);
   const capacity = BigInt(sporeCell.output.capacity);
-  return capacity - occupiedCapacity > BTC_TIME_CELL_INCREASED_SIZE;
+  return capacity - occupiedCapacity > BigInt(BTC_TIME_CELL_INCREASED_SIZE) * CKB_UNIT;
 };
 
 export const deduplicateList = (rgbppLockArgsList: Hex[]): Hex[] => {

--- a/packages/ckb/src/utils/ckb-tx.ts
+++ b/packages/ckb/src/utils/ckb-tx.ts
@@ -132,6 +132,7 @@ export const calculateRgbppClusterCellCapacity = (clusterData: RawClusterData): 
 // https://docs.spore.pro/recipes/Create/create-clustered-spore
 // For simplicity, we keep the capacity of the RGBPP cell the same as the BTC time cell
 // minimum occupied capacity and 1 ckb for transaction fee
+// The reserveMoreCkb is to reserve more CKB to leap from BTC to CKB, otherwise, not to reserve CKB, default value is true
 /**
  * rgbpp_spore_cell:
     lock: rgbpp_lock

--- a/packages/ckb/src/utils/ckb-tx.ts
+++ b/packages/ckb/src/utils/ckb-tx.ts
@@ -54,11 +54,11 @@ export const isTypeAssetSupported = (type: CKBComponents.Script, isMainnet: bool
 const CELL_CAPACITY_SIZE = 8;
 const UDT_CELL_DATA_SIZE = 16;
 
-// The BTC_TIME_CELL_INCREASED_SIZE is related to the specific lock script.
-// We assume that the maximum length of lock script args is 26 bytes. If it exceeds, an error will be thrown.
-const LOCK_ARGS_HEX_MAX_SIZE = 26 * 2;
-export const isLockArgsSizeExceeded = (args: Hex) => remove0x(args).length > LOCK_ARGS_HEX_MAX_SIZE;
+// Assume the length of the lock script args cannot exceed 26 bytes. If it exceeds, an error will be thrown.
+const LOCK_ARGS_HEX_MAX_SIZE = 26;
+export const isLockArgsSizeExceeded = (args: Hex) => remove0x(args).length > LOCK_ARGS_HEX_MAX_SIZE * 2;
 
+// The BTC_TIME_CELL_INCREASED_SIZE depends on the receiver lock script args whose length cannot exceed LOCK_ARGS_HEX_MAX_SIZE bytes
 const BTC_TIME_CELL_INCREASED_SIZE = 95;
 
 // For simplicity, we keep the capacity of the RGBPP cell the same as the BTC time cell


### PR DESCRIPTION
## Changes

- Allow RGB++ spore cell not to reserve more CKB for `btc_time_lock` cell when creating spores
- When the spore cell capacity is not sufficient for leaping from BTC to CKB, a paymaster cell is needed
- Add `calculateCellOccupiedCapacity` and `isSporeCapacitySufficient` util methods and related tests