### PR TITLE
Bump RGB++ SDK to v0.5.0

### DIFF
--- a/.changeset/clean-snails-admire.md
+++ b/.changeset/clean-snails-admire.md
@@ -1,5 +1,0 @@
----
-"@rgbpp-sdk/service": minor
----
-
-Add "type_script" in the return type of /rgbpp/v1/address/{btc_address}/balance API, and add "typeHash" in the return type of rgbpp asset APIs

--- a/.changeset/sharp-wasps-punch.md
+++ b/.changeset/sharp-wasps-punch.md
@@ -1,5 +1,0 @@
----
-'@rgbpp-sdk/ckb': minor
----
-
-refactor: Remove 1CKB from btc time cell capacity

--- a/.changeset/shy-tables-turn.md
+++ b/.changeset/shy-tables-turn.md
@@ -1,5 +1,0 @@
----
-'@rgbpp-sdk/btc': minor
----
-
-refactor: Batch fetching ckb rgb++ live cells

--- a/.changeset/three-hounds-listen.md
+++ b/.changeset/three-hounds-listen.md
@@ -1,5 +1,0 @@
----
-"@rgbpp-sdk/ckb": minor
----
-
-feat: Custom btc comfirmation blocks to unlock btc time cells

--- a/packages/btc/CHANGELOG.md
+++ b/packages/btc/CHANGELOG.md
@@ -1,6 +1,21 @@
 # @rgbpp-sdk/btc
 
