### PR TITLE
refactor(rgbpp|service): Add `send_rgbpp_group_txs` RPC to SDK Service

### DIFF
--- a/.changeset/rotten-carrots-raise.md
+++ b/.changeset/rotten-carrots-raise.md
@@ -1,0 +1,5 @@
+---
+'rgbpp': minor
+---
+
+refactor: update response of sending RGB++ group txs

--- a/apps/service/src/rgbpp/rgbpp.service.ts
+++ b/apps/service/src/rgbpp/rgbpp.service.ts
@@ -2,7 +2,13 @@ import { Inject } from '@nestjs/common';
 import { DataSource, NetworkType } from 'rgbpp/btc';
 import { BtcAssetsApi, RgbppApiTransactionState } from 'rgbpp/service';
 import { BTCTestnetType, Collector, Hex, append0x } from 'rgbpp/ckb';
-import { buildRgbppTransferTx, buildRgbppTransferAllTxs } from 'rgbpp';
+import {
+  buildRgbppTransferTx,
+  buildRgbppTransferAllTxs,
+  sendRgbppTxGroups,
+  RgbppTxGroup,
+  SentRgbppTxGroup,
+} from 'rgbpp';
 import { RpcHandler, RpcMethodHandler } from '../json-rpc/json-rpc.decorators.js';
 import { toSnakeCase, toCamelCase, SnakeCased } from '../utils/case.js';
 import { ensureSafeJson } from '../utils/json.js';
@@ -126,5 +132,13 @@ export class RgbppService {
     const { txHex } = toCamelCase(request[0]);
     const { txid } = await this.btcAssetsApi.sendBtcTransaction(txHex);
     return txid;
+  }
+
+  @RpcMethodHandler({ name: 'send_rgbpp_group_txs' })
+  public async sendRgbppGroupTxs(request: [RgbppTxGroup[]]): Promise<SnakeCased<SentRgbppTxGroup>[]> {
+    const txGroups = toCamelCase(request[0]);
+    const sentGroups = await sendRgbppTxGroups({ txGroups, btcService: this.btcAssetsApi });
+    const result = sentGroups.map((group) => toSnakeCase<SentRgbppTxGroup>(group));
+    return result;
   }
 }

