### PR TITLE
feat(btc): report extra context in the TxBuildError

### DIFF
--- a/.changeset/tiny-beds-protect.md
+++ b/.changeset/tiny-beds-protect.md
@@ -1,0 +1,5 @@
+---
+'@rgbpp-sdk/btc': minor
+---
+
+Report TxBuilder as extra context in the TxBuildError when the BTC Builder APIs fail

--- a/packages/btc/README.md
+++ b/packages/btc/README.md
@@ -17,7 +17,7 @@ $ yarn add @rgbpp-sdk/btc
 $ pnpm add @rgbpp-sdk/btc
 ```
 
-## Transaction
+## Transactions
 
 ### Transfer BTC from a `P2WPKH` address
 
@@ -247,6 +247,22 @@ const psbt = await sendRbf({
   requireGreaterFeeAndRate: true, // optional, default to true, require the fee rate&amount to be greater than the original transction
   source,
 });
+```
+
+## Errors
+
+### Visit context of the TxBuildError
+
+When you catch a `TxBuildError` error after calling the BTC Builder APIs (`sendBtc`, `sendUtxos`, etc), you can access the `e.context` object for error tracing, where it should contain a `tx` property that is a `TxBuilder` object:
+
+```typescript
+try {
+  await sendBtc({ ... });
+} catch (e) {
+  if (e instanceof TxBuildError) {
+    console.log(e.context.tx); // TxBuilder object for error tracing
+  }
+}
 ```
 
 ## Types

--- a/packages/btc/src/error.ts
+++ b/packages/btc/src/error.ts
@@ -1,3 +1,5 @@
+import { TxBuilder } from './transaction/build';
+
 export enum ErrorCodes {
   UNKNOWN,
 
@@ -56,16 +58,27 @@ export const ErrorMessages = {
   [ErrorCodes.MEMPOOL_API_RESPONSE_ERROR]: 'Mempool.space API returned an error',
 };
 
+export interface TxBuildErrorContext {
+  tx?: TxBuilder;
+}
+
 export class TxBuildError extends Error {
   public code = ErrorCodes.UNKNOWN;
-  constructor(code: ErrorCodes, message = ErrorMessages[code] || 'Unknown error') {
+  public context?: TxBuildErrorContext;
+
+  constructor(code: ErrorCodes, message = ErrorMessages[code] || 'Unknown error', context?: TxBuildErrorContext) {
     super(message);
     this.code = code;
+    this.context = context;
     Object.setPrototypeOf(this, TxBuildError.prototype);
   }
 
-  static withComment(code: ErrorCodes, comment?: string): TxBuildError {
+  static withComment(code: ErrorCodes, comment?: string, context?: TxBuildErrorContext): TxBuildError {
     const message: string | undefined = ErrorMessages[code];
-    return new TxBuildError(code, comment ? `${message}: ${comment}` : message);
+    return new TxBuildError(code, comment ? `${message}: ${comment}` : message, context);
+  }
+
+  setContext(context: TxBuildErrorContext) {
+    this.context = context;
   }
 }

--- a/packages/btc/src/error.ts
+++ b/packages/btc/src/error.ts
@@ -32,7 +32,8 @@ export enum ErrorCodes {
 export const ErrorMessages = {
   [ErrorCodes.UNKNOWN]: 'Unknown error',
 
-  [ErrorCodes.MISSING_PUBKEY]: 'Missing a pubkey that pairs with the address',
+  [ErrorCodes.MISSING_PUBKEY]:
+    'Missing a pubkey that pairs with the address, it is required for the P2TR UTXO included in the transaction',
   [ErrorCodes.CANNOT_FIND_UTXO]: 'Cannot find the UTXO, it may not exist or is not live',
   [ErrorCodes.UNCONFIRMED_UTXO]: 'Unconfirmed UTXO',
   [ErrorCodes.INSUFFICIENT_UTXO]: 'Insufficient UTXO to construct the transaction',


### PR DESCRIPTION
## Changes
- Add a `context` prop in the TxBuildError to report more info; The `TxBuilderError.context.tx` (a TxBuilder object) should exist when the BTC Builder APIs fail. For example, you should be able to visit the context when calling the `sendBtc` API and it fails:
  ```ts
  try {
    await sendBtc(...);
  } catch (e) {
    if (e instanceof TxBuildError) {
      console.log(e.context.tx); // TxBuilder
    }
  }
  ```
- Update the message of the MISSING_PUBKEY error
  ```
  Missing a pubkey that pairs with the address, it is required for the P2TR UTXO included in the transaction: {address}
  ```

## Related issues
- Resolves #266 
- Improves error tracing for users #260