### PR TITLE
refactor(example): Update spore example cobuild

### DIFF
--- a/examples/rgbpp/spore/local/4-transfer-spore.ts
+++ b/examples/rgbpp/spore/local/4-transfer-spore.ts
@@ -76,7 +76,10 @@ const transferSpore = async ({ sporeRgbppLockArgs, toBtcAddress, sporeTypeArgs }
       });
 
       // Replace cobuild witness with the final rgbpp lock script
-      ckbTx.witnesses[ckbTx.witnesses.length - 1] = generateSporeTransferCoBuild([sporeCell], ckbTx.outputs);
+      ckbTx.witnesses[ckbTx.witnesses.length - 1] = generateSporeTransferCoBuild(
+        [sporeCell],
+        ckbTx.outputs.slice(0, 1),
+      );
 
       // console.log('ckbTx: ', JSON.stringify(ckbTx));
 

--- a/examples/rgbpp/spore/local/5-leap-spore-to-ckb.ts
+++ b/examples/rgbpp/spore/local/5-leap-spore-to-ckb.ts
@@ -76,7 +76,10 @@ const leapSpore = async ({ sporeRgbppLockArgs, toCkbAddress, sporeTypeArgs }: Sp
       });
 
       // Replace cobuild witness with the final rgbpp lock script
-      ckbTx.witnesses[ckbTx.witnesses.length - 1] = generateSporeTransferCoBuild([sporeCell], ckbTx.outputs);
+      ckbTx.witnesses[ckbTx.witnesses.length - 1] = generateSporeTransferCoBuild(
+        [sporeCell],
+        ckbTx.outputs.slice(0, 1),
+      );
 
       // console.log('ckbTx: ', JSON.stringify(ckbTx));
 


### PR DESCRIPTION
## Changes

- Update spore `cobuild` construction parameter to adapt the leaping from BTC to CKB when the paymaster cell is needed