### PR TITLE
feat(example): Add example for batch transfer of RGBPP XUDT assets

### DIFF
--- a/examples/rgbpp/README.md
+++ b/examples/rgbpp/README.md
@@ -1,6 +1,6 @@
 # RGB++ Examples
 
-- xUDT directory: The examples for RGB++ UDT issuance, transfer, and leap
+- xUDT directory: The examples for RGB++ UDT issuance, transfer, transferAll and leap
 - Spore directory: The examples for RGB++ Spore creation, transfer and leap
 
 > [!TIP]
@@ -116,13 +116,19 @@ npx tsx xudt/1-ckb-leap-btc.ts
 npx tsx xudt/2-btc-transfer.ts 
 ```
 
-#### 3. Leap RGB++ xUDT from BTC to CKB with Queue Service
+#### 3. Transfer all RGB++ xUDT on BTC using a queue service
+
+```shell
+npx tsx xudt/btc-transfer-all/1-btc-transfer-all.ts 
+```
+
+#### 4. Leap RGB++ xUDT from BTC to CKB with Queue Service
 
 ```shell
 npx tsx xudt/3-btc-leap-ckb.ts 
 ```
 
-#### 4. Unlock xUDT BTC time cells on CKB
+#### 5. Unlock xUDT BTC time cells on CKB
 
 A cron job in RGB++ Queue service will construct a transaction unlocking the mature BTC time cells to the their `target_ckb_address`.
 

--- a/examples/rgbpp/xudt/btc-transfer-all/1-btc-transfer-all.ts
+++ b/examples/rgbpp/xudt/btc-transfer-all/1-btc-transfer-all.ts
@@ -1,0 +1,75 @@
+import { bitcoin } from 'rgbpp/btc';
+import { buildRgbppTransferAllTxs, sendRgbppTxGroups } from 'rgbpp';
+import { btcDataSource, isMainnet, collector, btcAccount } from '../../env';
+import { signPsbt } from '../../shared/btc-account';
+import { saveCkbVirtualTxResult } from '../../shared/utils';
+
+interface TestParams {
+  xudtTypeArgs: string;
+  fromAddress: string;
+  toAddress: string;
+}
+const SEND_TX_GROUPS = false;
+
+const rgbppTransferAllTxs = async ({ xudtTypeArgs, fromAddress, toAddress }: TestParams) => {
+  const result = await buildRgbppTransferAllTxs({
+    ckb: {
+      xudtTypeArgs,
+      collector,
+    },
+    btc: {
+      assetAddresses: [fromAddress],
+      fromAddress: fromAddress,
+      toAddress: toAddress,
+      dataSource: btcDataSource,
+      feeRate: 5,
+    },
+    isMainnet,
+  });
+
+  console.log('result.transactions.length', result.transactions.length);
+  console.log('result.summary.included.assets', result.summary.included.xudtAssets);
+  console.log('result.summary.excluded.assets', result.summary.excluded.xudtAssets);
+
+  const signedGroups = await Promise.all(
+    result.transactions.map(async (group) => {
+      const psbt = bitcoin.Psbt.fromHex(group.btc.psbtHex);
+
+      // Sign transactions
+      await signPsbt(psbt, btcAccount);
+
+      psbt.finalizeAllInputs();
+      psbt.extractTransaction();
+
+      return {
+        ckbVirtualTxResult: JSON.stringify(group.ckb.virtualTxResult),
+        btcTxHex: psbt.extractTransaction().toHex(),
+      };
+    }),
+  );
+
+  const ckbVirtualTxResult = JSON.parse(JSON.stringify(signedGroups, null, 2));
+
+  // Save ckbVirtualTxResult
+  saveCkbVirtualTxResult(ckbVirtualTxResult, '1-btc-transfer-all');
+
+  console.log('signedGroups', ckbVirtualTxResult);
+
+  if (!SEND_TX_GROUPS) {
+    return;
+  }
+
+  // Send transactions
+  const sentGroups = await sendRgbppTxGroups({
+    txGroups: signedGroups,
+    btcService: btcDataSource.service,
+  });
+  console.log('sentGroups', JSON.stringify(sentGroups, null, 2));
+};
+
+rgbppTransferAllTxs({
+  // Please use your own RGB++ xudt asset's xudtTypeArgs
+  xudtTypeArgs: '0xdec25e81ad1d5b909926265b0cdf404e270250b9885d436852b942d56d06be38',
+  fromAddress: btcAccount.from,
+  toAddress: 'tb1qdnvvnyhc5wegxgh0udwaej04n8w08ahrr0w4q9',
+}).catch(console.error);

--- a/examples/rgbpp/xudt/btc-transfer-all/1-btc-transfer-all.ts
+++ b/examples/rgbpp/xudt/btc-transfer-all/1-btc-transfer-all.ts
@@ -9,7 +9,6 @@ interface TestParams {
   fromAddress: string;
   toAddress: string;
 }
-const SEND_TX_GROUPS = false;
 
 const rgbppTransferAllTxs = async ({ xudtTypeArgs, fromAddress, toAddress }: TestParams) => {
   const result = await buildRgbppTransferAllTxs({
@@ -39,7 +38,6 @@ const rgbppTransferAllTxs = async ({ xudtTypeArgs, fromAddress, toAddress }: Tes
       await signPsbt(psbt, btcAccount);
 
       psbt.finalizeAllInputs();
-      psbt.extractTransaction();
 
       return {
         ckbVirtualTxResult: JSON.stringify(group.ckb.virtualTxResult),
@@ -48,16 +46,12 @@ const rgbppTransferAllTxs = async ({ xudtTypeArgs, fromAddress, toAddress }: Tes
     }),
   );
 
-  const ckbVirtualTxResult = JSON.parse(JSON.stringify(signedGroups, null, 2));
+  const signedGroupsData = JSON.parse(JSON.stringify(signedGroups, null, 2));
 
-  // Save ckbVirtualTxResult
-  saveCkbVirtualTxResult(ckbVirtualTxResult, '1-btc-transfer-all');
+  // Save signedGroupsData
+  saveCkbVirtualTxResult(signedGroupsData, '1-btc-transfer-all');
 
-  console.log('signedGroups', ckbVirtualTxResult);
-
-  if (!SEND_TX_GROUPS) {
-    return;
-  }
+  console.log('signedGroups', signedGroupsData);
 
   // Send transactions
   const sentGroups = await sendRgbppTxGroups({


### PR DESCRIPTION
## Changes

- This example demonstrates a batch transfer of RGBPP XUDT assets.
- It shows the process of transferring all assets from one account to another on the BTC network.