-## 0.4.0
+## v0.5.0
+
+### Minor Changes
+
+- [#261](https://github.com/ckb-cell/rgbpp-sdk/pull/261): Batch fetch CKB RGB++ live cells to construct BTC transaction ([@duanyytop](https://github.com/duanyytop))
+
+  - Batch fetch CKB RGB++ live cells to construct BTC transaction
+  - Remove useless fields for RGB++ lock args list
+
+### Patch Changes
+
+- Updated dependencies [[`9afc2a9`](https://github.com/ckb-cell/rgbpp-sdk/commit/9afc2a911e6a4ba8a200755b01159b5b149e4010), [`8f99429`](https://github.com/ckb-cell/rgbpp-sdk/commit/8f99429de45899e5169771e87e73603318a49ae8), [`475b3c3`](https://github.com/ckb-cell/rgbpp-sdk/commit/475b3c35ab1a25ba3aae28123f2820460101c889)]:
+  - @rgbpp-sdk/service@0.5.0
+  - @rgbpp-sdk/ckb@0.5.0
+
+## v0.4.0
 
 ### Minor Changes
 

--- a/packages/btc/package.json
+++ b/packages/btc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rgbpp-sdk/btc",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "scripts": {
     "test": "vitest",
     "build": "tsc -p tsconfig.build.json",

--- a/packages/ckb/CHANGELOG.md
+++ b/packages/ckb/CHANGELOG.md
@@ -1,6 +1,19 @@
 # @rgbpp-sdk/ckb
 
-## 0.4.0
+## v0.5.0
+
+### Minor Changes
+
+- [#258](https://github.com/ckb-cell/rgbpp-sdk/pull/258): Support for arbitrary btc confirmation blocks to unlock btc time cells([@duanyytop](https://github.com/duanyytop))
+
+- [#263](https://github.com/ckb-cell/rgbpp-sdk/pull/263): Remove 1CKB from BTC time cell capacity([@duanyytop](https://github.com/duanyytop))
+
+### Patch Changes
+
+- Updated dependencies [[`9afc2a9`](https://github.com/ckb-cell/rgbpp-sdk/commit/9afc2a911e6a4ba8a200755b01159b5b149e4010)]:
+  - @rgbpp-sdk/service@0.5.0
+
+## v0.4.0
 
 ### Minor Changes
 

--- a/packages/ckb/package.json
+++ b/packages/ckb/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rgbpp-sdk/ckb",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "scripts": {
     "test": "vitest",
     "build": "tsc -p tsconfig.build.json",

--- a/packages/rgbpp/CHANGELOG.md
+++ b/packages/rgbpp/CHANGELOG.md
@@ -1,6 +1,15 @@
 # rgbpp
 
-## 0.4.0
+## v0.5.0
+
+### Patch Changes
+
+- Updated dependencies [[`9afc2a9`](https://github.com/ckb-cell/rgbpp-sdk/commit/9afc2a911e6a4ba8a200755b01159b5b149e4010), [`8f99429`](https://github.com/ckb-cell/rgbpp-sdk/commit/8f99429de45899e5169771e87e73603318a49ae8), [`475b3c3`](https://github.com/ckb-cell/rgbpp-sdk/commit/475b3c35ab1a25ba3aae28123f2820460101c889), [`1a8bb1c`](https://github.com/ckb-cell/rgbpp-sdk/commit/1a8bb1c8c305ddaba80e139a0730c9c76f8c7784)]:
+  - @rgbpp-sdk/ckb@0.5.0
+  - @rgbpp-sdk/btc@0.5.0
+  - @rgbpp-sdk/service@0.5.0
+
+## v0.4.0
 
 ### Minor Changes
 

--- a/packages/rgbpp/package.json
+++ b/packages/rgbpp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rgbpp",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "scripts": {
     "build": "tsc -p tsconfig.build.json",
     "lint": "tsc && eslint --ext .ts src/* && prettier --check 'src/*.ts'",

--- a/packages/service/CHANGELOG.md
+++ b/packages/service/CHANGELOG.md
@@ -1,6 +1,12 @@
 # @rgbpp-sdk/service
 
-## 0.4.0
+## v0.5.0
+
+### Minor Changes
+
+- [#248](https://github.com/ckb-cell/rgbpp-sdk/pull/248): Add `type_script` to the response of `/rgbpp/v1/address/{btc_address}/balance` API, and add `typeHash` to the response of rgbpp assets-related APIs ([@ShookLyngs](https://github.com/ShookLyngs))
+
+## v0.4.0
 
 ### Minor Changes
 

--- a/packages/service/package.json
+++ b/packages/service/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rgbpp-sdk/service",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "scripts": {
     "test": "vitest",
     "build": "tsc -p tsconfig.build.json",


### PR DESCRIPTION
# v0.5.0

## @rgbpp-sdk/btc

### Minor Changes

- [#261](https://github.com/ckb-cell/rgbpp-sdk/pull/261): Batch fetch CKB RGB++ live cells to construct BTC transaction ([@duanyytop](https://github.com/duanyytop))

  - Batch fetch CKB RGB++ live cells to construct BTC transaction
  - Remove useless fields for RGB++ lock args list

### Patch Changes

- Updated dependencies [[`9afc2a9`](https://github.com/ckb-cell/rgbpp-sdk/commit/9afc2a911e6a4ba8a200755b01159b5b149e4010), [`8f99429`](https://github.com/ckb-cell/rgbpp-sdk/commit/8f99429de45899e5169771e87e73603318a49ae8), [`475b3c3`](https://github.com/ckb-cell/rgbpp-sdk/commit/475b3c35ab1a25ba3aae28123f2820460101c889)]:
  - @rgbpp-sdk/service@0.5.0
  - @rgbpp-sdk/ckb@0.5.0

## @rgbpp-sdk/ckb

### Minor Changes

- [#258](https://github.com/ckb-cell/rgbpp-sdk/pull/258): Support for arbitrary BTC confirmation blocks to unlock btc time cells([@duanyytop](https://github.com/duanyytop))

- [#263](https://github.com/ckb-cell/rgbpp-sdk/pull/263): Remove 1CKB from BTC time cell capacity([@duanyytop](https://github.com/duanyytop))

### Patch Changes

- Updated dependencies [[`9afc2a9`](https://github.com/ckb-cell/rgbpp-sdk/commit/9afc2a911e6a4ba8a200755b01159b5b149e4010)]:
  - @rgbpp-sdk/service@0.5.0

## @rgbpp-sdk/service

### Minor Changes

- [#248](https://github.com/ckb-cell/rgbpp-sdk/pull/248): Add `type_script` to the response of `/rgbpp/v1/address/{btc_address}/balance` API, and add `typeHash` to the response of rgbpp assets-related APIs ([@ShookLyngs](https://github.com/ShookLyngs))

## rgbpp

### Patch Changes

- Updated dependencies [[`9afc2a9`](https://github.com/ckb-cell/rgbpp-sdk/commit/9afc2a911e6a4ba8a200755b01159b5b149e4010), [`8f99429`](https://github.com/ckb-cell/rgbpp-sdk/commit/8f99429de45899e5169771e87e73603318a49ae8), [`475b3c3`](https://github.com/ckb-cell/rgbpp-sdk/commit/475b3c35ab1a25ba3aae28123f2820460101c889), [`1a8bb1c`](https://github.com/ckb-cell/rgbpp-sdk/commit/1a8bb1c8c305ddaba80e139a0730c9c76f8c7784)]:
  - @rgbpp-sdk/ckb@0.5.0
  - @rgbpp-sdk/btc@0.5.0
  - @rgbpp-sdk/service@0.5.0
