### PR TITLE
feat(ckb | example): Disable minimal rgbpp spore capacity

### DIFF
--- a/.changeset/sweet-singers-hang.md
+++ b/.changeset/sweet-singers-hang.md
@@ -1,5 +1,0 @@
----
-"@rgbpp-sdk/ckb": minor
----
-
-feat: Allow rgbpp spore cell to not reserve CKB

--- a/examples/rgbpp/spore/launch/2-create-cluster.ts
+++ b/examples/rgbpp/spore/launch/2-create-cluster.ts
@@ -54,6 +54,8 @@ const createCluster = async ({ ownerRgbppLockArgs }: { ownerRgbppLockArgs: strin
       const newCkbRawTx = updateCkbTxWithRealBtcTxId({ ckbRawTx, btcTxId, isMainnet });
 
       console.log('The cluster rgbpp lock args: ', newCkbRawTx.outputs[0].lock.args);
+      console.log('The cluster rgbpp lock args -- btc tx id: ', btcTxId);
+      console.log('The cluster rgbpp lock args -- btc tx out index: 1');
 
       const ckbTx = await appendCkbTxWitnesses({
         ckbRawTx: newCkbRawTx,

--- a/examples/rgbpp/spore/launch/3-create-spores.ts
+++ b/examples/rgbpp/spore/launch/3-create-spores.ts
@@ -33,8 +33,6 @@ interface SporeCreateParams {
 
 // Warning: Before runing this file for the first time, please run 2-prepare-cluster.ts
 const createSpores = async ({ clusterRgbppLockArgs, receivers }: SporeCreateParams) => {
-  // True is to reserve more CKB to leap from BTC to CKB, otherwise, not to reserve CKB, default value is true
-  const reserveMoreCkbForLeap = true;
   const ckbVirtualTxResult = await genCreateSporeCkbVirtualTx({
     collector,
     sporeDataList: receivers.map((receiver) => receiver.sporeData),
@@ -42,7 +40,6 @@ const createSpores = async ({ clusterRgbppLockArgs, receivers }: SporeCreatePara
     isMainnet,
     ckbFeeRate: BigInt(2000),
     btcTestnetType: BTC_TESTNET_TYPE,
-    reserveMoreCkb: reserveMoreCkbForLeap,
   });
 
   // Save ckbVirtualTxResult
@@ -76,6 +73,8 @@ const createSpores = async ({ clusterRgbppLockArgs, receivers }: SporeCreatePara
       // Update CKB transaction with the real BTC txId
       const newCkbRawTx = updateCkbTxWithRealBtcTxId({ ckbRawTx, btcTxId, isMainnet });
       console.log('The new cluster rgbpp lock args: ', newCkbRawTx.outputs[0].lock.args);
+      console.log('The new cluster rgbpp lock args -- btc tx id: ', btcTxId);
+      console.log('The new cluster rgbpp lock args -- btc tx out index: 1');
 
       const ckbTx = await appendCkbTxWitnesses({
         ckbRawTx: newCkbRawTx,

--- a/packages/ckb/README.md
+++ b/packages/ckb/README.md
@@ -152,7 +152,6 @@ export interface SporeCreateVirtualTxResult {
  * @param sporeDataList The spore's data list, including name and description.
  * @param isMainnet True is for BTC and CKB Mainnet, false is for BTC and CKB Testnet(see btcTestnetType for details about BTC Testnet)
  * @param btcTestnetType(Optional) The Bitcoin Testnet type including Testnet3 and Signet, default value is Testnet3
- * @param reserveMoreCkb(Optional) True is to reserve more CKB to leap from BTC to CKB, otherwise, not to reserve CKB, default value is true
  */
 export const genCreateSporeCkbVirtualTx = async ({
   collector,
@@ -160,7 +159,6 @@ export const genCreateSporeCkbVirtualTx = async ({
   sporeDataList,
   isMainnet,
   btcTestnetType,
-  reserveMoreCkb
 }: CreateSporeCkbVirtualTxParams): Promise<SporeCreateVirtualTxResult>
 ```
 

--- a/packages/ckb/src/spore/leap.ts
+++ b/packages/ckb/src/spore/leap.ts
@@ -1,5 +1,5 @@
 import { BtcTimeCellsParams, RgbppCkbVirtualTx } from '../types/rgbpp';
-import { append0x, calculateTransactionFee, fetchTypeIdCellDeps, isSporeCapacitySufficient } from '../utils';
+import { append0x, calculateTransactionFee, fetchTypeIdCellDeps } from '../utils';
 import {
   btcTxIdFromBtcTimeLockArgs,
   buildSpvClientCellDep,
@@ -63,7 +63,6 @@ export const genLeapSporeFromBtcToCkbVirtualTx = async ({
   throwErrorWhenSporeCellsInvalid(sporeCells, sporeTypeBytes, isMainnet);
 
   const sporeCell = sporeCells![0];
-  const needPaymasterCell = !isSporeCapacitySufficient(sporeCell);
 
   const inputs: CKBComponents.CellInput[] = [
     {
@@ -113,7 +112,7 @@ export const genLeapSporeFromBtcToCkbVirtualTx = async ({
     ckbRawTx,
     commitment,
     sporeCell,
-    needPaymasterCell,
+    needPaymasterCell: false,
     sumInputsCapacity: sporeCell.output.capacity,
   };
 };

--- a/packages/ckb/src/spore/spore.ts
+++ b/packages/ckb/src/spore/spore.ts
@@ -58,7 +58,6 @@ import signWitnesses from '@nervosnetwork/ckb-sdk-core/lib/signWitnesses';
  * @param sporeDataList The spore's data list, including name and description.
  * @param isMainnet True is for BTC and CKB Mainnet, false is for BTC and CKB Testnet(see btcTestnetType for details about BTC Testnet)
  * @param btcTestnetType(Optional) The Bitcoin Testnet type including Testnet3 and Signet, default value is Testnet3
- * @param reserveMoreCkb(Optional) True is to reserve more CKB to leap from BTC to CKB, otherwise, not to reserve CKB, default value is true
  */
 export const genCreateSporeCkbVirtualTx = async ({
   collector,
@@ -66,7 +65,6 @@ export const genCreateSporeCkbVirtualTx = async ({
   sporeDataList,
   isMainnet,
   btcTestnetType,
-  reserveMoreCkb,
 }: CreateSporeCkbVirtualTxParams): Promise<SporeCreateVirtualTxResult> => {
   const clusterRgbppLock = genRgbppLockScript(clusterRgbppLockArgs, isMainnet, btcTestnetType);
   const clusterCells = await collector.getCells({ lock: clusterRgbppLock, isDataMustBeEmpty: false });
@@ -104,7 +102,7 @@ export const genCreateSporeCkbVirtualTx = async ({
       // The CKB transaction outputs[0] fro cluster and outputs[1]... for spore
       args: generateSporeId(inputs[0], index + 1),
     },
-    capacity: append0x(calculateRgbppSporeCellCapacity(data, reserveMoreCkb).toString(16)),
+    capacity: append0x(calculateRgbppSporeCellCapacity(data).toString(16)),
   }));
   const sporeOutputsData = sporeDataList.map((data) => bytesToHex(packRawSporeData(data)));
 

--- a/packages/ckb/src/types/spore.ts
+++ b/packages/ckb/src/types/spore.ts
@@ -46,8 +46,6 @@ export interface CreateSporeCkbVirtualTxParams {
   witnessLockPlaceholderSize?: number;
   // The CKB transaction fee rate, default value is 1100
   ckbFeeRate?: bigint;
-  // True is to reserve more CKB to leap from BTC to CKB, otherwise, not to reserve CKB, default value is true
-  reserveMoreCkb?: boolean;
 }
 
 export interface SporeCreateVirtualTxResult {

--- a/packages/ckb/src/utils/ckb-tx.spec.ts
+++ b/packages/ckb/src/utils/ckb-tx.spec.ts
@@ -12,7 +12,6 @@ import {
   isTypeAssetSupported,
   checkCkbTxInputsCapacitySufficient,
   calculateCellOccupiedCapacity,
-  isSporeCapacitySufficient,
 } from './ckb-tx';
 import { hexToBytes } from '@nervosnetwork/ckb-sdk-utils';
 import { Collector } from '../collector';
@@ -139,7 +138,6 @@ describe('ckb tx utils', () => {
       clusterId: '0xbc5168a4f90116fada921e185d4b018e784dc0f6266e539a3c092321c932700a',
     };
     expect(calculateRgbppSporeCellCapacity(sporeData)).toBe(BigInt(319_0000_0000));
-    expect(calculateRgbppSporeCellCapacity(sporeData, false)).toBe(BigInt(224_0000_0000));
   });
 
   it('deduplicateList', () => {
@@ -199,35 +197,6 @@ describe('ckb tx utils', () => {
       outputData: '0x6b6a9580fc2aceb920c63adea27a667acfc180f67cf875b36f31b42546ac4920',
     };
     expect(BigInt(17000000000)).toBe(calculateCellOccupiedCapacity(cell));
-  });
-
-  it('isSporeCapacitySufficient', () => {
-    const sporeCell: IndexerCell = {
-      output: {
-        capacity: '0x639f53e00', // 267.42177280 CKB
-        lock: {
-          args: '0x6b6a9580fc2aceb920c63adea27a667acfc180f67cf875b36f31b42546ac4920',
-          codeHash: '0x61ca7a4796a4eb19ca4f0d065cb9b10ddcf002f10f7cbb810c706cb6bb5c3248',
-          hashType: 'type',
-        },
-        type: {
-          args: '0x6b6a9580fc2aceb920c63adea27a667acfc180f67cf875b36f31b42546ac4920',
-          codeHash: '0x25c29dc317811a6f6f3985a7a9ebc4838bd388d19d0feeecf0bcd60f6c0975bb',
-          hashType: 'type',
-        },
-      },
-      outPoint: {
-        index: '0x1',
-        txHash: '0x1a6d2b18faed84293b81ada9d00600a3cdb637fa43a5cfa20eb63934757352ea',
-      },
-      blockNumber: '0x0',
-      txIndex: '0x0',
-      outputData: '0x6b6a9580fc2aceb920c63adea27a667acfc180f67cf875b36f31b42546ac4920',
-    };
-    expect(true).toBe(isSporeCapacitySufficient(sporeCell));
-
-    sporeCell.output.capacity = '0x5e9f53e00'; // 254 CKB
-    expect(false).toBe(isSporeCapacitySufficient(sporeCell));
   });
 
   it('checkCkbTxInputsCapacitySufficient', { timeout: 20000 }, async () => {

--- a/packages/ckb/src/utils/ckb-tx.ts
+++ b/packages/ckb/src/utils/ckb-tx.ts
@@ -132,18 +132,16 @@ export const calculateRgbppClusterCellCapacity = (clusterData: RawClusterData): 
 // https://docs.spore.pro/recipes/Create/create-clustered-spore
 // For simplicity, we keep the capacity of the RGBPP cell the same as the BTC time cell
 // minimum occupied capacity and 1 ckb for transaction fee
-// The reserveMoreCkb is to reserve more CKB to leap from BTC to CKB, otherwise, not to reserve CKB, default value is true
 /**
  * rgbpp_spore_cell:
     lock: rgbpp_lock
     type: spore_type
     data: sporeData
  */
-export const calculateRgbppSporeCellCapacity = (sporeData: SporeDataProps, reserveMoreCkb = true): bigint => {
+export const calculateRgbppSporeCellCapacity = (sporeData: SporeDataProps): bigint => {
   const sporeDataSize = packRawSporeData(sporeData).length;
   const sporeTypeSize = 32 + 1 + 32;
-  const reservedCapacity = reserveMoreCkb ? BTC_TIME_CELL_INCREASED_SIZE : 0;
-  const cellSize = RGBPP_LOCK_SIZE + sporeTypeSize + CELL_CAPACITY_SIZE + sporeDataSize + reservedCapacity;
+  const cellSize = RGBPP_LOCK_SIZE + sporeTypeSize + CELL_CAPACITY_SIZE + sporeDataSize + BTC_TIME_CELL_INCREASED_SIZE;
   return BigInt(cellSize + 1) * CKB_UNIT;
 };
 
@@ -154,12 +152,6 @@ export const calculateCellOccupiedCapacity = (cell: IndexerCell): bigint => {
   const typeSize = cell.output.type ? remove0x(cell.output.type.args).length / 2 + 1 + 32 : 0;
   const cellSize = cellDataSize + lockSize + typeSize + CELL_CAPACITY_SIZE;
   return BigInt(cellSize) * CKB_UNIT;
-};
-
-export const isSporeCapacitySufficient = (sporeCell: IndexerCell) => {
-  const occupiedCapacity = calculateCellOccupiedCapacity(sporeCell);
-  const capacity = BigInt(sporeCell.output.capacity);
-  return capacity - occupiedCapacity > BigInt(BTC_TIME_CELL_INCREASED_SIZE) * CKB_UNIT;
 };
 
 export const deduplicateList = (rgbppLockArgsList: Hex[]): Hex[] => {


### PR DESCRIPTION
## Changes

- Disable minimal RGB++ spore-occupied capacity to avoid leaping from BTC to CKB fail