### PR TITLE
refactor(ckb): Remove 1CKB from BTC time cell capacity

### DIFF
--- a/.changeset/sharp-wasps-punch.md
+++ b/.changeset/sharp-wasps-punch.md
@@ -1,0 +1,5 @@
+---
+'@rgbpp-sdk/ckb': minor
+---
+
+refactor: Remove 1CKB from btc time cell capacity

--- a/packages/ckb/src/utils/ckb-tx.spec.ts
+++ b/packages/ckb/src/utils/ckb-tx.spec.ts
@@ -43,10 +43,10 @@ describe('ckb tx utils', () => {
       args: '0x06ec22c2def100bba3e295a1ff279c490d227151bf3166a4f3f008906c849399',
     };
     const capacity = calculateRgbppCellCapacity(xudtType);
-    expect(BigInt(254_0000_0000)).toBe(capacity);
+    expect(BigInt(253_0000_0000)).toBe(capacity);
 
     const actual = calculateRgbppCellCapacity();
-    expect(actual).toBe(BigInt(254_0000_0000));
+    expect(actual).toBe(BigInt(253_0000_0000));
   });
 
   it('isClusterSporeTypeSupported', () => {
@@ -109,7 +109,7 @@ describe('ckb tx utils', () => {
     expect(isTypeAssetSupported(xudtMainnetErrorType, true)).toBe(false);
   });
 
-  it('calculateRgbppCellCapacity', () => {
+  it('generateUniqueTypeArgs', () => {
     const firstInput = {
       previousOutput: {
         txHash: '0x047b6894a0b7a4d7a73b1503d1ae35c51fc5fa6306776dcf22b1fb3daaa32a29',

--- a/packages/ckb/src/utils/ckb-tx.ts
+++ b/packages/ckb/src/utils/ckb-tx.ts
@@ -63,7 +63,7 @@ export const isLockArgsSizeExceeded = (args: Hex) => remove0x(args).length > LOC
 const BTC_TIME_CELL_INCREASED_SIZE = 95;
 
 // For simplicity, we keep the capacity of the RGBPP cell the same as the BTC time cell
-// minimum occupied capacity and 1 ckb for transaction fee and assume UDT cell data size is 16bytes
+// minimum occupied capacity and assume UDT cell data size is 16bytes
 /**
  * RGB_lock:
     code_hash: 
@@ -77,7 +77,7 @@ export const calculateRgbppCellCapacity = (xudtType?: CKBComponents.Script): big
   const udtTypeSize = 33 + typeArgsSize;
   const cellSize =
     RGBPP_LOCK_SIZE + udtTypeSize + CELL_CAPACITY_SIZE + UDT_CELL_DATA_SIZE + BTC_TIME_CELL_INCREASED_SIZE;
-  return BigInt(cellSize + 1) * CKB_UNIT;
+  return BigInt(cellSize) * CKB_UNIT;
 };
 
 // Minimum occupied capacity and 1 ckb for transaction fee

--- a/packages/ckb/src/utils/rgbpp.ts
+++ b/packages/ckb/src/utils/rgbpp.ts
@@ -3,7 +3,6 @@ import { BTCTestnetType, Hex, IndexerCell, RgbppCkbVirtualTx, RgbppTokenInfo, Sp
 import { append0x, remove0x, reverseHex, u32ToLe, u8ToHex, utf8ToHex } from './hex';
 import {
   BTC_JUMP_CONFIRMATION_BLOCKS,
-  CKB_UNIT,
   RGBPP_TX_ID_PLACEHOLDER,
   RGBPP_TX_INPUTS_MAX_LENGTH,
   RGBPP_TX_WITNESS_MAX_SIZE,
@@ -286,6 +285,6 @@ export const isRgbppCapacitySufficientForChange = (
   sumUdtInputsCapacity: bigint,
   receiverOutputCapacity: bigint,
 ): boolean => {
-  const rgbppOccupiedCapacity = calculateRgbppCellCapacity() - CKB_UNIT;
+  const rgbppOccupiedCapacity = calculateRgbppCellCapacity();
   return sumUdtInputsCapacity > receiverOutputCapacity + rgbppOccupiedCapacity;
 };


### PR DESCRIPTION
## Changes

- Considering the BTC time cell capacity cannot be used for transaction fees, removing 1CKB from BTC time cell capacity is reasonable.