--- a/apps/service/src/rgbpp/rgbpp.service.ts
+++ b/apps/service/src/rgbpp/rgbpp.service.ts
@@ -88,7 +88,7 @@ export class RgbppService {
     return transactions.map(({ ckb, btc }) =>
       toSnakeCase<RgbppTransferAllResp>({
         ckbVirtualTxResult: JSON.stringify(ckb.virtualTxResult),
-        psbtHex: btc.psbtHex,
+        btcPsbtHex: btc.psbtHex,
         btcFeeRate: btc.feeRate,
         btcFee: btc.fee,
       }),

--- a/apps/service/src/rgbpp/types.ts
+++ b/apps/service/src/rgbpp/types.ts
@@ -73,7 +73,7 @@ export interface RgbppTransferAllReq {
 
 export interface RgbppTransferAllResp {
   ckbVirtualTxResult: string;
-  psbtHex: string;
+  btcPsbtHex: string;
   btcFeeRate: number;
   btcFee: number;
 }

--- a/apps/service/src/rgbpp/types.ts
+++ b/apps/service/src/rgbpp/types.ts
@@ -1,4 +1,3 @@
-import { RgbppTransferAllTxGroup, RgbppTransferAllTxsResult } from 'rgbpp';
 import { AddressToPubkeyMap } from 'rgbpp/btc';
 import { Hex } from 'rgbpp/ckb';
 
@@ -72,12 +71,9 @@ export interface RgbppTransferAllReq {
   };
 }
 
-export interface RgbppTransferAllRes extends Omit<RgbppTransferAllTxsResult, 'transactions'> {
-  transactions: RgbppTransferAllGroupWithStringCkbVtx[];
-}
-
-export interface RgbppTransferAllGroupWithStringCkbVtx extends Omit<RgbppTransferAllTxGroup, 'ckb'> {
-  ckb: Omit<RgbppTransferAllTxGroup['ckb'], 'virtualTxResult'> & {
-    virtualTxResult: string;
-  };
+export interface RgbppTransferAllResp {
+  ckbVirtualTxResult: string;
+  psbtHex: string;
+  btcFeeRate: number;
+  btcFee: number;
 }

--- a/examples/rgbpp/xudt/btc-transfer-all/1-btc-transfer-all.ts
+++ b/examples/rgbpp/xudt/btc-transfer-all/1-btc-transfer-all.ts
@@ -35,7 +35,7 @@ const rgbppTransferAllTxs = async ({ xudtTypeArgs, fromAddress, toAddress }: Tes
       const psbt = bitcoin.Psbt.fromHex(group.btc.psbtHex);
 
       // Sign transactions
-      await signPsbt(psbt, btcAccount);
+      signPsbt(psbt, btcAccount);
 
       psbt.finalizeAllInputs();
 

--- a/packages/rgbpp/src/index.ts
+++ b/packages/rgbpp/src/index.ts
@@ -66,6 +66,7 @@ export type {
   RgbppTransferAllTxGroup,
 } from './rgbpp/types/xudt';
 export type { TransactionGroupSummary } from './rgbpp/summary/asset-summarizer';
+export type { RgbppTxGroup, SentRgbppTxGroup } from './rgbpp/utils/transaction';
 export { RgbppError, RgbppErrorCodes } from './rgbpp/error';
 export { buildRgbppTransferTx } from './rgbpp/xudt/btc-transfer';
 export { buildRgbppTransferAllTxs } from './rgbpp/xudt/btc-transfer-all';

--- a/packages/rgbpp/src/rgbpp/utils/transaction.ts
+++ b/packages/rgbpp/src/rgbpp/utils/transaction.ts
@@ -25,6 +25,7 @@ export async function sendRgbppTxGroups(props: {
       });
       results.push({ btcTxId: txid });
     } catch (e) {
+      console.error(e);
       if (e instanceof BtcAssetsApiError) {
         results.push({ error: e.message });
       } else {

--- a/packages/rgbpp/src/rgbpp/utils/transaction.ts
+++ b/packages/rgbpp/src/rgbpp/utils/transaction.ts
@@ -1,5 +1,5 @@
 import { BaseCkbVirtualTxResult } from '@rgbpp-sdk/ckb';
-import { BtcAssetsApi } from '@rgbpp-sdk/service';
+import { BtcAssetsApi, BtcAssetsApiError } from '@rgbpp-sdk/service';
 
 export interface RgbppTxGroup {
   ckbVirtualTxResult: BaseCkbVirtualTxResult | string;
@@ -7,13 +7,8 @@ export interface RgbppTxGroup {
 }
 
 export interface SentRgbppTxGroup {
-  btc: {
-    txId?: string;
-    error?: Error | unknown;
-  };
-  ckb: {
-    error?: Error | unknown;
-  };
+  btcTxId?: string;
+  error?: string;
 }
 
 export async function sendRgbppTxGroups(props: {
@@ -22,25 +17,20 @@ export async function sendRgbppTxGroups(props: {
 }): Promise<SentRgbppTxGroup[]> {
   const results: SentRgbppTxGroup[] = [];
   for (const group of props.txGroups) {
-    const result: SentRgbppTxGroup = {
-      ckb: {},
-      btc: {},
-    };
     try {
-      const sent = await props.btcService.sendBtcTransaction(group.btcTxHex);
-      result.btc.txId = sent.txid;
-    } catch (e) {
-      result.btc.error = e;
-    }
-    try {
+      const { txid } = await props.btcService.sendBtcTransaction(group.btcTxHex);
       await props.btcService.sendRgbppCkbTransaction({
-        btc_txid: result.btc.txId!,
+        btc_txid: txid,
         ckb_virtual_result: group.ckbVirtualTxResult,
       });
+      results.push({ btcTxId: txid });
     } catch (e) {
-      result.ckb.error = e;
+      if (e instanceof BtcAssetsApiError) {
+        results.push({ error: e.message });
+      } else {
+        results.push({ error: 'Sending the RGB++ group transactions failed' });
+      }
     }
-    results.push(result);
   }
 
   return results;


### PR DESCRIPTION
## Changes

-  Update response of sending RGB++ group transactions
-  Add `send_rgbpp_group_txs` RPC to SDK service
- Update `generate_rgbpp_transfer_all_txs` response